### PR TITLE
Fix for Handling PGN Databases with Multi-Line Moves

### DIFF
--- a/chess-api/example.pgn
+++ b/chess-api/example.pgn
@@ -1,520 +1,21470 @@
-[Event "Hourly Blitz Arena"]
-[Site "https://lichess.org/ICrBBEAN"]
-[Date "2023.06.26"]
-[White "iliria1912"]
-[Black "jjcarv"]
-[Result "0-1"]
-[UTCDate "2023.06.26"]
-[UTCTime "00:52:04"]
-[WhiteElo "2108"]
-[BlackElo "2156"]
-[WhiteRatingDiff "-5"]
-[BlackRatingDiff "+6"]
-[Variant "Standard"]
-[TimeControl "300+0"]
-[ECO "B10"]
-[Termination "Time forfeit"]
-
-1. e4 c6 2. Nf3 d5 3. exd5 cxd5 4. d4 Nf6 5. h3 Nc6 6. Bb5 Bd7 7. O-O e6 8. c3 Bd6 9. Bg5 h6 10. Bxf6 Qxf6 11. Re1 O-O 12. Ne5 Bxe5 13. dxe5 Nxe5 14. Rxe5 Bxb5 15. Re1 Rac8 16. Nd2 Rfd8 17. Nf3 Qf4 18. Nd4 Bc6 19. Re3 Qf6 20. Qe2 Re8 21. Re1 Qd8 22. a3 Qb6 23. Qd2 Bd7 24. Re5 Qc7 25. R5e3 b5 26. Qe2 Qb6 27. g4 a5 28. Qf3 b4 29. axb4 axb4 30. h4 bxc3 31. bxc3 Qa5 32. g5 hxg5 33. hxg5 Rf8 34. Qg3 e5 35. Qxe5 Rxc3 36. Kg2 Rxe3 37. Qxe3 Re8 38. Qxe8+ Bxe8 39. Rxe8+ Kh7 40. Nf3 Qb5 41. Re1 Kg6 42. Kg3 Qb8+ 43. Kg2 Qf4 44. Re5 Qg4+ 0-1
-
-
-[Event "Hourly Blitz Arena"]
-[Site "https://lichess.org/DWHHtkrd"]
-[Date "2023.06.26"]
-[White "jjcarv"]
-[Black "soginsky"]
+﻿[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "fedateam"]
+[Black "PimponNicois"]
 [Result "1-0"]
-[UTCDate "2023.06.26"]
-[UTCTime "00:46:58"]
-[WhiteElo "2152"]
-[BlackElo "1935"]
-[WhiteRatingDiff "+4"]
-[BlackRatingDiff "-4"]
-[Variant "Standard"]
-[TimeControl "300+0"]
-[ECO "D10"]
-[Termination "Normal"]
+[ECO "D45"]
+[WhiteElo "2346"]
+[BlackElo "2334"]
+[PlyCount "91"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
 
-1. d4 d5 2. c4 c6 3. Nc3 Nf6 4. cxd5 cxd5 5. Nf3 Nc6 6. e3 Bg4 7. Be2 e6 8. Qb3 Qb6 9. Qxb6 axb6 10. Bd2 Ne4 11. Nxe4 dxe4 12. Ng5 Bxe2 13. Kxe2 f5 14. Nxe6 Kd7 15. Nf4 g5 16. Nd5 Ra6 17. Rhc1 Bg7 18. b4 b5 19. a4 Rha8 20. a5 Bf8 21. Nb6+ Rxb6 22. axb6 Rxa1 23. Rxa1 Bxb4 24. Bxb4 Nxb4 25. Rb1 Nd5 26. Kd2 Kc6 27. Rc1+ Kxb6 28. Rc5 Ne7 29. Re5 Nc6 30. Rxf5 h6 31. Rf6 b4 32. d5 1-0
+1. d4 d5 2. c4 c6 3. Nc3 Nf6 4. Nf3 e6 5. e3 Nbd7 6. Qc2 Bd6 7. Bd2 a6 8. O-O-O
+b5 9. c5 Bc7 10. a3 a5 11. Ne2 b4 12. a4 Ne4 13. Be1 Ba6 14. Ng3 Bxf1 15. Rxf1
+Nxg3 16. hxg3 O-O 17. Rh1 Nf6 18. Nd2 e5 19. dxe5 Bxe5 20. f4 Bc7 21. g4 Qe7
+22. Bh4 b3 23. Qd3 h6 24. Bxf6 Qxf6 25. g5 Qg6 26. Qxg6 fxg6 27. gxh6 Rfe8 28.
+Rde1 gxh6 29. Rxh6 Kg7 30. Rhh1 Rab8 31. g4 Rb4 32. Kb1 Rxa4 33. Nxb3 Rae4 34.
+Nd4 Bxf4 35. Nxc6 Rxe3 36. Rxe3 Bxe3 37. Re1 Kf6 38. Nxa5 Ke5 39. Nc6+ Kf4 40.
+b4 Re6 41. Na5 d4 42. Kc2 Ra6 43. Kd3 Kxg4 44. c6 Kf5 45. c7 Ra8 46. b5 1-0
 
-
-[Event "Hourly Blitz Arena"]
-[Site "https://lichess.org/M96XXMnM"]
-[Date "2023.06.26"]
-[White "Gyaljensherpa2"]
-[Black "jjcarv"]
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Sensei24"]
+[Black "hungzhao"]
 [Result "0-1"]
-[UTCDate "2023.06.26"]
-[UTCTime "00:39:58"]
-[WhiteElo "1939"]
-[BlackElo "2149"]
-[WhiteRatingDiff "-3"]
-[BlackRatingDiff "+3"]
-[Variant "Standard"]
-[TimeControl "300+0"]
-[ECO "B10"]
-[Termination "Normal"]
+[ECO "A21"]
+[WhiteElo "2449"]
+[BlackElo "2617"]
+[PlyCount "54"]
+[EventDate "2020.??.??"]
 
-1. e4 c6 2. c4 d5 3. cxd5 cxd5 4. exd5 Nf6 5. Nc3 Nxd5 6. Nf3 Nc6 7. Be2 Bg4 8. O-O e6 9. d4 Be7 10. h3 Bf5 11. Bb5 Rc8 12. Ne5 O-O 13. Nxc6 bxc6 14. Bd3 Bxd3 15. Qxd3 c5 16. dxc5 Nxc3 17. Qxd8 Ne2+ 18. Kh1 Rfxd8 19. b4 Nxc1 20. Rfxc1 a5 21. a3 Rd4 22. Rab1 axb4 23. axb4 h5 24. f3 h4 25. Kg1 Bg5 26. Rc2 Be3+ 27. Kf1 Rd2 28. Rc3 Bd4 29. Rc4 e5 30. c6 Bb6 31. b5 Rf2+ 32. Ke1 Rxg2 33. Rb3 Ra8 34. Rc1 Rg1+ 35. Kd2 Ra2+ 36. Rc2 Rg2+ 37. Kd3 Rgxc2 38. Ke4 Kf8 39. Kxe5 Ke7 40. Kd5 Ra4 41. Ke5 Rc5# 0-1
+1. c4 e5 2. Nc3 Bb4 3. g3 Bxc3 4. bxc3 Nc6 5. Bg2 Nge7 6. d3 d6 7. e4 O-O 8.
+Ne2 f5 9. O-O fxe4 10. dxe4 Be6 11. c5 dxc5 12. Be3 b6 13. Qa4 Qe8 14. Rfd1 Bg4
+15. Qc2 Qh5 16. Re1 Rf6 17. f4 Raf8 18. f5 g6 19. fxg6 hxg6 20. a4 Kg7 21. h4
+R6f7 22. Bg5 Nc8 23. Nc1 Nd6 24. Nd3 Bf3 25. Qd2 Bxg2 26. Qxg2 Qg4 27. Nf2 Rxf2
+0-1
 
-
-[Event "Hourly Blitz Arena"]
-[Site "https://lichess.org/DDPPly53"]
-[Date "2023.06.26"]
-[White "jjcarv"]
-[Black "mercator4"]
+[Event "Rated Bullet tournament GAdGz1co"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Zuritadas"]
+[Black "RaylessStarfish"]
 [Result "1-0"]
-[UTCDate "2023.06.26"]
-[UTCTime "00:32:20"]
-[WhiteElo "2147"]
-[BlackElo "1775"]
-[WhiteRatingDiff "+2"]
-[BlackRatingDiff "-1"]
-[Variant "Standard"]
-[TimeControl "300+0"]
-[ECO "A53"]
-[Termination "Normal"]
+[ECO "B01"]
+[WhiteElo "2397"]
+[BlackElo "2387"]
+[PlyCount "67"]
+[EventDate "2020.??.??"]
 
-1. d4 d6 2. c4 Nf6 3. Nc3 Nbd7 4. e4 c6 5. f4 Qc7 6. Nf3 e5 7. fxe5 dxe5 8. d5 Bc5 9. Bd3 Ng4 10. Qe2 Bf2+ 11. Kf1 Bc5 12. Na4 Be7 13. h3 Ngf6 14. Be3 O-O 15. g4 cxd5 16. cxd5 Nc5 17. Nxc5 Bxc5 18. Rc1 b6 19. b4 Nd7 20. bxc5 Nxc5 21. Bxc5 bxc5 22. Qf2 f5 23. gxf5 Bxf5 24. Qxc5 Qxc5 25. Rxc5 Bg6 26. Kg2 Bh5 27. Rf1 Rab8 28. Nxe5 Rb2+ 29. Rc2 Rfb8 30. Rxb2 Rxb2+ 31. Rf2 Rb4 32. Nc6 Rb7 33. d6 Be8 34. Bc4+ Bf7 35. Ne7+ Rxe7 36. dxe7 Bxc4 37. Rf8# 1-0
+1. e4 d5 2. exd5 Nf6 3. c4 e6 4. dxe6 Bxe6 5. Be2 c5 6. Nf3 Nc6 7. O-O Bd6 8.
+Nc3 Qd7 9. d3 h6 10. Be3 O-O-O 11. Qa4 Kb8 12. Nb5 a6 13. Nxd6 Qxd6 14. b4 cxb4
+15. d4 Bg4 16. d5 Bxf3 17. Bxf3 Ne5 18. Be2 Neg4 19. Bxg4 Nxg4 20. g3 Nxe3 21.
+fxe3 Qe5 22. Rae1 f5 23. Qxb4 Rhe8 24. Rf3 g5 25. Qb1 Rf8 26. Ref1 f4 27. exf4
+Qd4+ 28. Kg2 Qxc4 29. fxg5 Qxd5 30. g6 Rxf3 31. Rxf3 Rf8 32. Qd3 Qxa2+ 33. Kh3
+Qg8 34. Qd6+ 1-0
 
-
-[Event "Hourly Blitz Arena"]
-[Site "https://lichess.org/0GCZToBJ"]
-[Date "2023.06.26"]
-[White "ADUJLEON7"]
-[Black "jjcarv"]
+[Event "Rated Bullet tournament GAdGz1co"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "ScherlockKA"]
+[Black "dragonwelb"]
 [Result "0-1"]
-[UTCDate "2023.06.26"]
-[UTCTime "00:27:32"]
-[WhiteElo "1431"]
-[BlackElo "2147"]
-[WhiteRatingDiff "+0"]
-[BlackRatingDiff "+0"]
-[Variant "Standard"]
-[TimeControl "300+0"]
-[ECO "B10"]
-[Termination "Normal"]
-
-1. e4 c6 2. f4 d5 3. exd5 cxd5 4. Nf3 Nc6 5. d4 Bg4 6. Bb5 e6 7. O-O Bd6 8. h3 Bxf3 9. Qxf3 Ne7 10. Nc3 a6 11. Bxc6+ Nxc6 12. f5 Nxd4 13. Qe3 Nxf5 14. Rxf5 O-O 15. Rf2 d4 16. Qf3 dxc3 17. bxc3 Bc5 18. Be3 Qb6 19. Bxc5 Qxc5 20. Kh2 Qc7+ 21. Kh1 Rac8 22. Rb1 b5 23. a4 Rb8 24. axb5 Rxb5 25. Rbf1 Rc5 26. h4 h6 27. h5 Rxc3 28. Qe4 Rc4 29. Qe2 Rh4+ 30. Kg1 Qh2# 0-1
-
-
-[Event "Hourly Blitz Arena"]
-[Site "https://lichess.org/SL4gKi21"]
-[Date "2023.06.26"]
-[White "jjcarv"]
-[Black "Simonmelo"]
-[Result "1-0"]
-[UTCDate "2023.06.26"]
-[UTCTime "00:23:45"]
-[WhiteElo "2144"]
-[BlackElo "1887"]
-[WhiteRatingDiff "+3"]
-[BlackRatingDiff "-2"]
-[Variant "Standard"]
-[TimeControl "300+0"]
-[ECO "D31"]
-[Termination "Time forfeit"]
-
-1. d4 e6 2. c4 d5 3. Nc3 c6 4. e4 f5 5. exf5 exf5 6. cxd5 cxd5 7. Bb5+ Nc6 8. Nf3 Nf6 9. O-O Ke7 10. Bg5 Kf7 11. Qb3 Be6 12. Bxc6 bxc6 13. Ne5+ Kg8 14. Nxc6 Qd6 15. Bxf6 gxf6 16. Na5 1-0
-
-
-[Event "Hourly Blitz Arena"]
-[Site "https://lichess.org/ZRC4eDGx"]
-[Date "2023.06.26"]
-[White "Akinluyi"]
-[Black "jjcarv"]
-[Result "0-1"]
-[UTCDate "2023.06.26"]
-[UTCTime "00:17:11"]
-[WhiteElo "1928"]
-[BlackElo "2141"]
-[WhiteRatingDiff "-2"]
-[BlackRatingDiff "+3"]
-[Variant "Standard"]
-[TimeControl "300+0"]
-[ECO "A07"]
-[Termination "Normal"]
-
-1. Nf3 d5 2. g3 Nd7 3. Bg2 e5 4. d3 Ngf6 5. O-O Bd6 6. Bg5 h6 7. Bxf6 Nxf6 8. Nbd2 c6 9. e4 O-O 10. Nh4 dxe4 11. Nxe4 Nxe4 12. Bxe4 f5 13. Bg2 Qf6 14. Qh5 Bd7 15. Bh3 g5 16. Ng6 Be8 17. Qxh6 Qxg6 18. Qxg6+ Bxg6 19. Rae1 g4 20. Bg2 f4 21. d4 f3 22. dxe5 fxg2 23. Kxg2 Bc5 24. e6 Rae8 25. Re5 Be7 26. c3 Kg7 27. f4 gxf3+ 28. Rxf3 Rxf3 29. Kxf3 0-1
-
-
-[Event "Hourly Blitz Arena"]
-[Site "https://lichess.org/YIUG76o5"]
-[Date "2023.06.26"]
-[White "jjcarv"]
-[Black "tesacarelacaca"]
-[Result "1-0"]
-[UTCDate "2023.06.26"]
-[UTCTime "00:15:40"]
-[WhiteElo "2140"]
-[BlackElo "1557"]
-[WhiteRatingDiff "+1"]
-[BlackRatingDiff "-1"]
-[Variant "Standard"]
-[TimeControl "300+0"]
-[ECO "D32"]
-[Termination "Normal"]
-
-1. d4 e6 2. Nf3 d5 3. c4 c5 4. cxd5 exd5 5. Nc3 cxd4 6. Nxd4 Bc5 7. Nb3 Bxf2+ 8. Kxf2 Qh4+ 9. g3 Qe7 10. Nxd5 1-0
-
-
-[Event "Hourly Blitz Arena"]
-[Site "https://lichess.org/Ituosnbg"]
-[Date "2023.06.26"]
-[White "jjcarv"]
-[Black "yurichesspk"]
-[Result "1-0"]
-[UTCDate "2023.06.26"]
-[UTCTime "00:08:43"]
-[WhiteElo "2138"]
-[BlackElo "1801"]
-[WhiteRatingDiff "+2"]
-[BlackRatingDiff "-1"]
-[Variant "Standard"]
-[TimeControl "300+0"]
-[ECO "D21"]
-[Termination "Normal"]
-
-1. d4 d5 2. c4 dxc4 3. Nf3 c6 4. a4 Bf5 5. Nc3 e6 6. e4 Bg6 7. Bxc4 Nf6 8. Qe2 Be7 9. O-O O-O 10. Bf4 Bh5 11. Rfd1 Bg6 12. h3 h6 13. Ne5 Bh7 14. Rac1 Nbd7 15. Bg3 Qc8 16. f3 Nxe5 17. Bxe5 Rd8 18. Bb3 Nd7 19. Bf4 Nf6 20. Bh2 Ne8 21. d5 exd5 22. Nxd5 cxd5 23. Rxc8 Raxc8 24. Bxd5 Nf6 25. Bxb7 Rc7 26. Bxc7 Rxd1+ 27. Qxd1 Bc5+ 28. Kh2 Bg6 29. Qd8+ Kh7 30. Be5 Nh5 31. Bd4 Bxd4 32. Qxd4 Nf4 33. Qxa7 Nd3 34. Qb6 Ne5 35. a5 Nc4 36. Qb4 Ne5 37. a6 Nd7 38. a7 Ne5 39. a8=Q Nxf3+ 40. gxf3 Bh5 41. e5 f6 42. Be4+ g6 43. Qbb7# 1-0
-
-
-[Event "Hourly Blitz Arena"]
-[Site "https://lichess.org/Dhdngh2R"]
-[Date "2023.06.26"]
-[White "mrmicheas"]
-[Black "jjcarv"]
-[Result "0-1"]
-[UTCDate "2023.06.26"]
-[UTCTime "00:01:57"]
-[WhiteElo "2074"]
-[BlackElo "2132"]
-[WhiteRatingDiff "-5"]
-[BlackRatingDiff "+6"]
-[Variant "Standard"]
-[TimeControl "300+0"]
-[ECO "B15"]
-[Termination "Time forfeit"]
-
-1. e4 c6 2. d4 d5 3. Nd2 dxe4 4. Nxe4 Nf6 5. Ng5 h6 6. N5f3 Bg4 7. h3 Bh5 8. g4 Bg6 9. Ne5 Bh7 10. Bc4 e6 11. Ngf3 Nd5 12. Qe2 Nd7 13. Bd2 Nxe5 14. Nxe5 Bd6 15. O-O-O O-O 16. f4 Bxe5 17. dxe5 b5 18. Bb3 a5 19. a4 Qb6 20. g5 h5 21. Qxh5 Bg6 22. Qe2 bxa4 23. Bxa4 Rfb8 24. b3 Nb4 25. Be3 Qb7 26. c3 Nd5 27. Bd2 c5 28. c4 Nb4 29. Bxb4 Qxb4 30. h4 Qc3+ 0-1
-
-
-[Event "Rated Blitz game"]
-[Site "https://lichess.org/honkmeMl"]
-[Date "2023.06.25"]
-[White "jjcarv"]
-[Black "JediDanih2"]
-[Result "1-0"]
-[UTCDate "2023.06.25"]
-[UTCTime "23:50:23"]
-[WhiteElo "2123"]
-[BlackElo "2140"]
-[WhiteRatingDiff "+9"]
-[BlackRatingDiff "-6"]
-[Variant "Standard"]
-[TimeControl "180+2"]
-[ECO "E01"]
-[Termination "Time forfeit"]
-
-1. d4 Nf6 2. c4 e6 3. g3 d5 4. Bg2 c5 5. cxd5 exd5 6. Nf3 Nc6 7. O-O h6 8. Nc3 Be6 9. Bf4 Be7 10. dxc5 Bxc5 11. Qa4 O-O 12. Rad1 Qb6 13. Qc2 Rac8 14. Na4 Nb4 15. Nxb6 Nxc2 16. Nxc8 Rxc8 17. Rc1 Nb4 18. a3 Na6 19. b4 Be7 20. Rxc8+ Bxc8 21. Nd4 Nh5 22. Rc1 Bd7 23. Be3 Nf6 24. h3 Bd6 25. Bf4 Bxf4 26. gxf4 Kh7 27. b5 Nb8 28. Rc7 1-0
-
-
-[Event "Rated Blitz game"]
-[Site "https://lichess.org/dERtJ2Y5"]
-[Date "2023.06.25"]
-[White "JediDanih2"]
-[Black "jjcarv"]
-[Result "1/2-1/2"]
-[UTCDate "2023.06.25"]
-[UTCTime "23:40:24"]
-[WhiteElo "2140"]
-[BlackElo "2123"]
-[WhiteRatingDiff "+0"]
-[BlackRatingDiff "+0"]
-[Variant "Standard"]
-[TimeControl "180+2"]
-[ECO "B13"]
-[Termination "Normal"]
-
-1. e4 c6 2. d4 d5 3. exd5 cxd5 4. h3 Nf6 5. Bd3 Nc6 6. c3 e5 7. dxe5 Nxe5 8. Nf3 Nxd3+ 9. Qxd3 Bc5 10. O-O O-O 11. Bg5 Be6 12. Nbd2 h6 13. Bxf6 Qxf6 14. Nb3 Bb6 15. Nbd4 Rfd8 16. Rfe1 Rac8 17. Re2 Re8 18. Rae1 Bd7 19. Rxe8+ Bxe8 20. Qf5 Qxf5 21. Nxf5 Kf8 22. Nd6 Rb8 23. Nxe8 Rxe8 24. Rxe8+ Kxe8 25. Kf1 Ke7 26. Ke2 Kd6 27. b4 a5 28. a3 axb4 29. axb4 g5 30. Nd2 f5 31. g3 Ke5 32. f3 Bc7 33. Ke3 Bb6+ 34. Kd3 Ba7 35. Nb3 Bf2 36. g4 fxg4 37. hxg4 Kf4 38. Ke2 Bg1 39. Na5 b6 40. Nb3 Be3 41. b5 Bg1 42. Nc1 Ke5 43. Nd3+ Kd6 44. f4 gxf4 45. Nxf4 Bc5 46. Kf3 Ba3 47. Nd3 d4 48. c4 Bc5 49. Ke4 Ke6 50. Nf4+ Kf6 51. Nd3 Ke6 52. Kf3 Bd6 53. Ke4 Bc5 1/2-1/2
-
-
-[Event "Hourly Blitz Arena"]
-[Site "https://lichess.org/tUrdOxDP"]
-[Date "2023.05.31"]
-[White "jjcarv"]
-[Black "gen123pal"]
-[Result "1-0"]
-[UTCDate "2023.05.31"]
-[UTCTime "02:52:59"]
-[WhiteElo "2118"]
-[BlackElo "2001"]
-[WhiteRatingDiff "+5"]
-[BlackRatingDiff "-3"]
-[Variant "Standard"]
-[TimeControl "300+0"]
-[ECO "D10"]
-[Termination "Normal"]
-
-1. d4 d5 2. c4 c6 3. cxd5 cxd5 4. Nc3 Nf6 5. Nf3 Nc6 6. e3 e6 7. Ne5 Bc5 8. Nxc6 bxc6 9. dxc5 O-O 10. Bd3 e5 11. O-O e4 12. Be2 Nd7 13. Na4 Ne5 14. b3 Qg5 15. f4 exf3 16. Bxf3 Bh3 17. e4 Qg6 18. Bb2 Rae8 19. Bxe5 Rxe5 20. exd5 cxd5 21. Rf2 Rg5 22. Qd2 Re8 23. Rd1 h5 24. Kh1 Be6 25. c6 h4 26. c7 h3 27. g3 Rxg3 28. hxg3 Qxg3 29. Rg1 Qxc7 30. Qc3 Qxc3 31. Nxc3 d4 32. Ne4 Rd8 33. Rd2 Bf5 34. Nf6+ Kf8 35. Nd5 Be6 36. Rxd4 f6 37. Nf4 Re8 38. Nxe6+ Rxe6 39. Bg4 1-0
-
-
-[Event "Hourly Blitz Arena"]
-[Site "https://lichess.org/auEnFYCO"]
-[Date "2023.05.31"]
-[White "Franco_Milazzo"]
-[Black "jjcarv"]
-[Result "1-0"]
-[UTCDate "2023.05.31"]
-[UTCTime "02:42:15"]
-[WhiteElo "1835"]
-[BlackElo "2130"]
-[WhiteRatingDiff "+10"]
-[BlackRatingDiff "-12"]
-[Variant "Standard"]
-[TimeControl "300+0"]
-[ECO "C42"]
-[Termination "Time forfeit"]
-
-1. e4 e5 2. Nf3 Nf6 3. Nxe5 d6 4. Nf3 Nxe4 5. d4 d5 6. Bd3 Be7 7. O-O O-O 8. Nbd2 Bf5 9. Re1 Nd6 10. Bxf5 Nxf5 11. Nf1 Nc6 12. c3 h6 13. Qd3 Nd6 14. Ng3 Bf6 15. Ne5 Re8 16. f4 Bh4 17. Bd2 Bxg3 18. hxg3 Ne4 19. Ng4 Ne7 20. Nf2 Nd6 21. Re2 Qd7 22. Rae1 Nef5 23. g4 Rxe2 24. Rxe2 Nh4 25. Qg3 Ng6 26. f5 Nf8 27. Bf4 Re8 28. Qf3 Rxe2 29. Qxe2 Qe8 30. Qf3 Nd7 31. Kh2 Nf6 32. Bxd6 cxd6 33. Kg3 Ne4+ 34. Kh2 Qe7 35. g3 b6 36. Nd3 Qg5 37. Nf4 Nf6 38. Kh3 h5 39. Nxh5 Nxh5 40. gxh5 Qc1 41. Qxd5 Qxb2 42. f6 Qb1 43. fxg7 Qf1+ 44. Kh4 Kxg7 45. Qg5+ Kh7 46. h6 Qh1+ 47. Kg4 Qe4+ 48. Kh3 1-0
-
-
-[Event "Hourly Blitz Arena"]
-[Site "https://lichess.org/8RAjqtHR"]
-[Date "2023.05.31"]
-[White "jjcarv"]
-[Black "van_gomes"]
-[Result "1/2-1/2"]
-[UTCDate "2023.05.31"]
-[UTCTime "02:36:15"]
-[WhiteElo "2129"]
-[BlackElo "2171"]
-[WhiteRatingDiff "+1"]
-[BlackRatingDiff "+0"]
-[Variant "Standard"]
-[TimeControl "300+0"]
-[ECO "A51"]
-[Termination "Normal"]
-
-1. d4 Nf6 2. c4 e5 3. dxe5 Ne4 4. Nf3 Bb4+ 5. Bd2 Nxd2 6. Nbxd2 Nc6 7. e3 O-O 8. a3 Bxd2+ 9. Qxd2 Re8 10. Qc3 Qe7 11. Be2 Nxe5 12. Nxe5 Qxe5 13. Qxe5 Rxe5 14. O-O-O d6 15. Bf3 Rb8 16. Rd5 Be6 17. Rxe5 dxe5 18. c5 b6 19. c6 Rd8 20. Rd1 Rxd1+ 21. Kxd1 Kf8 22. Kd2 Ke7 23. Kc3 Kd6 24. b4 f5 25. b5 Kc5 26. Be2 Bd5 27. g3 g5 28. h3 h6 29. f4 exf4 30. exf4 Be4 31. h4 gxf4 32. gxf4 Bb1 33. Bf1 Be4 34. Be2 a5 35. Bf1 Bb1 36. Be2 Be4 37. Bf1 Bb1 38. Be2 Be4 39. Bf1 1/2-1/2
-
-
-[Event "Hourly Blitz Arena"]
-[Site "https://lichess.org/UMNfPufK"]
-[Date "2023.05.31"]
-[White "jjcarv"]
-[Black "Uncycledude"]
-[Result "1/2-1/2"]
-[UTCDate "2023.05.31"]
-[UTCTime "02:27:28"]
-[WhiteElo "2133"]
-[BlackElo "1914"]
-[WhiteRatingDiff "-4"]
-[BlackRatingDiff "+4"]
-[Variant "Standard"]
-[TimeControl "300+0"]
-[ECO "E91"]
-[Termination "Normal"]
-
-1. d4 g6 2. c4 Bg7 3. Nf3 Nf6 4. Nc3 d6 5. e4 O-O 6. Be2 Nbd7 7. Bg5 e5 8. d5 h6 9. Bh4 g5 10. Bg3 Nh7 11. Nd2 f5 12. exf5 Rxf5 13. Bg4 Rf8 14. Be6+ Kh8 15. Qc2 Ndf6 16. Bxc8 Qxc8 17. O-O Qd7 18. Nde4 Rf7 19. Rad1 Raf8 20. b4 b6 21. c5 bxc5 22. bxc5 Nxe4 23. Nxe4 Nf6 24. cxd6 cxd6 25. f3 Rc8 26. Nxf6 Bxf6 27. Qg6 Bg7 28. Rc1 Rcf8 29. Rc6 Rf6 30. Qc2 Re8 31. Rc7 Qb5 32. Rc1 Qxd5 33. Rxa7 Qd4+ 34. Bf2 Qf4 35. Qc7 Rg8 36. Rd1 e4 37. Bg3 Qe3+ 38. Bf2 Qf4 39. Bg3 Qe3+ 40. Bf2 Qf4 1/2-1/2
-
-
-[Event "Hourly Blitz Arena"]
-[Site "https://lichess.org/akcetPW3"]
-[Date "2023.05.31"]
-[White "joseh63"]
-[Black "jjcarv"]
-[Result "0-1"]
-[UTCDate "2023.05.31"]
-[UTCTime "02:16:55"]
-[WhiteElo "1799"]
-[BlackElo "2131"]
-[WhiteRatingDiff "-1"]
-[BlackRatingDiff "+2"]
-[Variant "Standard"]
-[TimeControl "300+0"]
-[ECO "C00"]
-[Termination "Time forfeit"]
-
-1. e4 e6 2. d3 d5 3. Nd2 b6 4. Ngf3 Bb7 5. exd5 Qxd5 6. g3 Bb4 7. Bg2 Qd8 8. O-O Nf6 9. c3 Bd6 10. d4 O-O 11. Nc4 Be7 12. Nce5 Nbd7 13. Bf4 Nxe5 14. Nxe5 Bxg2 15. Kxg2 Bd6 16. Qe2 Nd5 17. Bd2 Bxe5 18. Qxe5 b5 19. Rae1 c6 20. f4 Re8 21. f5 exf5 22. Qxf5 Qf6 23. Qxf6 Nxf6 24. Bg5 Nd5 25. Kf2 f6 26. Bd2 a5 27. Rxe8+ Rxe8 28. Re1 Rxe1 29. Kxe1 Kf7 30. Ke2 Ke6 31. Kd3 Nb6 32. b3 a4 33. Be3 axb3 34. axb3 Nd5 35. Bd2 g5 36. c4 Ne7 37. g4 h6 38. h3 f5 39. gxf5+ Nxf5 40. Ke4 Nd6+ 41. Kd3 Kf5 42. d5 bxc4+ 43. bxc4 cxd5 44. cxd5 Ke5 45. Bb4 Kxd5 46. Bxd6 Kxd6 47. Kd4 Ke6 48. Ke4 Kf6 0-1
-
-
-[Event "Hourly Blitz Arena"]
-[Site "https://lichess.org/nc21Ep4c"]
-[Date "2023.05.31"]
-[White "jjcarv"]
-[Black "HardRob"]
-[Result "1-0"]
-[UTCDate "2023.05.31"]
-[UTCTime "02:10:08"]
-[WhiteElo "2129"]
-[BlackElo "1744"]
-[WhiteRatingDiff "+2"]
-[BlackRatingDiff "-1"]
-[Variant "Standard"]
-[TimeControl "300+0"]
-[ECO "E91"]
-[Termination "Time forfeit"]
-
-1. d4 Nf6 2. c4 g6 3. Nc3 Bg7 4. e4 d6 5. Nf3 O-O 6. Be2 Nc6 7. d5 Ne5 8. Nxe5 dxe5 9. c5 Ne8 10. O-O f5 11. f3 f4 12. b4 Kh8 13. Bb2 g5 14. a4 Nf6 15. a5 h5 16. b5 g4 17. b6 axb6 18. axb6 Rxa1 19. Bxa1 g3 20. hxg3 fxg3 21. Qe1 h4 22. Nb5 c6 23. dxc6 bxc6 24. Na7 Bb7 25. Bxe5 Nd7 26. Bxg7+ Kxg7 27. Qa1+ e5 28. Rd1 Rf7 29. Qxe5+ Nxe5 30. Rxd8 Rd7 31. Rxd7+ Nxd7 32. f4 Nxc5 33. Bf3 Nd7 34. e5 Nxb6 35. Nxc6 Nc4 36. Nd4 Bxf3 37. Nxf3 Kg6 38. Nxh4+ 1-0
-
-
-[Event "Hourly Blitz Arena"]
-[Site "https://lichess.org/c79V6573"]
-[Date "2023.05.31"]
-[White "badapp"]
-[Black "jjcarv"]
-[Result "0-1"]
-[UTCDate "2023.05.31"]
-[UTCTime "02:01:45"]
-[WhiteElo "1917"]
-[BlackElo "2126"]
-[WhiteRatingDiff "-3"]
-[BlackRatingDiff "+3"]
-[Variant "Standard"]
-[TimeControl "300+0"]
-[ECO "D82"]
-[Termination "Normal"]
-
-1. d4 Nf6 2. c4 g6 3. Nc3 d5 4. Bf4 Bg7 5. e3 a6 6. Rc1 dxc4 7. Bxc4 b5 8. Bb3 Bb7 9. Nf3 Nbd7 10. O-O c5 11. Re1 c4 12. Bc2 O-O 13. b3 Rc8 14. bxc4 Rxc4 15. Bb3 Rc8 16. Ne2 Ne4 17. Qd3 Ndf6 18. Ne5 Nh5 19. Rxc8 Qxc8 20. Rc1 Nxf4 21. Rxc8 Nxd3 22. Rxf8+ Kxf8 23. Nxd3 f6 24. f3 Nd2 25. Nc5 Nxb3 26. axb3 Bc8 27. b4 e5 28. Kf2 exd4 29. Nxd4 Ke7 30. Nc6+ Kd6 31. Nb8 f5 32. Nbxa6 Bc3 33. e4 Bxb4 34. Nxb4 Kxc5 35. Nd3+ Kd4 36. exf5 Kxd3 37. fxg6 hxg6 38. g4 b4 39. h4 b3 40. h5 gxh5 41. gxh5 b2 42. h6 Bf5 43. Kg3 b1=Q 44. Kf4 Kd4 45. Kg5 Bh7 46. f4 Qf5+ 47. Kh4 Qxf4+ 48. Kh5 Qf5+ 49. Kh4 Qg6 50. Kh3 Ke3 51. Kh4 Kf4 0-1
-
-
-[Event "Hourly Blitz Arena"]
-[Site "https://lichess.org/qicgwFmC"]
-[Date "2023.05.31"]
-[White "jjcarv"]
-[Black "Phox23"]
-[Result "0-1"]
-[UTCDate "2023.05.31"]
-[UTCTime "01:51:16"]
-[WhiteElo "2135"]
-[BlackElo "2027"]
-[WhiteRatingDiff "-9"]
-[BlackRatingDiff "+7"]
-[Variant "Standard"]
-[TimeControl "180+2"]
-[ECO "A43"]
-[Termination "Time forfeit"]
-
-1. d4 c5 2. d5 b5 3. e4 a6 4. a4 b4 5. Nd2 d6 6. Nc4 a5 7. Bd3 Nd7 8. Nf3 Ngf6 9. h3 g6 10. Bf4 Bg7 11. Bh2 O-O 12. O-O Bb7 13. Nfd2 Nb6 14. Nxb6 Qxb6 15. Nc4 Qd8 16. f4 Nd7 17. Be2 Nb6 18. Nxb6 Qxb6 19. Bc4 Bxb2 20. e5 Bxa1 21. Qxa1 Ba6 22. Bxa6 Rxa6 23. Kh1 c4 24. f5 Qe3 25. Rf3 Qe2 26. Qc1 dxe5 27. Re3 Qf2 28. Rf3 Qd4 29. Qe1 Qxd5 30. Bxe5 Rd8 31. Qg3 Qd1+ 32. Kh2 Qd7 33. fxg6 Rxg6 34. Qf4 f6 35. Bc7 Rc8 36. Qxc4+ e6 37. Qh4 Qxc7+ 38. Kg1 Qc4 39. Rf4 Qc5+ 40. Kh2 Qg5 41. Qxg5 Rxg5 42. Rxf6 Rxc2 43. Kg1 Rgxg2+ 44. Kf1 Rh2 45. Kg1 Rhd2 0-1
-
-
-[Event "Hourly Blitz Arena"]
-[Site "https://lichess.org/Bnb1HuPM"]
-[Date "2023.05.31"]
-[White "PedroCP_2000"]
-[Black "jjcarv"]
-[Result "0-1"]
-[UTCDate "2023.05.31"]
-[UTCTime "01:44:58"]
-[WhiteElo "1518"]
-[BlackElo "2135"]
-[WhiteRatingDiff "+0"]
-[BlackRatingDiff "+0"]
-[Variant "Standard"]
-[TimeControl "180+2"]
 [ECO "A46"]
-[Termination "Normal"]
+[WhiteElo "2323"]
+[BlackElo "2378"]
+[PlyCount "84"]
+[EventDate "2020.??.??"]
 
-1. d4 Nf6 2. Nf3 e6 3. Bf4 Bd6 4. Bg3 b6 5. Nc3 Bb7 6. e3 a6 7. Bd3 Bb4 8. O-O Bxc3 9. bxc3 d6 10. Bh4 h6 11. Bxf6 Qxf6 12. e4 Nd7 13. c4 e5 14. d5 Nc5 15. Be2 Bc8 16. c3 Bd7 17. a3 Nxe4 18. Bd3 Nc5 19. Bc2 O-O 20. Re1 Rfe8 21. Bb1 Bg4 22. Qc2 e4 23. Nd4 Bh5 24. Nb3 Bg6 25. Nxc5 bxc5 26. Re3 Rab8 27. Qe2 Rb3 28. Bc2 Rxc3 29. Rxc3 Qxc3 30. Re1 e3 31. Bxg6 exf2+ 32. Kxf2 Qxe1+ 33. Qxe1 Rxe1 34. Kxe1 fxg6 35. Ke2 Kf7 36. Kd2 Kf6 37. Kc3 Ke5 38. Kb3 Kd4 39. Ka4 Kxc4 40. Ka5 Kb3 41. a4 c4 42. Kxa6 Kxa4 43. Kb7 c3 44. Kxc7 c2 45. Kxd6 c1=Q 46. Ke7 0-1
+1. d4 Nf6 2. Nf3 c5 3. dxc5 e6 4. g3 Bxc5 5. Bg2 Nc6 6. O-O O-O 7. a3 d5 8. b4
+Be7 9. Bb2 b6 10. Nbd2 Bb7 11. c4 Rc8 12. Rc1 Re8 13. Qb3 dxc4 14. Nxc4 Qc7 15.
+Nce5 Qb8 16. Rfd1 Nxe5 17. Bxe5 Qa8 18. h4 h6 19. Bf4 Bd5 20. Qb2 Ne4 21. Be5
+Bf6 22. Bxf6 Nxf6 23. Ne1 Bxg2 24. Nxg2 Rxc1 25. Rxc1 Rd8 26. Rc7 a5 27. b5 Qd5
+28. Ne3 Qh5 29. Rc6 Nd7 30. Rd6 Qc5 31. Qd2 Qc7 32. Rc6 Qb8 33. a4 Nc5 34. Qc2
+Rd4 35. f3 Rxa4 36. Rxc5 Ra1+ 37. Kg2 bxc5 38. Nc4 Qxb5 39. Nd6 Qb1 40. Qxb1
+Rxb1 41. Nc4 a4 42. Nd2 Rb4 0-1
 
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "vmedina1"]
+[Black "elRope"]
+[Result "0-1"]
+[ECO "C28"]
+[WhiteElo "2304"]
+[BlackElo "2353"]
+[PlyCount "78"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
 
-[Event "Hourly Blitz Arena"]
-[Site "https://lichess.org/ffGeHZyR"]
-[Date "2023.05.31"]
-[White "jjcarv"]
-[Black "Escalabar"]
+1. e4 e5 2. Nc3 Nf6 3. Bc4 Nc6 4. d3 Be7 5. f4 d6 6. Nf3 O-O 7. O-O Be6 8. Bxe6
+fxe6 9. fxe5 dxe5 10. h3 Qe8 11. Be3 Nh5 12. Ng5 Rxf1+ 13. Qxf1 Qg6 14. Nf3 Rf8
+15. Ne2 Nf4 16. Nxf4 exf4 17. Bf2 e5 18. Qe2 Qe6 19. c3 Bf6 20. d4 Ne7 21. d5
+Qd6 22. c4 b6 23. Rb1 a5 24. b3 g5 25. Nh2 Ng6 26. Ng4 Bg7 27. Rc1 f3 28. gxf3
+Nf4 29. Qe1 h5 30. Nh2 Qd7 31. Qf1 Nxh3+ 32. Kh1 g4 33. c5 Bh6 34. Rd1 Bf4 35.
+fxg4 hxg4 36. Bh4 Bxh2 37. Qg2 Bf4 38. cxb6 cxb6 39. Rc1 Bxc1 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "ajedrez2021"]
+[Black "sutcunuri"]
 [Result "1-0"]
-[UTCDate "2023.05.31"]
-[UTCTime "01:41:52"]
-[WhiteElo "2132"]
-[BlackElo "1890"]
-[WhiteRatingDiff "+3"]
-[BlackRatingDiff "-2"]
-[Variant "Standard"]
-[TimeControl "180+2"]
-[ECO "D08"]
-[Termination "Normal"]
+[ECO "D07"]
+[WhiteElo "2574"]
+[BlackElo "2538"]
+[PlyCount "29"]
+[EventDate "2020.??.??"]
 
-1. d4 d5 2. c4 e5 3. dxe5 d4 4. a3 Nc6 5. Nf3 Bg4 6. Bf4 Qe7 7. e3 Bxf3 8. Qxf3 d3 9. Bxd3 O-O-O 10. Be4 Nxe5 11. Bxe5 Qxe5 12. Bxb7+ Kb8 13. Nc3 Rd6 14. Bd5 Nf6 15. O-O Rd8 16. Ba8 Nd7 17. Qb7# 1-0
+1. Nf3 Nc6 2. d4 d5 3. c4 Bg4 4. Nc3 Nf6 5. cxd5 Nxd5 6. Qb3 Nxc3 7. bxc3 e6 8.
+Qxb7 Bxf3 9. exf3 Ne7 10. Bb5+ c6 11. Bxc6+ Nxc6 12. Qxc6+ Ke7 13. Rb1 Kf6 14.
+h4 h6 15. Bg5+ 1-0
 
-
-[Event "Hourly Blitz Arena"]
-[Site "https://lichess.org/wer3DGbc"]
-[Date "2023.05.31"]
-[White "Irukandy"]
-[Black "jjcarv"]
-[Result "0-1"]
-[UTCDate "2023.05.31"]
-[UTCTime "01:32:18"]
-[WhiteElo "1987"]
-[BlackElo "2127"]
-[WhiteRatingDiff "-3"]
-[BlackRatingDiff "+5"]
-[Variant "Standard"]
-[TimeControl "180+2"]
-[ECO "A22"]
-[Termination "Normal"]
-
-1. c4 e5 2. Nc3 Nf6 3. e4 Bc5 4. g3 c6 5. Bg2 d6 6. h3 a5 7. Nge2 Be6 8. d3 Na6 9. O-O Nc7 10. b3 d5 11. d4 exd4 12. Nxd4 Bxd4 13. Qxd4 dxc4 14. Qxd8+ Rxd8 15. bxc4 Bxc4 16. Re1 O-O 17. Bg5 Ne6 18. e5 Nxg5 19. exf6 Ne6 20. fxg7 Kxg7 21. Rab1 Rd7 22. Rb6 Nc5 23. h4 Rfd8 24. h5 h6 25. Bf1 Be6 26. Bg2 Rd3 27. Ne4 Rd1 28. Rxd1 Rxd1+ 29. Kh2 Nxe4 30. Bxe4 Rd7 31. a3 Bg4 32. f4 Bxh5 33. Kh3 Be2 34. Bf5 Re7 35. Bc8 Ba6 36. Kh4 c5 37. Bf5 c4 38. Rb2 c3 39. Rc2 Rc7 40. Kg4 b5 41. Bd3 b4 42. Bxa6 b3 43. Rg2 c2 0-1
-
-
-[Event "Hourly Blitz Arena"]
-[Site "https://lichess.org/E1UCmpYG"]
-[Date "2023.05.31"]
-[White "jjcarv"]
-[Black "FILETEDEDRAGON"]
-[Result "0-1"]
-[UTCDate "2023.05.31"]
-[UTCTime "01:23:59"]
-[WhiteElo "2142"]
-[BlackElo "1509"]
-[WhiteRatingDiff "-15"]
-[BlackRatingDiff "+45"]
-[Variant "Standard"]
-[TimeControl "180+2"]
-[ECO "E91"]
-[Termination "Time forfeit"]
-
-1. d4 Nf6 2. c4 g6 3. Nc3 Bg7 4. e4 d6 5. Nf3 O-O 6. Be2 c5 7. dxc5 dxc5 8. Qxd8 Rxd8 9. Be3 b6 10. h3 Bb7 11. Nd2 Nbd7 12. O-O-O Ne5 13. Kc2 Nc6 14. Nd5 Nxd5 15. exd5 Nb4+ 16. Kb3 a5 17. a4 Bc8 18. Ne4 Bf5 19. f3 Bxe4 20. fxe4 f5 21. Bf3 fxe4 22. Bxe4 Rf8 23. Rhf1 Be5 24. Bg5 Rxf1 25. Rxf1 Rf8 26. Rxf8+ Kxf8 27. h4 Kf7 28. g4 Bf6 29. Bxf6 Kxf6 0-1
-
-
-[Event "Hourly Blitz Arena"]
-[Site "https://lichess.org/uV7VlDCw"]
-[Date "2023.05.31"]
-[White "MANDAYARDA"]
-[Black "jjcarv"]
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "onthewaygm"]
+[Black "starkspieler"]
 [Result "1-0"]
-[UTCDate "2023.05.31"]
-[UTCTime "01:15:56"]
-[WhiteElo "2204"]
-[BlackElo "2148"]
-[WhiteRatingDiff "+5"]
-[BlackRatingDiff "-6"]
-[Variant "Standard"]
-[TimeControl "180+2"]
-[ECO "C10"]
-[Termination "Normal"]
+[ECO "E90"]
+[WhiteElo "2428"]
+[BlackElo "2424"]
+[PlyCount "109"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
 
-1. Nc3 e6 2. d4 d5 3. e4 c5 4. Nf3 Nf6 5. Bg5 cxd4 6. Qxd4 Nc6 7. Bb5 Be7 8. exd5 Nxd5 9. Nxd5 Qxd5 10. Bxc6+ bxc6 11. Qxg7 Rf8 12. Bxe7 Qe4+ 13. Kd2 Kxe7 14. Rae1 Qf4+ 15. Re3 Rd8+ 16. Kc1 h6 17. Re1 Ba6 18. g3 Qf6 19. Rxe6+ Qxe6 20. Rxe6+ Kxe6 21. Qf6+ Kd7 22. Qxf7+ Kd6 23. Qf6+ Kc7 24. b3 Be2 25. Qe7+ Kb6 26. Qxe2 1-0
+1. c4 g6 2. Nc3 Bg7 3. Nf3 Nf6 4. d4 d6 5. e4 O-O 6. h3 Na6 7. Be3 e5 8. d5 c5
+9. g4 h5 10. Bg5 hxg4 11. hxg4 Bxg4 12. Be2 Qb6 13. b3 Qa5 14. Bd2 Bh5 15. Ng5
+Bh6 16. Nb5 Qd8 17. Bxh5 Nxh5 18. Rxh5 gxh5 19. Qxh5 Qf6 20. O-O-O Qg6 21. Qh4
+f5 22. Ne6 Bxd2+ 23. Rxd2 fxe4 24. Nxd6 Nb4 25. Nxf8 Rxf8 26. Nxe4 Rf4 27. Qd8+
+Rf8 28. Qg5 Qxg5 29. Nxg5 Rf4 30. Ne6 Re4 31. Nxc5 Re1+ 32. Kb2 b6 33. Nd3
+Nxd3+ 34. Rxd3 Re2+ 35. Ka3 Rxf2 36. d6 Rf8 37. Kb4 Rd8 38. Kb5 Kf7 39. Kc6 Ke6
+40. d7 e4 41. Rd1 Ke5 42. b4 e3 43. Kc7 Rh8 44. d8=Q Rxd8 45. Rxd8 Ke4 46. c5
+bxc5 47. bxc5 e2 48. Re8+ Kd5 49. c6 Kc5 50. Rxe2 a5 51. Kb7 Kb5 52. c7 Ka4 53.
+c8=Q Ka3 54. Qc3+ Ka4 55. Qb3# 1-0
 
+[Event "Rated Rapid tournament PyTrQpu8"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "OjaiJoao"]
+[Black "FitzwilliamDarcy"]
+[Result "1-0"]
+[ECO "B06"]
+[WhiteElo "2441"]
+[BlackElo "2300"]
+[PlyCount "73"]
+[EventDate "2020.??.??"]
+[EventType "rapid"]
 
-[Event "Hourly Blitz Arena"]
-[Site "https://lichess.org/hj5Gq9mY"]
-[Date "2023.05.31"]
-[White "Johaidii"]
-[Black "jjcarv"]
+1. d4 g6 2. e4 Bg7 3. Nc3 d6 4. Be3 c6 5. f4 Qc7 6. Nf3 Nf6 7. Bd3 Nbd7 8. O-O
+O-O 9. h3 a5 10. a4 Nh5 11. g4 Nhf6 12. Qe1 b6 13. Qh4 Ba6 14. Bxa6 Rxa6 15. f5
+e5 16. g5 Nh5 17. f6 Bh8 18. d5 Nc5 19. dxc6 Qxc6 20. Nd5 Re8 21. Bxc5 Qxc5+
+22. Qf2 Rc8 23. c3 Ra7 24. Rad1 Nf4 25. Qxc5 bxc5 26. Nxf4 exf4 27. Rxd6 h6 28.
+h4 Rb7 29. Rf2 Rcb8 30. Rfd2 Rxb2 31. Rxb2 Rxb2 32. Ne5 Rb8 33. Rd7 Re8 34.
+Nxf7 Rxe4 35. Nxh8 Kxh8 36. Rd8+ Kh7 37. f7 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "estocastico"]
+[Black "Tigerscot"]
+[Result "1-0"]
+[ECO "C41"]
+[WhiteElo "2576"]
+[BlackElo "2461"]
+[PlyCount "55"]
+[EventDate "2020.??.??"]
+
+1. e4 d6 2. d4 Nf6 3. Nc3 e5 4. Nf3 Nbd7 5. Bc4 Be7 6. O-O O-O 7. a4 a6 8. b3
+b6 9. Bb2 Bb7 10. Re1 h6 11. h3 c6 12. Bd3 b5 13. Ne2 Re8 14. Ng3 Bf8 15. Nf5
+Qc7 16. Qd2 Rad8 17. axb5 axb5 18. Qa5 Qxa5 19. Rxa5 Ra8 20. Rea1 Rxa5 21. Rxa5
+g6 22. Ng3 exd4 23. Ra7 Ne5 24. Nxe5 dxe5 25. Rxb7 h5 26. Nf1 Bh6 27. Ba3 Rd8
+28. Be7 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Nurgyul"]
+[Black "chipmunknau"]
 [Result "0-1"]
-[UTCDate "2023.05.31"]
-[UTCTime "01:11:25"]
-[WhiteElo "1788"]
-[BlackElo "2147"]
-[WhiteRatingDiff "-1"]
-[BlackRatingDiff "+1"]
-[Variant "Standard"]
-[TimeControl "180+2"]
+[ECO "A01"]
+[WhiteElo "2547"]
+[BlackElo "2576"]
+[PlyCount "48"]
+[EventDate "2020.??.??"]
+
+1. b3 e5 2. Bb2 Nc6 3. g3 Bc5 4. Bg2 d6 5. e3 Nge7 6. Ne2 O-O 7. d4 Bb6 8. d5
+Nb8 9. O-O f5 10. c4 Nd7 11. Nbc3 a6 12. b4 Kh8 13. Rc1 Nf6 14. Na4 Ba7 15. c5
+Bd7 16. cxd6 cxd6 17. Nac3 Rc8 18. Kh1 Qe8 19. Qd2 Qh5 20. h3 f4 21. exf4 Bxh3
+22. Kg1 Ng4 23. Bf3 Bg2 24. Bxg4 Qh1# 0-1
+
+[Event "Rated Blitz tournament 24qBif2r"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Kaliberda_Vladimir"]
+[Black "Nikame"]
+[Result "0-1"]
+[ECO "D11"]
+[WhiteElo "2372"]
+[BlackElo "2355"]
+[PlyCount "38"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. Nf3 d5 2. d4 c6 3. c4 e6 4. cxd5 exd5 5. Nc3 Bd6 6. Qc2 Nf6 7. Bg5 h6 8. Bh4
+Nbd7 9. e3 Qa5 10. Bd3 O-O 11. O-O Re8 12. a3 Qc7 13. Rac1 Qb8 14. Bg3 Bxg3 15.
+hxg3 Qd6 16. Na4 Nf8 17. Nc5 Ng6 18. b4 Ne7 19. Nb3 Ng4 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "zaqvili"]
+[Black "imdejong"]
+[Result "1-0"]
+[ECO "E00"]
+[WhiteElo "2331"]
+[BlackElo "2360"]
+[PlyCount "85"]
+[EventDate "2020.??.??"]
+
+1. d4 e6 2. c4 Bb4+ 3. Bd2 a5 4. Nc3 Nf6 5. g3 O-O 6. Bg2 d6 7. Nf3 Nc6 8. O-O
+e5 9. d5 Ne7 10. Rc1 Bf5 11. Bg5 Nd7 12. Na4 Nc5 13. a3 Nxa4 14. Qxa4 Bc5 15.
+Rfe1 Bd7 16. Qc2 f6 17. Bd2 a4 18. Bc3 c6 19. e4 Qb6 20. dxc6 bxc6 21. Red1 Ng6
+22. Be1 f5 23. exf5 Bxf5 24. Qc3 Rf7 25. Ng5 Rf6 26. Ne4 Bxe4 27. Bxe4 Bxf2+
+28. Bxf2 Rxf2 29. c5 Qxb2 30. Qxb2 Rxb2 31. Bxc6 Rc8 32. cxd6 Rd8 33. d7 Rb6
+34. Bxa4 Kf7 35. Rc8 Ke7 36. Rxd8 Kxd8 37. Rc1 Ne7 38. Rf1 Ra6 39. Rf8+ Kc7 40.
+d8=Q+ Kb7 41. Qxe7+ Kb6 42. Rb8+ Ka5 43. Qb4# 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Olaffo"]
+[Black "telodijomonstruo"]
+[Result "1-0"]
+[ECO "A01"]
+[WhiteElo "2519"]
+[BlackElo "2513"]
+[PlyCount "151"]
+[EventDate "2020.??.??"]
+
+1. b3 e5 2. Bb2 Nc6 3. e3 a6 4. Bc4 d5 5. Be2 Nf6 6. c4 d4 7. exd4 exd4 8. d3
+Bd6 9. Bf3 Bf5 10. Ne2 h5 11. h3 Qd7 12. a3 a5 13. Qc2 Kf8 14. c5 Be5 15. Nd2
+Re8 16. Nc4 g5 17. Bxc6 Qxc6 18. Nxe5 Rxe5 19. Bxd4 Rd5 20. Bxf6 Qxf6 21. O-O
+Bxd3 22. Qc3 Qxc3 23. Nxc3 Rxc5 24. Rfc1 Kg7 25. b4 axb4 26. axb4 Rc4 27. Nd5
+Rxc1+ 28. Rxc1 c6 29. Ne3 Ba6 30. Rd1 Kf6 31. Rd6+ Ke7 32. Nf5+ Ke8 33. Ng7+
+Ke7 34. Nf5+ Ke8 35. g3 h4 36. g4 Rg8 37. f3 Rg6 38. Rd4 Kf8 39. Kf2 Re6 40.
+Rd8+ Re8 41. Rd6 Re2+ 42. Kf1 Re6+ 43. Kg2 Rxd6 44. Nxd6 Ke7 45. Ne4 Ke6 46.
+Nxg5+ Kd5 47. Nxf7 Kc4 48. g5 Kxb4 49. g6 Bc4 50. Nh8 Bf7 51. gxf7 c5 52. f8=Q
+Kb3 53. Qd6 c4 54. Ng6 c3 55. Nxh4 Kc2 56. Qb6 Kc1 57. Qxb7 c2 58. Qc6 Kd1 59.
+Qxc2+ Kxc2 60. f4 Kd2 61. f5 Kc3 62. f6 Kd2 63. f7 Kd1 64. f8=Q Kc2 65. Ng6 Kd1
+66. h4 Kc2 67. h5 Kd1 68. h6 Kc1 69. h7 Kd1 70. h8=Q Kc1 71. Qhf6 Kd1 72. Q6e7
+Kc1 73. Qfd8 Kb2 74. Qec7 Ka1 75. Qdb8 Ka2 76. Qca7# 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "HoldenHc"]
+[Black "gg-gm-gmg"]
+[Result "1-0"]
+[ECO "A41"]
+[WhiteElo "2557"]
+[BlackElo "2682"]
+[PlyCount "93"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 d6 2. c3 Nd7 3. Nf3 e5 4. e4 Ngf6 5. Bd3 g6 6. O-O Bg7 7. Nbd2 O-O 8. a4
+Nh5 9. Re1 Nf4 10. Bf1 a6 11. g3 Ne6 12. Nc4 h6 13. a5 Re8 14. dxe5 Nxe5 15.
+Nfxe5 dxe5 16. Qxd8 Rxd8 17. Be3 Bd7 18. f3 f6 19. Red1 Bc6 20. b4 Kf7 21. Kf2
+Bf8 22. Be2 h5 23. h4 Rxd1 24. Rxd1 Rd8 25. Rxd8 Nxd8 26. Bd3 Bb5 27. f4 Bg7
+28. fxe5 fxe5 29. Ke2 Ke6 30. Nd2 Bxd3+ 31. Kxd3 Nf7 32. Nb3 Bf8 33. Bc5 Bd6
+34. Bxd6 cxd6 35. c4 g5 36. c5 gxh4 37. gxh4 d5 38. b5 dxe4+ 39. Ke2 Kd7 40.
+c6+ Kc7 41. cxb7 axb5 42. a6 Nd6 43. Ke3 b4 44. Nc5 Kb8 45. Nd7+ Kc7 46. b8=Q+
+Kxd7 47. Qxb4 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Schachpanda_YT"]
+[Black "Ahmed-abdelsattar"]
+[Result "0-1"]
+[ECO "E63"]
+[WhiteElo "2325"]
+[BlackElo "2371"]
+[PlyCount "88"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 Nf6 2. Nf3 g6 3. g3 Bg7 4. Bg2 O-O 5. O-O d6 6. c4 Nc6 7. Nc3 a6 8. b3
+Bd7 9. Re1 Rb8 10. Nd5 Ne8 11. e4 b5 12. cxb5 axb5 13. Bg5 h6 14. Be3 e6 15.
+Nf4 e5 16. Nd5 exd4 17. Nxd4 Ne5 18. h3 c6 19. Nc3 b4 20. Nce2 c5 21. Nc2 Bb5
+22. a4 Ba6 23. Nf4 g5 24. Nd5 Nd3 25. Re2 Bxa1 26. Qxa1 Ne5 27. f4 Bxe2 28.
+fxe5 Bd3 29. Ne1 c4 30. Nxd3 cxd3 31. Bf1 dxe5 32. Qxe5 Qd6 33. Ne7+ Kh7 34.
+Qf5+ Kg7 35. Nd5 Qxg3+ 36. Kh1 Qe1 37. Bd4+ f6 38. Ne7 Kf7 39. Bc5 Ng7 40. Qg6+
+Ke6 41. Kg1 d2 42. Kh2 Qxf1 43. Qxg7 d1=Q 44. Nf5 Qh1+ 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Evgen_88"]
+[Black "JLeon"]
+[Result "0-1"]
+[ECO "E35"]
+[WhiteElo "2554"]
+[BlackElo "2552"]
+[PlyCount "76"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 Nf6 2. c4 e6 3. Nc3 Bb4 4. Qc2 d5 5. cxd5 exd5 6. Bg5 h6 7. Bh4 c6 8. e3
+O-O 9. Bd3 Re8 10. Nge2 Bg4 11. f3 Bh5 12. Bf2 Bd6 13. g4 Bxg4 14. fxg4 Nxg4
+15. Ng3 Nxe3 16. Bxe3 Rxe3+ 17. Nce2 Bxg3+ 18. hxg3 Nd7 19. O-O-O Qg5 20. Kb1
+Rae8 21. Rhf1 Nf6 22. Rf5 Qg4 23. Rxf6 gxf6 24. Nc3 Rxg3 25. a3 Rg1 26. Rxg1
+Qxg1+ 27. Ka2 Qxd4 28. Qg2+ Kf8 29. Bc2 Qc4+ 30. Bb3 Qf4 31. Qh3 Re6 32. Na4 b6
+33. Nc3 a5 34. a4 f5 35. Qd3 Kg7 36. Ne2 Qe3 37. Qxe3 Rxe3 38. Nd4 f4 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Napo18"]
+[Black "Nice_Ice_Eyes"]
+[Result "1-0"]
+[ECO "B01"]
+[WhiteElo "2558"]
+[BlackElo "2377"]
+[PlyCount "41"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 d5 2. exd5 Qxd5 3. Nc3 Qa5 4. Bc4 c6 5. d3 Nf6 6. Bd2 Bg4 7. f3 Bh5 8. g4
+Bg6 9. Qe2 Qb6 10. f4 h5 11. f5 Bh7 12. g5 Nfd7 13. Bxf7+ Kxf7 14. g6+ Bxg6 15.
+Qe6+ Ke8 16. Qxg6+ Kd8 17. O-O-O c5 18. Nf3 Nc6 19. Ng5 Kc8 20. Ne6 Nce5 21.
+Qe8+ 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "chesslismab"]
+[Black "LordBendtner99"]
+[Result "1-0"]
+[ECO "A40"]
+[WhiteElo "2442"]
+[BlackElo "2499"]
+[PlyCount "35"]
+[EventDate "2020.??.??"]
+
+1. d4 g6 2. Nf3 f6 3. e4 Nh6 4. Nc3 Nf7 5. Bc4 Bg7 6. Bb3 e6 7. h4 O-O 8. h5 g5
+9. h6 Bxh6 10. e5 Bg7 11. exf6 Qxf6 12. Ne4 Qf5 13. Ng3 Qf6 14. c3 h6 15. Bc2
+d5 16. Qd3 Nh8 17. Qh7+ Kf7 18. Nh5 1-0
+
+[Event "Rated Blitz tournament nLsDCFvz"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "ElPeinador"]
+[Black "dukenebur"]
+[Result "1/2-1/2"]
+[ECO "A35"]
+[WhiteElo "2355"]
+[BlackElo "2358"]
+[PlyCount "22"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. c4 c5 2. Nc3 Nc6 3. Nf3 e5 4. e3 d6 5. d4 Be7 6. d5 Nb8 7. e4 Nf6 8. Be2
+Nbd7 9. O-O O-O 10. Ne1 Ne8 11. Be3 Bg5 1/2-1/2
+
+[Event "Rated Blitz tournament nLsDCFvz"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "spidernv"]
+[Black "Quepaseelquesigue"]
+[Result "1-0"]
+[ECO "A10"]
+[WhiteElo "2412"]
+[BlackElo "2362"]
+[PlyCount "59"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. c4 d6 2. g3 Nf6 3. Bg2 g6 4. Nc3 Bg7 5. d4 O-O 6. e3 c5 7. Nge2 Nc6 8. O-O
+Bd7 9. b3 a6 10. Bb2 Rb8 11. a4 cxd4 12. exd4 Qc8 13. Re1 Bh3 14. Bh1 Re8 15.
+Nf4 Bg4 16. Qd2 e5 17. dxe5 Nxe5 18. Nfd5 Bf3 19. Nxf6+ Bxf6 20. Nd5 Bxd5 21.
+Bxd5 b5 22. axb5 axb5 23. Ra7 Re7 24. Rxe7 Bxe7 25. Bxe5 dxe5 26. Rxe5 Bf6 27.
+Re4 Qh3 28. Qf4 Rb6 29. Qc7 Ra6 30. Qxf7+ 1-0
+
+[Event "Rated Blitz tournament hM7PUvgg"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "vangulio"]
+[Black "GlennTipton"]
+[Result "0-1"]
+[ECO "C91"]
+[WhiteElo "2437"]
+[BlackElo "2445"]
+[PlyCount "54"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3
+O-O 9. d4 Bg4 10. Be3 exd4 11. cxd4 Na5 12. Bc2 c5 13. b3 Rc8 14. Nbd2 Nc6 15.
+d5 Ne5 16. h3 Nxf3+ 17. Nxf3 Bh5 18. a4 Nd7 19. axb5 axb5 20. g4 Bg6 21. Nd2
+Bf6 22. Ra6 Nb8 23. Ra2 h5 24. f4 hxg4 25. hxg4 Bc3 26. Bf2 Qf6 27. g5 Qxf4 0-1
+
+[Event "Rated Blitz tournament hM7PUvgg"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Club-Jaque-al-Rey"]
+[Black "emmacristal"]
+[Result "1-0"]
+[ECO "B40"]
+[WhiteElo "2539"]
+[BlackElo "2331"]
+[PlyCount "71"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 c5 2. Nf3 e6 3. c4 d5 4. Nc3 d4 5. Ne2 Nc6 6. d3 Bd6 7. g3 h5 8. h4 Nf6
+9. Bh3 Ng4 10. Bf4 Qc7 11. Bxd6 Qxd6 12. Nf4 Nce5 13. Nxh5 Rxh5 14. Nxe5 Nxe5
+15. Qxh5 Nxd3+ 16. Kf1 Nxb2 17. e5 Qc6 18. Bg2 Qa6 19. Kg1 Nxc4 20. Qh8+ Ke7
+21. Qxg7 Bd7 22. Qf6+ Ke8 23. Qh8+ Ke7 24. Qxa8 Nxe5 25. Qxb7 Qd6 26. Qxa7 d3
+27. Rd1 c4 28. f4 Ng4 29. Bf3 Nf6 30. h5 c3 31. Qe3 c2 32. Rxd3 Qxd3 33. Qxd3
+c1=Q+ 34. Kg2 Bc6 35. Rxc1 Bxf3+ 36. Kxf3 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Elhlwagy11"]
+[Black "Mondesespoir2700"]
+[Result "1/2-1/2"]
+[ECO "C13"]
+[WhiteElo "2309"]
+[BlackElo "2425"]
+[PlyCount "126"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 d5 2. Nc3 e6 3. e4 Nf6 4. Bg5 Be7 5. Bxf6 Bxf6 6. Nf3 O-O 7. Bd3 b6 8. h4
+c5 9. e5 Be7 10. dxc5 bxc5 11. Ng5 h6 12. Qh5 Bxg5 13. hxg5 Qxg5 14. Qxg5 hxg5
+15. Bh7+ Kh8 16. Nb5 Nc6 17. Nd6 Bd7 18. O-O-O Nxe5 19. Rh3 g6 20. Bxg6+ Kg7
+21. Bd3 Rh8 22. Rg3 Nxd3+ 23. Rdxd3 f6 24. f4 Rh5 25. f5 c4 26. Nxc4 Rh1+ 27.
+Kd2 Rc8 28. fxe6 Bxe6 29. Ne3 Rd8 30. c4 d4 31. Nc2 Bxc4 32. Rxd4 Rxd4+ 33.
+Nxd4 Bxa2 34. Ra3 Bd5 35. Rxa7+ Kg6 36. g4 Rg1 37. Nf5 Bf7 38. Ne3 Be6 39. Ra4
+Rh1 40. b4 Rg1 41. b5 Rb1 42. Ra6 Bc8 43. Rb6 Rb2+ 44. Kc3 Rf2 45. Rb8 Bd7 46.
+b6 Rf3 47. Kd4 Rf4+ 48. Kd5 Bxg4 49. b7 Bf3+ 50. Kd6 Rb4 51. Rg8+ Kf7 52. b8=Q
+Rxb8 53. Rxb8 Kg6 54. Ke6 Kh5 55. Kxf6 Kh4 56. Rg8 g4 57. Kf5 g3 58. Kf4 Bh5
+59. Rh8 g2 60. Nxg2+ Kh3 61. Rxh5+ Kxg2 62. Re5 Kf2 63. Re2+ Kxe2 1/2-1/2
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Frogkiller"]
+[Black "Karabakh-Azerbaijan"]
+[Result "1-0"]
+[ECO "D78"]
+[WhiteElo "2371"]
+[BlackElo "2451"]
+[PlyCount "93"]
+[EventDate "2020.??.??"]
+
+1. g3 Nf6 2. Bg2 g6 3. Nf3 Bg7 4. O-O O-O 5. d4 d5 6. c4 c6 7. Nc3 dxc4 8. Ne5
+Nbd7 9. Nxc4 Nb6 10. Ne5 Nfd7 11. Nf3 e5 12. d5 Nxd5 13. Nxd5 cxd5 14. Qxd5 Nb6
+15. Qa5 e4 16. Ng5 f5 17. Be3 h6 18. Rfd1 Qf6 19. Nh3 Qxb2 20. Rab1 Qf6 21. Nf4
+Be6 22. Nxe6 Qxe6 23. Bxb6 axb6 24. Qxb6 Qxa2 25. Qxg6 Qxe2 26. Bf1 Qg4 27.
+Qxg4 fxg4 28. Rxb7 Rad8 29. Bc4+ Kh8 30. Rxd8 Rxd8 31. Re7 Rd2 32. Rxe4 Bd4 33.
+Rf4 Kg7 34. Be6 h5 35. Bf7 Kh6 36. Rf5 h4 37. gxh4 Rd1+ 38. Kg2 Rd2 39. Bh5 Kg7
+40. Bxg4 Kh8 41. h5 Kh7 42. h6 Kg8 43. h4 Kh7 44. Rf6 Kh8 45. Rf7 Kg8 46. Bh5
+Kh8 47. h7 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "sutcunuri"]
+[Black "ajedrez2021"]
+[Result "0-1"]
+[ECO "B06"]
+[WhiteElo "2533"]
+[BlackElo "2579"]
+[PlyCount "49"]
+[EventDate "2020.??.??"]
+
+1. e4 g6 2. Nf3 Bg7 3. Bc4 c5 4. O-O Nc6 5. Re1 d6 6. h3 Nf6 7. c3 O-O 8. d4
+cxd4 9. cxd4 e5 10. Nc3 exd4 11. Nxd4 Nxd4 12. Qxd4 Be6 13. Qd3 Re8 14. Bf4 Rc8
+15. Bxe6 Rxe6 16. Rad1 Qa5 17. Bxd6 Rd8 18. e5 Ne8 19. Nd5 Nxd6 20. exd6 Rxe1+
+21. Rxe1 Qxe1+ 22. Kh2 Be5+ 23. f4 Bxd6 24. Nf6+ Kg7 25. Qc3 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "MiroMiljkovic"]
+[Black "Ogrilla"]
+[Result "0-1"]
+[ECO "A01"]
+[WhiteElo "2608"]
+[BlackElo "2824"]
+[PlyCount "122"]
+[EventDate "2020.??.??"]
+
+1. b3 Nf6 2. Bb2 g6 3. Nf3 Bg7 4. e4 O-O 5. e5 Ne8 6. d4 d6 7. Be2 dxe5 8. dxe5
+Qxd1+ 9. Bxd1 Nc6 10. O-O Bg4 11. Re1 Rd8 12. h3 Bf5 13. Na3 Nb4 14. g4 Be6 15.
+Be2 c6 16. Rad1 Nc7 17. c3 Nxa2 18. Rd3 Bxb3 19. c4 Rxd3 20. Bxd3 Rd8 21. Bb1
+Nb4 22. Nd4 Ba4 23. c5 Ncd5 24. e6 Bxd4 25. exf7+ Kxf7 26. Bxd4 Nf4 27. Be5
+Nbd3 28. Re3 Nxe5 29. Rxe5 Rd3 30. Bxd3 Nxd3 31. Re3 Nxc5 32. Nc4 b5 33. Ne5+
+Kf6 34. Nxc6 e5 35. Nb4 Ke6 36. f4 e4 37. Nc6 Kd5 38. Nxa7 b4 39. f5 gxf5 40.
+gxf5 b3 41. f6 b2 42. Re1 Bc2 43. f7 Ne6 44. Nb5 Nf8 45. Nc3+ Kd4 46. Nb1 e3
+47. Na3 Be4 48. Kh2 Kd3 49. Kg3 Kd2 50. Rg1 h5 51. h4 e2 52. Kf2 Ne6 53. Re1
+Bd3 54. Nc4+ Bxc4 55. f8=Q Nxf8 56. Rg1 Ne6 57. Rg6 Nc5 58. Re6 Nd3+ 59. Kf3
+e1=Q 60. Rxe1 Nxe1+ 61. Kf4 Nd3+ 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "LouiVos"]
+[Black "zpxocivubyntmraeswdq"]
+[Result "1-0"]
+[ECO "E16"]
+[WhiteElo "2743"]
+[BlackElo "2685"]
+[PlyCount "103"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 Nf6 2. c4 e6 3. Nf3 Bb4+ 4. Bd2 a5 5. g3 b6 6. Bg2 Bb7 7. O-O O-O 8. Bf4
+Be7 9. Qc2 d5 10. Rd1 Na6 11. a3 c5 12. Nc3 Rc8 13. dxc5 Nxc5 14. Ne5 Qe8 15.
+cxd5 Nxd5 16. Nxd5 exd5 17. Bh3 Ne6 18. Qd2 Rd8 19. Rac1 Bc5 20. Nd3 d4 21. b4
+axb4 22. axb4 Nxf4 23. Nxf4 Be7 24. Bg2 Bxg2 25. Nxg2 Qb5 26. Rb1 Rfe8 27. Ne1
+Bg5 28. Qd3 Qd5 29. Nc2 Bf6 30. e3 h5 31. exd4 h4 32. Ne3 Qg5 33. d5 hxg3 34.
+hxg3 Re5 35. d6 Re6 36. d7 Re7 37. Nd5 Rexd7 38. Nxf6+ Qxf6 39. Qxd7 Rxd7 40.
+Rxd7 g6 41. Rc1 Qb2 42. Rc8+ Kg7 43. Rcc7 Qb1+ 44. Kh2 Qf5 45. Rxf7+ Qxf7 46.
+Rxf7+ Kxf7 47. Kh3 Ke6 48. Kg4 Kd5 49. Kg5 Kc4 50. f4 Kxb4 51. Kxg6 b5 52. f5
+1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "FerociousLion98999"]
+[Black "Maxterlopez"]
+[Result "0-1"]
+[ECO "C70"]
+[WhiteElo "2614"]
+[BlackElo "2623"]
+[PlyCount "62"]
+[EventDate "2020.??.??"]
+
+1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nge7 5. O-O g6 6. c3 Bg7 7. d4 exd4 8.
+cxd4 b5 9. Bc2 O-O 10. Nc3 d6 11. h3 Bb7 12. Be3 Na5 13. Rc1 Nc4 14. b3 Nxe3
+15. fxe3 c5 16. d5 Bxc3 17. Qe2 Bg7 18. Qf2 h6 19. Qg3 Kh7 20. Nh2 Ng8 21. Ng4
+Nf6 22. e5 Nxg4 23. Qxg4 Qg5 24. Qd7 Bc8 25. Qxd6 Qxe5 26. Qxc5 Bd7 27. e4 Rac8
+28. Qa7 Qd4+ 29. Qxd4 Bxd4+ 30. Kh1 Be3 31. Rce1 Bd2 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "RigelStar"]
+[Black "FinalCut"]
+[Result "0-1"]
+[ECO "A43"]
+[WhiteElo "2421"]
+[BlackElo "2437"]
+[PlyCount "128"]
+[EventDate "2020.??.??"]
+
+1. d4 c5 2. Nf3 cxd4 3. Qxd4 Nc6 4. Qd1 g6 5. b3 Bg7 6. c3 Nf6 7. Bb2 d5 8. e3
+O-O 9. Be2 Bg4 10. O-O b6 11. h3 Bf5 12. Na3 Rc8 13. Ba6 Rc7 14. Nb5 Rd7 15.
+Nfd4 Nb8 16. Nxf5 gxf5 17. Nd4 Nxa6 18. Nxf5 Bh8 19. Qf3 Qb8 20. c4 dxc4 21.
+Rad1 Rfd8 22. Rxd7 Rxd7 23. bxc4 Bg7 24. Rd1 Rxd1+ 25. Qxd1 Nc5 26. Nxe7+ Kf8
+27. Nf5 Nce4 28. f3 Ng3 29. Nxg7 Kxg7 30. Kf2 Nf5 31. g4 Qh2+ 32. Ke1 Qxb2 33.
+gxf5 Qc3+ 34. Qd2 Qxd2+ 35. Kxd2 Nd7 36. e4 Kf6 37. Kc3 Ke5 38. Kd3 Kf4 39. Ke2
+f6 40. h4 h5 41. c5 Nxc5 42. Kf2 Nd7 43. e5 Nxe5 44. Ke2 Nxf3 45. a4 Nxh4 46.
+Kd3 Nxf5 47. Kc4 h4 48. Kb5 h3 49. a5 h2 50. axb6 axb6 51. Ka6 h1=Q 52. Kxb6
+Qe4 53. Kc7 Kg5 54. Kd8 Nh4 55. Kc7 f5 56. Kd7 f4 57. Kc7 f3 58. Kd7 f2 59. Kd8
+f1=Q 60. Kd7 Qfe2 61. Kc7 Q2d3 62. Kb8 Qec4 63. Ka7 Qdb3 64. Ka8 Qca4# 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Dimitriy1975"]
+[Black "mixo23"]
+[Result "0-1"]
+[ECO "A43"]
+[WhiteElo "2386"]
+[BlackElo "2418"]
+[PlyCount "46"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 c5 2. d5 Nf6 3. c4 g6 4. Nc3 Bg7 5. e4 O-O 6. Nf3 e6 7. Bd3 exd5 8. cxd5
+b5 9. Nxb5 Nxe4 10. Bxe4 Qa5+ 11. Nc3 Ba6 12. Bd2 Re8 13. Ng5 h6 14. Qf3 hxg5
+15. O-O-O d6 16. Rhe1 Nd7 17. Bxg5 Rab8 18. Bb1 Ne5 19. Qg3 Nc4 20. Rxe8+ Rxe8
+21. Bd3 Nxb2 22. Bxa6 Nxd1 23. Nxd1 Qxa6 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "exchangedistrict"]
+[Black "sleepylock"]
+[Result "0-1"]
+[ECO "B07"]
+[WhiteElo "2490"]
+[BlackElo "2496"]
+[PlyCount "62"]
+[EventDate "2020.??.??"]
+
+1. e4 g6 2. d4 d6 3. Nc3 c6 4. Be3 Bg7 5. f3 b5 6. Qd2 Nd7 7. g4 Nb6 8. Nce2
+Nc4 9. Qc1 Nxe3 10. Qxe3 Qc7 11. Ng3 Nf6 12. O-O-O h5 13. g5 Nd7 14. f4 Nb6 15.
+Nf3 Rb8 16. Kb1 Nc4 17. Bxc4 bxc4 18. c3 Qb6 19. Rd2 Bg4 20. h3 Bxf3 21. Qxf3
+Qa5 22. f5 O-O 23. f6 exf6 24. gxf6 Bh6 25. Rc2 Rb5 26. Ka1 Rfb8 27. Rhh2 Qa4
+28. d5 Ra5 29. a3 Qb3 30. Qe2 Rxa3+ 31. bxa3 Qb1# 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Valema"]
+[Black "Mjolnir1980"]
+[Result "0-1"]
+[ECO "B00"]
+[WhiteElo "2302"]
+[BlackElo "2317"]
+[PlyCount "114"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 b6 2. Nc3 Bb7 3. Bc4 e6 4. Qf3 f5 5. d3 Nf6 6. Bg5 Bb4 7. Nge2 fxe4 8.
+dxe4 O-O 9. O-O-O Qe8 10. Bxf6 Rxf6 11. Qg3 Na6 12. f4 Nc5 13. e5 Rg6 14. Qe3
+Rxg2 15. Rhg1 Qg6 16. Rxg2 Qxg2 17. a3 Bxc3 18. Nxc3 Qf3 19. Qd2 Bc6 20. Rf1
+Qg2 21. Rf2 Qg1+ 22. Bf1 Bg2 23. Rxg2 Qxf1+ 24. Nd1 Ne4 25. Qe2 Qxe2 26. Rxe2
+Nc5 27. b4 Nb7 28. Rd2 d5 29. Ne3 c5 30. f5 d4 31. Nc4 exf5 32. Rf2 g6 33. b5
+Re8 34. Re2 Kf7 35. a4 Ke6 36. Kd2 Kd5 37. Kd3 Na5 38. Nxa5 bxa5 39. e6 Rxe6
+40. Rg2 c4+ 41. Kd2 c3+ 42. Kd1 Kc4 43. h4 Re4 44. h5 Rg4 45. Rxg4 fxg4 46.
+hxg6 hxg6 47. Ke2 Kb4 48. Kd3 g3 49. Kxd4 g2 50. Kd5 g1=Q 51. b6 Qxb6 52. Ke4
+Kxa4 53. Kd3 Ka3 54. Kxc3 Qb4+ 55. Kd3 Kb2 56. c3 Qb3 57. Ke4 Qxc3 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Checkmater47"]
+[Black "RyanX4FleteChavale"]
+[Result "1-0"]
+[ECO "B10"]
+[WhiteElo "2329"]
+[BlackElo "2357"]
+[PlyCount "129"]
+[EventDate "2020.??.??"]
+
+1. e4 c6 2. Nf3 d5 3. exd5 Bg4 4. c4 cxd5 5. cxd5 Nf6 6. Nc3 Nbd7 7. Be2 Bxf3
+8. Bxf3 e6 9. dxe6 fxe6 10. O-O Bd6 11. Re1 Kf8 12. Rxe6 h5 13. Rxd6 Qc7 14.
+Rxf6+ Nxf6 15. Nb5 Qc5 16. Nc3 Ng4 17. Bxg4 hxg4 18. b3 Re8 19. a4 Kg8 20. Ba3
+Qh5 21. h4 gxh3 22. g3 h2+ 23. Kh1 Qxd1+ 24. Rxd1 Rh6 25. Nd5 Rhe6 26. Ne3 a6
+27. Kxh2 b5 28. Kg2 bxa4 29. bxa4 Rc8 30. Bb2 Rb8 31. Bc3 Rb3 32. Nc4 Rb8 33.
+Nd6 Ree8 34. Nxe8 Rd8 35. d4 Rxe8 36. Rd3 Rc8 37. Rf3 Rd8 38. Bd2 g6 39. Bf4
+Kg7 40. Be5+ Kh6 41. Bf6 g5 42. Bxd8 Kg6 43. Rf4 a5 44. Rg4 Kf5 45. d5 Kxg4 46.
+d6 Kf5 47. d7 Ke6 48. Bc7 Kxd7 49. Bb6 Ke6 50. Bxa5 Kf5 51. Bb6 Kg6 52. a5 Kf5
+53. a6 g4 54. a7 Kg6 55. a8=Q Kf5 56. Qa7 Kg6 57. Qb7 Kf5 58. Qc7 Kg6 59. Qc6+
+Kf5 60. Qd6 Kg5 61. Qd5+ Kh6 62. Bd4 Kh7 63. Qe5 Kg6 64. Qf6+ Kh7 65. Qg7# 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "LordBendtner99"]
+[Black "Sensei24"]
+[Result "0-1"]
 [ECO "A00"]
-[Termination "Normal"]
+[WhiteElo "2492"]
+[BlackElo "2445"]
+[PlyCount "132"]
+[EventDate "2020.??.??"]
 
-1. b4 e6 2. Bb2 Nf6 3. a3 d5 4. e3 Bd6 5. c4 b6 6. cxd5 exd5 7. Nf3 O-O 8. Be2 Bb7 9. O-O Nbd7 10. d4 Ne4 11. Nbd2 Qe7 12. Nxe4 dxe4 13. Nd2 f5 14. Nc4 Nf6 15. Nxd6 cxd6 16. f3 Rac8 17. fxe4 Qxe4 18. Bf3 Qxe3+ 19. Kh1 Bxf3 20. Qxf3 Qxf3 21. Rxf3 Nd5 22. h3 Rc2 23. Bc1 Re8 24. Bg5 h6 25. Bh4 Re4 26. Bf2 f4 27. Re1 Rxe1+ 28. Bxe1 Rc1 29. Rf1 Ne3 30. Rg1 Nc2 31. Bd2 Rxg1+ 32. Kxg1 Nxd4 33. Bxf4 Ne2+ 0-1
+1. g3 g6 2. f3 Bg7 3. Nh3 c5 4. Nf2 d5 5. Bg2 Nc6 6. O-O Nf6 7. d3 O-O 8. e4 e5
+9. Nc3 Re8 10. h3 Be6 11. a4 Rc8 12. Bd2 a6 13. b3 Nd4 14. f4 exf4 15. gxf4
+dxe4 16. Nfxe4 Nxe4 17. Nxe4 Bd5 18. c3 Nf5 19. Qc2 b6 20. Rae1 Nh4 21. Be3
+Nxg2 22. Qxg2 f5 23. Bd2 fxe4 24. dxe4 Bxb3 25. a5 Bc4 26. Rf2 bxa5 27. f5 Bf7
+28. Kh1 a4 29. Rg1 a3 30. Bg5 Qd7 31. h4 a2 32. h5 Rc6 33. hxg6 hxg6 34. f6 Bh8
+35. Rd2 Qe6 36. Qh2 Qxe4+ 37. Rdg2 Bd5 38. c4 Bxc4 39. f7+ Kxf7 40. Qh7+ Bg7
+41. Rf1+ Bxf1 42. Qh2 Bxg2+ 43. Qxg2 Qxg2+ 44. Kxg2 c4 45. Be3 c3 46. Bf2 a1=Q
+47. Kg3 Qb2 48. Be3 c2 49. Bf4 c1=Q 50. Kg4 Qb3 51. Bg3 Qcc3 52. Kh3 Qcc4 53.
+Kh2 Qbb4 54. Kg1 Qe4 55. Kf1 Rc5 56. Bf2 Qbc4+ 57. Kg1 Qcd4 58. Kh2 Rc3 59. Bg3
+Qdd3 60. Kh3 Qee2 61. Kh4 Qdd2 62. Bf4 Qee3 63. Bg3 Qd5 64. Kh3 Bf6 65. Kh2 g5
+66. Kh3 Qxg3# 0-1
 
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "chipmunknau"]
+[Black "hungzhao"]
+[Result "0-1"]
+[ECO "A07"]
+[WhiteElo "2582"]
+[BlackElo "2620"]
+[PlyCount "124"]
+[EventDate "2020.??.??"]
+
+1. Nf3 d5 2. g3 Nf6 3. Bg2 c6 4. O-O Bg4 5. d3 Nbd7 6. Nc3 e5 7. e4 dxe4 8.
+dxe4 Bc5 9. h3 Bh5 10. Qe2 O-O 11. Be3 Bxe3 12. Qxe3 Qb6 13. Qxb6 axb6 14. g4
+Bg6 15. Nh4 Nc5 16. Nxg6 hxg6 17. Rad1 Rfd8 18. a3 Ne6 19. Kh2 g5 20. Kg3 Nf4
+21. Rfe1 b5 22. Bf1 g6 23. Bd3 Nd7 24. Ne2 Nc5 25. Nc1 Nce6 26. c3 Rd6 27. Bf1
+Rad8 28. Rxd6 Rxd6 29. Kf3 Rd2 30. b4 Rc2 31. Ne2 Nxe2 32. Rxe2 Rxc3+ 33. Re3
+Nd4+ 34. Kg2 Rxe3 35. fxe3 Nc2 36. Bd3 Nxa3 37. Kf2 Kf8 38. Ke2 Ke7 39. Kd2 b6
+40. Kc3 c5 41. Be2 Kd6 42. Bd3 Kc6 43. Be2 cxb4+ 44. Kxb4 Nc2+ 45. Kc3 Nxe3 46.
+Bd3 Kc5 47. Kd2 Ng2 48. Bc2 Nf4 49. Bb3 f6 50. Bf7 Kd4 51. Kc2 Kxe4 52. Kb3 Kf3
+53. Kb4 Nxh3 54. Kxb5 Nf4 55. Kxb6 e4 56. Kc6 e3 57. Kd6 e2 58. Bc4 e1=Q 59.
+Kd7 Qd2+ 60. Bd5+ Kxg4 61. Ke7 Kg3 62. Kxf6 Qd4+ 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "chesslismab"]
+[Black "vassiukov"]
+[Result "1-0"]
+[ECO "A90"]
+[WhiteElo "2448"]
+[BlackElo "2378"]
+[PlyCount "97"]
+[EventDate "2020.??.??"]
+
+1. d4 e6 2. Nf3 f5 3. g3 Nf6 4. Bg2 d5 5. O-O Bd6 6. c4 c6 7. Nc3 Nbd7 8. Bf4
+Bxf4 9. gxf4 O-O 10. e3 Ne4 11. Qd3 Rf6 12. cxd5 exd5 13. Ne5 Rh6 14. f3 Nd6
+15. Rf2 Qh4 16. Bf1 Nf6 17. Rg2 Bd7 18. b4 Be8 19. b5 Rc8 20. bxc6 bxc6 21. Qd2
+Bh5 22. Qf2 Qxf2+ 23. Kxf2 Rb8 24. Rb1 Rxb1 25. Nxb1 Be8 26. Nc3 Nf7 27. Na4
+Nxe5 28. fxe5 Nd7 29. f4 Re6 30. Ba6 Re7 31. Bc8 Nb6 32. Nxb6 axb6 33. Bxf5 Ra7
+34. Kg3 Ra3 35. Rb2 Rxe3+ 36. Kf2 Ra3 37. Rxb6 Rxa2+ 38. Kg3 Kf8 39. Rb8 Ke7
+40. Rb7+ Kf8 41. e6 g6 42. Bb1 Rd2 43. Kh4 Rxd4 44. Kg5 h6+ 45. Kxh6 Rxf4 46.
+Rg7 Rh4+ 47. Kg5 Rh5+ 48. Kf6 Rxh2 49. e7# 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "DoctorFromGallifrey"]
+[Black "Nurgyul"]
+[Result "0-1"]
+[ECO "B10"]
+[WhiteElo "2566"]
+[BlackElo "2542"]
+[PlyCount "32"]
+[EventDate "2020.??.??"]
+
+1. e4 c6 2. d3 d5 3. Nd2 e5 4. Ngf3 Bd6 5. g3 Nf6 6. Bg2 O-O 7. O-O Nbd7 8. a4
+Re8 9. a5 a6 10. c3 Nc5 11. Qe2 dxe4 12. Nxe4 Nfxe4 13. dxe4 Be6 14. Ng5 Bb3
+15. Qh5 h6 16. Qxf7+ Bxf7 0-1
+
+[Event "Rated Bullet tournament GAdGz1co"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "RaylessStarfish"]
+[Black "BlitzTherapy"]
+[Result "0-1"]
+[ECO "A11"]
+[WhiteElo "2381"]
+[BlackElo "2768"]
+[PlyCount "58"]
+[EventDate "2020.??.??"]
+
+1. c4 c6 2. g3 d5 3. cxd5 cxd5 4. Bg2 e5 5. Nf3 Nc6 6. O-O Nf6 7. d4 e4 8. Ne5
+Bd6 9. f4 Bf5 10. Nc3 h5 11. h3 Qc8 12. Kh2 Rb8 13. e3 O-O 14. Qb3 Qe6 15. Bd2
+Rfc8 16. Rf2 b5 17. Rg1 Na5 18. Qd1 Nc4 19. Bc1 b4 20. Na4 Qe7 21. Bf1 Nb6 22.
+Nxb6 Rxb6 23. g4 hxg4 24. hxg4 Nxg4+ 25. Nxg4 Qh4+ 26. Bh3 b3 27. Rfg2 bxa2 28.
+Bd2 Rxb2 29. Ne5 Qxh3# 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "taras05"]
+[Black "G0DZILLA"]
+[Result "1-0"]
+[ECO "B19"]
+[WhiteElo "2461"]
+[BlackElo "2650"]
+[PlyCount "99"]
+[EventDate "2020.??.??"]
+
+1. e4 c6 2. d4 d5 3. Nd2 dxe4 4. Nxe4 Bf5 5. Ng3 Bg6 6. Nf3 Nd7 7. h4 h6 8. h5
+Bh7 9. Bd3 Bxd3 10. Qxd3 e6 11. Bd2 Ngf6 12. O-O-O Be7 13. Ne4 Nxe4 14. Qxe4
+Nf6 15. Qe2 Qd5 16. c4 Qe4 17. Qxe4 Nxe4 18. Be3 Nf6 19. Nd2 Ng4 20. Kc2 O-O
+21. Rhe1 Rfd8 22. Kd3 Rd7 23. f3 Nxe3 24. Kxe3 Bg5+ 25. Ke4 Rad8 26. Nb3 b6 27.
+f4 Bh4 28. Re3 f5+ 29. Kf3 Kf7 30. Red3 Bf6 31. Ke3 a5 32. a4 Be7 33. Nc1 Bb4
+34. Ne2 Kf6 35. b3 Kf7 36. Kf3 Kf6 37. g4 Kf7 38. g5 Be7 39. g6+ Kf6 40. Nc3
+Bb4 41. Ne2 Be7 42. d5 Bb4 43. Nd4 exd5 44. Nxc6 d4 45. Nxd4 Bc5 46. Ke3 Rxd4
+47. Rxd4 Rxd4 48. Rxd4 Bxd4+ 49. Kxd4 Ke6 50. c5 1-0
+
+[Event "Rated Bullet tournament Ty5yUoqy"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "vervitu"]
+[Black "Superman89"]
+[Result "0-1"]
+[ECO "B20"]
+[WhiteElo "2328"]
+[BlackElo "2327"]
+[PlyCount "96"]
+[EventDate "2020.??.??"]
+
+1. e4 c5 2. b4 cxb4 3. a3 bxa3 4. Bxa3 d6 5. d4 Nc6 6. c3 g6 7. Bd3 Bg7 8. Ne2
+Nf6 9. O-O O-O 10. d5 Ne5 11. f4 Nxd3 12. Qxd3 b6 13. Nd2 a5 14. c4 Ba6 15. Bb2
+Nd7 16. Bxg7 Kxg7 17. Qd4+ Kg8 18. Nb3 Qc7 19. Rac1 Nc5 20. Nxc5 Qxc5 21. Qxc5
+bxc5 22. Nc3 Bxc4 23. Rfe1 a4 24. Ra1 Bb3 25. Nb5 c4 26. Nc3 e6 27. e5 dxe5 28.
+fxe5 exd5 29. Nxd5 Rfe8 30. Nf6+ Kg7 31. Nxe8+ Rxe8 32. Re3 Re6 33. Re4 f6 34.
+Rae1 Rxe5 35. Rxe5 fxe5 36. Rxe5 a3 37. Ra5 a2 38. Kf2 c3 39. Ke3 c2 40. Kd2
+Kf6 41. Kc1 Be6 42. Kb2 g5 43. Kxc2 h6 44. Kd2 Bf5 45. Ra3 Be6 46. Rf3+ Kg6 47.
+Ra3 a1=Q 48. Rxa1 Bf5 0-1
+
+[Event "Rated Blitz tournament hM7PUvgg"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "juancruzariasTDF"]
+[Black "Tenessy"]
+[Result "1-0"]
+[ECO "B23"]
+[WhiteElo "2431"]
+[BlackElo "2367"]
+[PlyCount "57"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 c5 2. Nc3 e6 3. g3 Nc6 4. Bg2 g6 5. d3 Bg7 6. Be3 b6 7. Qd2 h6 8. Nge2
+Nge7 9. d4 cxd4 10. Nxd4 Nxd4 11. Bxd4 O-O 12. Bxg7 Kxg7 13. O-O-O d5 14. exd5
+Bb7 15. Qd4+ Kg8 16. Ne4 Nxd5 17. c4 Rc8 18. Kb1 f5 19. cxd5 Bxd5 20. Nf6+ Qxf6
+21. Bxd5 exd5 22. Qxd5+ Kg7 23. Rhe1 Rc7 24. Re6 Qf7 25. Qe5+ Kg8 26. Rdd6 Re7
+27. Rxg6+ Qxg6 28. Rxg6+ Kf7 29. Rg7+ 1-0
+
+[Event "Rated Blitz tournament hM7PUvgg"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "matussalen"]
+[Black "lama17"]
+[Result "0-1"]
+[ECO "A41"]
+[WhiteElo "2330"]
+[BlackElo "2309"]
+[PlyCount "74"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 g6 2. c4 Bg7 3. Nc3 d6 4. e4 Nd7 5. f4 e5 6. Nf3 Ne7 7. Be2 Nc6 8. Be3
+O-O 9. fxe5 dxe5 10. d5 Ne7 11. O-O h6 12. Qd2 Kh7 13. c5 f5 14. d6 cxd6 15.
+cxd6 Nc6 16. Rad1 f4 17. Bf2 g5 18. h3 Nf6 19. Bb5 Nd7 20. Nd5 a6 21. Bxc6 bxc6
+22. Nc7 Rb8 23. Ne6 Qf6 24. Nxf8+ Bxf8 25. b3 h5 26. Nh2 Qg6 27. Qe2 Nf6 28.
+Bc5 Bd7 29. Qb2 Re8 30. Rfe1 g4 31. hxg4 hxg4 32. Nf1 g3 33. Rd3 Qh5 34. Red1
+Bg7 35. Nxg3 fxg3 36. Rxg3 Qxd1+ 37. Kh2 Ng4+ 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "estocastico"]
+[Black "badbadger95"]
+[Result "0-1"]
+[ECO "C88"]
+[WhiteElo "2579"]
+[BlackElo "2610"]
+[PlyCount "44"]
+[EventDate "2020.??.??"]
+
+1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 O-O 8. a4
+d5 9. axb5 dxe4 10. bxc6 exf3 11. Qxf3 e4 12. Qg3 Bd6 13. Qh4 Bxh2+ 14. Qxh2
+Ng4 15. Qg3 Qg5 16. d3 Qh5 17. Rxe4 Bf5 18. Rf4 Rae8 19. Bd2 Re2 20. Ra5 Rfe8
+21. f3 Qh2+ 22. Kf1 Qh1# 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "alirezafirulais"]
+[Black "Phoenix-20"]
+[Result "1-0"]
+[ECO "D19"]
+[WhiteElo "2347"]
+[BlackElo "2493"]
+[PlyCount "61"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 d5 2. Nf3 Nf6 3. c4 c6 4. Nc3 dxc4 5. a4 Bf5 6. e3 e6 7. Bxc4 Bb4 8. O-O
+Nbd7 9. Qe2 Bg6 10. Rd1 O-O 11. h3 h6 12. Ne5 Nxe5 13. dxe5 Nd7 14. Bd3 Bxd3
+15. Rxd3 Qc7 16. f4 Nc5 17. Rd1 Rfd8 18. Bd2 Rd7 19. Be1 Rad8 20. Kh2 a5 21.
+Rxd7 Rxd7 22. Qc2 Qd8 23. Rd1 Bxc3 24. Rxd7 Qxd7 25. Bxc3 Qd3 26. Qxd3 Nxd3 27.
+Kg3 Kf8 28. Kf3 Nc5 29. Bxa5 Nxa4 30. b3 Nb2 31. Ke2 1-0
+
+[Event "Rated Rapid game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Ahmet19114"]
+[Black "Kameelperd"]
+[Result "0-1"]
+[ECO "C55"]
+[WhiteElo "2317"]
+[BlackElo "2362"]
+[PlyCount "104"]
+[EventDate "2020.??.??"]
+[EventType "rapid"]
+
+1. e4 e5 2. Nf3 Nc6 3. Bc4 Nf6 4. O-O Bc5 5. d3 d6 6. Bg5 h6 7. Bxf6 Qxf6 8.
+Nc3 Qd8 9. Nd5 O-O 10. c3 a5 11. d4 Ba7 12. h3 Re8 13. Re1 Be6 14. a3 a4 15.
+Ba2 Kh8 16. Qxa4 Bxd4 17. Qb5 Bxd5 18. Bxd5 Bb6 19. Bxc6 bxc6 20. Qxc6 Re6 21.
+b4 Rf6 22. a4 Ra6 23. Kf1 Rxf3 24. gxf3 Qh4 25. Ra2 Kh7 26. a5 Qxh3+ 27. Ke2
+Bxf2 28. Qxa6 Bh4 29. Qc4 Qg2+ 30. Kd1 Qxf3+ 31. Ree2 Bg5 32. a6 Qf1+ 33. Kc2
+Qc1+ 34. Kb3 Qd1+ 35. Rec2 c6 36. a7 d5 37. exd5 cxd5 38. Qc5 Qb1+ 39. Rab2 Qa1
+40. Qd4 exd4 41. a8=Q Qxa8 42. cxd4 Qd8 43. Rc8 Qd7 44. Rc7 Qe6 45. Rxf7 Qxf7
+46. Rc2 Qf6 47. Rc3 Qxd4 48. Rc4 Qxc4+ 49. Ka4 Qb5+ 50. Ka3 d4 51. Kb3 d3 52.
+Kc3 d2 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Glig"]
+[Black "Al_Shima"]
+[Result "0-1"]
+[ECO "B02"]
+[WhiteElo "2463"]
+[BlackElo "2492"]
+[PlyCount "14"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 d5 2. Nc3 Nf6 3. Nf3 Nxe4 4. Nxe4 dxe4 5. Ng5 Bf5 6. Bc4 e6 7. Qe2 Qxg5
+0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "self_service"]
+[Black "Atomrod"]
+[Result "1-0"]
+[ECO "A35"]
+[WhiteElo "2425"]
+[BlackElo "2499"]
+[PlyCount "105"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. c4 c5 2. Nc3 Nc6 3. f3 g6 4. e4 Bg7 5. Bd3 e6 6. Bc2 Nge7 7. Ba4 O-O 8. Bxc6
+Nxc6 9. Nge2 Nd4 10. d3 b5 11. Nxd4 cxd4 12. Nxb5 d5 13. O-O dxc4 14. dxc4 a6
+15. Na3 Bb7 16. Qd3 f5 17. Bd2 a5 18. Nb5 Qb6 19. Rac1 Rac8 20. Rfd1 e5 21. b4
+axb4 22. Bxb4 Rf6 23. a4 fxe4 24. fxe4 Rf4 25. c5 Qe6 26. Nd6 Rc7 27. Nxb7 Rxb7
+28. c6 Rxb4 29. c7 Rf8 30. Qa3 Rc4 31. Rxc4 Qxc4 32. Rc1 Qe2 33. Qxf8+ Bxf8 34.
+c8=Q d3 35. Qc4+ Kg7 36. Rf1 Bd6 37. a5 Qe3+ 38. Kh1 d2 39. a6 Bc5 40. Qf7+ Kh6
+41. Qf3 Qe1 42. h4 Bf2 43. Qf8+ Kh5 44. Qf3+ Kxh4 45. g3+ Kh3 46. Qg2+ Kg4 47.
+Kh2 d1=Q 48. Qh3+ Kf3 49. g4+ Ke2 50. Rxf2+ Qxf2+ 51. Qg2 Qxg2+ 52. Kxg2 Qf1+
+53. Kg3 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "ajedrez2021"]
+[Black "sutcunuri"]
+[Result "1-0"]
+[ECO "A04"]
+[WhiteElo "2584"]
+[BlackElo "2528"]
+[PlyCount "101"]
+[EventDate "2020.??.??"]
+
+1. Nf3 b6 2. c4 Bb7 3. Nc3 c5 4. g3 Bxf3 5. exf3 Nc6 6. Bg2 g6 7. O-O Bg7 8. f4
+Rc8 9. Re1 e6 10. d3 h5 11. f5 gxf5 12. Bf4 h4 13. Nb5 Kf8 14. Nd6 Ra8 15. Nxf5
+exf5 16. Bd6+ Nge7 17. Bxc6 dxc6 18. Bxe7+ Qxe7 19. Rxe7 Kxe7 20. Qf3 Bd4 21.
+Qxf5 hxg3 22. hxg3 Rh6 23. Re1+ Kf8 24. Kg2 Rf6 25. Qh5 Rxf2+ 26. Kh3 Kg7 27.
+Qg5+ Kf8 28. Re4 Re8 29. Qh6+ Bg7 30. Rxe8+ Kxe8 31. Qxg7 Rf5 32. Qh8+ Ke7 33.
+Qb8 Rh5+ 34. Kg2 Rh6 35. Qxa7+ Kf6 36. Qxb6 Kg7 37. Qxc5 Re6 38. Qd4+ Kg6 39.
+Qc3 Rf6 40. Kh3 Kg7 41. d4 Kg6 42. d5 Rf5 43. Qd3 cxd5 44. cxd5 Kf6 45. d6 Rh5+
+46. Kg4 Rd5 47. Qxd5 Kg6 48. Qg5+ Kh7 49. Kf5 Kh8 50. Kf6 Kh7 51. Qg7# 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "allan-cantonjos"]
+[Black "Dohani"]
+[Result "1-0"]
+[ECO "D01"]
+[WhiteElo "2400"]
+[BlackElo "2376"]
+[PlyCount "61"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 d5 2. Nc3 Nf6 3. Bg5 Bf5 4. Qd2 e6 5. f3 Be7 6. O-O-O c6 7. Kb1 h6 8.
+Bxf6 Bxf6 9. e4 Bg6 10. g4 Nd7 11. Nge2 Qa5 12. Nf4 Bh7 13. Bg2 Bg5 14. h4 Bxf4
+15. Qxf4 Qd8 16. g5 h5 17. Qg3 Bg6 18. f4 O-O 19. Rhf1 dxe4 20. Nxe4 Re8 21.
+Qf3 Nf8 22. Ng3 Qd5 23. Qe2 Qd6 24. Nxh5 Bxh5 25. Qxh5 g6 26. Qg4 Rad8 27. h5
+gxh5 28. Qxh5 Ng6 29. Be4 Nf8 30. Rh1 f5 31. gxf6 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Ganziitoo"]
+[Black "rudolf85"]
+[Result "1-0"]
+[ECO "A06"]
+[WhiteElo "2402"]
+[BlackElo "2409"]
+[PlyCount "141"]
+[EventDate "2020.??.??"]
+
+1. e4 d5 2. Nf3 dxe4 3. Ng5 Nf6 4. Nc3 e6 5. Ngxe4 Be7 6. Nxf6+ Bxf6 7. d3 O-O
+8. Bd2 Be7 9. Be2 Nd7 10. O-O Nf6 11. Bf3 Re8 12. Re1 c6 13. Bg5 Nd7 14. Bxe7
+Qxe7 15. Qe2 Nf6 16. Qe5 Qd8 17. Rad1 Nd7 18. Qh5 Nf6 19. Qh3 Nd5 20. Nxd5 cxd5
+21. d4 e5 22. Bg4 Bxg4 23. Qxg4 e4 24. f3 Qc8 25. Qxc8 Raxc8 26. fxe4 dxe4 27.
+c3 f5 28. g3 Kf7 29. Re3 Ke6 30. d5+ Ke5 31. Rd4 Red8 32. Rb4 b6 33. c4 Rc5 34.
+Rc3 b5 35. Rxb5 Rxb5 36. cxb5 Rxd5 37. a4 g5 38. Kf2 f4 39. gxf4+ gxf4 40. Rc7
+Rd2+ 41. Ke1 Rxb2 42. Rxa7 Kd4 43. Rxh7 Ke3 44. Kd1 f3 45. Rf7 Kd3 46. Kc1 Rxh2
+47. b6 Rc2+ 48. Kb1 Rc4 49. b7 Rb4+ 50. Ka2 Ke2 51. Ka3 Rb1 52. a5 f2 53. a6
+f1=Q 54. Rxf1 Kxf1 55. a7 Ra1+ 56. Kb4 Rxa7 57. b8=Q Ra1 58. Qf4+ Ke2 59. Qxe4+
+Kd1 60. Qd4+ Kc1 61. Qxa1+ Kd2 62. Qd4+ Ke2 63. Kc5 Kf3 64. Kd5 Kg2 65. Qc3 Kh1
+66. Ke5 Kg1 67. Kf4 Kh1 68. Qb2 Kg1 69. Qd2 Kf1 70. Kg3 Kg1 71. Qg2# 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "vava05"]
+[Black "Terben"]
+[Result "1-0"]
+[ECO "B12"]
+[WhiteElo "2393"]
+[BlackElo "2429"]
+[PlyCount "53"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 c6 2. d4 d5 3. e5 Bf5 4. h4 c5 5. g4 Bc8 6. c3 Nc6 7. h5 cxd4 8. f4 Nh6
+9. Be2 d3 10. Qxd3 Bxg4 11. Bxg4 Nxg4 12. Nf3 e6 13. b4 Qb6 14. Qe2 Rc8 15. Ng5
+Nh6 16. Be3 Qc7 17. Nd2 Nf5 18. Kf2 h6 19. Ngf3 Be7 20. Nb3 a5 21. a3 O-O 22.
+Rac1 f6 23. Nbd4 fxe5 24. Nxe6 Qd6 25. Nxf8 exf4 26. Bc5 Qf6 27. Qe6+ 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "alireza3700"]
+[Black "Training88"]
+[Result "0-1"]
+[ECO "A40"]
+[WhiteElo "2373"]
+[BlackElo "2339"]
+[PlyCount "90"]
+[EventDate "2020.??.??"]
+
+1. d4 a6 2. Nc3 b5 3. e4 b4 4. Nce2 Bb7 5. f3 e6 6. c3 a5 7. cxb4 axb4 8. Bd2
+c5 9. dxc5 Bxc5 10. Qc2 Qb6 11. Nh3 Nc6 12. Rc1 Be7 13. g3 Nf6 14. Bg2 h5 15.
+Nhf4 h4 16. Qd3 Bc5 17. Qc4 Bf2+ 18. Kf1 hxg3 19. hxg3 Rxh1+ 20. Bxh1 d5 21.
+exd5 exd5 22. Nxd5 Nxd5 23. Qxd5 Nd4 24. Qe4+ Ne6 25. Qxb4 Qa6 26. Kxf2 Rb8 27.
+Qh4 Qa7+ 28. Kg2 Qxa2 29. Bc3 Qd5 30. Re1 Qxf3+ 31. Kg1 Qe3+ 32. Kh2 Qf2+ 33.
+Kh3 Bxh1 34. Rxh1 Qxe2 35. Qh8+ Ke7 36. Qxb8 Qh5+ 37. Kg2 Qe2+ 38. Kh3 Ng5+ 39.
+Kh4 Nf3+ 40. Kg4 Ne5+ 41. Kf4 Nd3+ 42. Kf5 g6+ 43. Kg5 Qe3+ 44. Kh4 Qe4+ 45.
+Kh3 Nf2+ 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "pmlmail"]
+[Black "BillyLaimbeer"]
+[Result "0-1"]
+[ECO "D45"]
+[WhiteElo "2487"]
+[BlackElo "2370"]
+[PlyCount "76"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 d5 2. Nf3 e6 3. c4 Nf6 4. Nc3 c6 5. e3 Bd6 6. b3 Nbd7 7. Bd3 Qe7 8. Bb2
+a6 9. e4 dxe4 10. Nxe4 Nxe4 11. Bxe4 Bb4+ 12. Kf1 Nf6 13. Bc2 b5 14. a3 Ba5 15.
+b4 Bb6 16. c5 Bc7 17. Ne5 Bb7 18. Qe2 O-O 19. g3 Rad8 20. Kg2 Nd5 21. Rhe1 Rfe8
+22. f4 f6 23. Nf3 Qf7 24. Qd3 f5 25. Ng5 Qf6 26. Re2 h6 27. Nf3 a5 28. Bc3 axb4
+29. axb4 Ra8 30. Rae1 Bxf4 31. Ne5 Bxe5 32. Rxe5 Ra3 33. Rxd5 cxd5 34. Qxb5
+Rea8 35. Re3 Ra2 36. Re2 Ba6 37. Qc6 Bxe2 38. Bb3 Bb5+ 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Al_Shima"]
+[Black "Glig"]
+[Result "0-1"]
+[ECO "A01"]
+[WhiteElo "2497"]
+[BlackElo "2458"]
+[PlyCount "136"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. b3 d5 2. Bb2 Bg4 3. g3 e6 4. Bg2 Nd7 5. h3 Bh5 6. Nf3 Ngf6 7. O-O h6 8. d3
+Be7 9. Nbd2 c6 10. Qe1 a5 11. a3 Bg6 12. e4 O-O 13. e5 Ne8 14. Qe2 Bh7 15. Nh2
+Nc7 16. Ng4 a4 17. b4 c5 18. c3 d4 19. bxc5 dxc3 20. Bxc3 Nxc5 21. d4 Bd3 22.
+Qf3 Bxf1 23. Nxf1 Nb3 24. Ra2 Nd5 25. Bb2 Rc8 26. Nge3 Nxe3 27. Nxe3 Nxd4 28.
+Bxd4 Qxd4 29. Qxb7 Bg5 30. Re2 Qa1+ 31. Nf1 Qxa3 32. f4 Be7 33. Kh2 Rb8 34. Qa7
+Bc5 35. Qc7 Rfc8 36. Qa5 Bf8 37. Re4 Rb4 38. Re3 Qb2 39. Qa6 Rcb8 40. Re2 Qa1
+41. Ne3 a3 42. Nc2 Qb2 43. Qxa3 Qxa3 44. Nxa3 Ra4 45. Nc2 Rb2 46. Nd4 Rxe2 47.
+Nxe2 Rc4 48. Bf3 Bc5 49. h4 g6 50. Kg2 h5 51. Ng1 Kf8 52. Ne2 Ke7 53. Kf1 Kd7
+54. Kg2 Kc7 55. Ng1 Bxg1 56. Kxg1 Rc2 57. Be4 Rb2 58. Bg2 Kb6 59. Kh2 Kc5 60.
+Kh3 Kd4 61. Bc6 Rc2 62. Be8 Rc7 63. g4 Ke4 64. gxh5 gxh5 65. Kg3 Rc3+ 66. Kg2
+Kxf4 67. Bxf7 Kxe5 68. Bxh5 Kf4 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "chakin"]
+[Black "DoctorFromGallifrey"]
+[Result "1-0"]
+[ECO "A15"]
+[WhiteElo "2613"]
+[BlackElo "2560"]
+[PlyCount "107"]
+[EventDate "2020.??.??"]
+
+1. c4 Nf6 2. g3 g6 3. Bg2 Bg7 4. Nc3 O-O 5. e4 d6 6. Nge2 e5 7. d3 c6 8. O-O a5
+9. h3 Na6 10. Kh2 Rb8 11. a4 Nc5 12. f4 exf4 13. Bxf4 Nh5 14. Be3 Be6 15. d4
+Na6 16. d5 cxd5 17. cxd5 Bd7 18. Nb5 Bxb5 19. axb5 Nb4 20. Bd4 Bxd4 21. Qxd4 b6
+22. g4 Nc2 23. Qf2 Nxa1 24. gxh5 Nb3 25. h6 f5 26. Qg3 Nc5 27. exf5 Qf6 28. Nf4
+Qxf5 29. Ne6 Qe5 30. Qxe5 dxe5 31. Nxf8 Rxf8 32. Re1 Rf5 33. d6 Kf8 34. Bc6
+Rf2+ 35. Kg3 Rxb2 36. Rxe5 Rd2 37. Re8+ Kf7 38. Re7+ Kf6 39. Rxh7 Rxd6 40. Rc7
+Rd3+ 41. Kf2 Kg5 42. h7 Rxh3 43. Kg2 Rh5 44. Rg7 Nd3 45. Kg3 Nf4 46. Bf3 Rh3+
+47. Kf2 Rh2+ 48. Ke3 Rh3 49. Rxg6+ Kxg6 50. Kxf4 Kxh7 51. Bg4 Kg7 52. Bf5 Kf6
+53. Bxh3 a4 54. Bg4 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "imdejong"]
+[Black "Xychael27"]
+[Result "1-0"]
+[ECO "B90"]
+[WhiteElo "2354"]
+[BlackElo "2327"]
+[PlyCount "65"]
+[EventDate "2020.??.??"]
+
+1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bc4 e6 7. O-O Be7 8. Bb3
+O-O 9. f4 Nc6 10. Kh1 Nxd4 11. Qxd4 b5 12. f5 e5 13. Qd3 Bb7 14. Bg5 Rc8 15.
+Bxf6 Bxf6 16. Nd5 Bxd5 17. Bxd5 Kh8 18. c3 Rc5 19. b4 Rc7 20. a4 Qc8 21. Rf3
+Qb8 22. axb5 axb5 23. Ra5 Rfc8 24. Rxb5 Qa7 25. c4 Bg5 26. g3 h6 27. h4 Bf6 28.
+Kg2 Qa6 29. Ra5 Qb6 30. Kh3 Qxb4 31. Rb5 Qe1 32. Rf1 Qc3 33. Qxc3 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "vaillant77"]
+[Black "zaqvili"]
+[Result "1/2-1/2"]
+[ECO "B21"]
+[WhiteElo "2412"]
+[BlackElo "2337"]
+[PlyCount "117"]
+[EventDate "2020.??.??"]
+
+1. e4 c5 2. d4 cxd4 3. Nf3 d3 4. Bxd3 g6 5. O-O Bg7 6. c4 Nc6 7. Nc3 d6 8. Qc2
+Nf6 9. b3 Nb4 10. Qe2 Nxd3 11. Qxd3 O-O 12. Bb2 Bg4 13. Rad1 Rc8 14. h3 Bxf3
+15. Qxf3 a6 16. Qe3 Qa5 17. f4 Qc5 18. Qxc5 Rxc5 19. e5 dxe5 20. fxe5 Rxe5 21.
+Nd5 Nxd5 22. Bxe5 Ne3 23. Bxg7 Kxg7 24. Rd7 Nxf1 25. Kxf1 b5 26. Rxe7 bxc4 27.
+bxc4 Rc8 28. Ra7 Rxc4 29. Rxa6 Rc2 30. a4 h5 31. Ra7 Ra2 32. a5 h4 33. a6 g5
+34. Kg1 Kg6 35. Kh2 Kf6 36. Ra8 Ra1 37. a7 Kg7 38. g4 hxg3+ 39. Kxg3 Ra4 40.
+Kf3 f5 41. Kg3 Ra3+ 42. Kg2 Ra2+ 43. Kf3 Ra3+ 44. Ke2 Ra2+ 45. Kd3 Ra3+ 46. Kd4
+g4 47. hxg4 fxg4 48. Ke4 g3 49. Rb8 Rxa7 50. Kf3 Ra3+ 51. Kg2 Kg6 52. Rb5 Kf6
+53. Rc5 Kg6 54. Rb5 Kf6 55. Rc5 Kf7 56. Kh3 Ke6 57. Rg5 Kf6 58. Rxg3 Rxg3+ 59.
+Kxg3 1/2-1/2
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "telodijomonstruo"]
+[Black "Olaffo"]
+[Result "1-0"]
+[ECO "B10"]
+[WhiteElo "2507"]
+[BlackElo "2525"]
+[PlyCount "165"]
+[EventDate "2020.??.??"]
+
+1. e4 c6 2. Nc3 g6 3. Nf3 d5 4. d4 dxe4 5. Nxe4 Nf6 6. Nxf6+ exf6 7. Bc4 Bg7 8.
+O-O O-O 9. h3 Nd7 10. a3 Nb6 11. Ba2 Be6 12. Bxe6 fxe6 13. Re1 Qd7 14. c3 Rad8
+15. Bf4 Nc4 16. Qc1 b5 17. b3 Nd6 18. Bh6 a5 19. Bxg7 Kxg7 20. Qf4 g5 21. Qg3
+Nf5 22. Qg4 Qd5 23. b4 a4 24. Re2 Kg6 25. Rae1 h5 26. Qe4 Qxe4 27. Rxe4 Ng7 28.
+h4 g4 29. Nd2 Rd5 30. f3 e5 31. Nf1 Nf5 32. dxe5 fxe5 33. Rxe5 Rxe5 34. Rxe5
+Nxh4 35. fxg4 hxg4 36. Ng3 Rf6 37. Re4 Kg5 38. Rd4 Re6 39. Ne4+ Kf4 40. Nc5+
+Kg3 41. Nxe6 Nf5 42. Rd3+ Kh4 43. Nd4 Ng3 44. Rxg3 Kxg3 45. Nxc6 Kf4 46. Nd4
+Ke5 47. Nxb5 Ke4 48. c4 Kd3 49. c5 Kc4 50. c6 Kxb5 51. c7 Kc4 52. c8=Q+ Kb3 53.
+Qxg4 Kxa3 54. Qd7 Kxb4 55. Qxa4+ Kxa4 56. Kf2 Kb5 57. Kf3 Kc6 58. Kf4 Kd7 59.
+Kf5 Ke7 60. Kg6 Kf8 61. g4 Kg8 62. g5 Kh8 63. Kf7 Kh7 64. g6+ Kh6 65. g7 Kg5
+66. g8=Q+ Kf5 67. Qg6+ Ke5 68. Qf6+ Kd5 69. Kg6 Kc5 70. Qf5+ Kb4 71. Kf6 Kc4
+72. Qe5 Kb3 73. Kf5 Kc2 74. Qe4+ Kb2 75. Ke5 Kc1 76. Qd4 Kc2 77. Ke4 Kb3 78.
+Qd3+ Ka2 79. Kd4 Ka1 80. Qc3+ Kb1 81. Qd2 Ka1 82. Kc3 Kb1 83. Qb2# 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "wsxcde"]
+[Black "Nurgyul"]
+[Result "0-1"]
+[ECO "A13"]
+[WhiteElo "2381"]
+[BlackElo "2548"]
+[PlyCount "72"]
+[EventDate "2020.??.??"]
+
+1. c4 e6 2. e3 Nf6 3. Nc3 d5 4. d4 c5 5. Nf3 cxd4 6. exd4 Nc6 7. c5 Be7 8. Bd3
+O-O 9. O-O b6 10. cxb6 axb6 11. Re1 Ba6 12. Bb1 g6 13. Bh6 Re8 14. Ne5 Nxe5 15.
+dxe5 Nd7 16. Qf3 Bg5 17. Qh3 Bxh6 18. Qxh6 Qe7 19. Bc2 Qf8 20. Qf4 Qg7 21. Rad1
+Rac8 22. Bb3 Nc5 23. Bxd5 exd5 24. Nxd5 Nd3 25. Rxd3 Bxd3 26. Nf6+ Kh8 27. Qd4
+Red8 28. Qxb6 Bf5 29. a4 Qf8 30. g4 Be6 31. h3 Qc5 32. Qb7 Rd2 33. Re3 Qc7 34.
+Qf3 Kg7 35. Nd5 Bxd5 36. Qf6+ Kg8 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "camilomunoz0107"]
+[Black "Vladimir_Putilov"]
+[Result "1-0"]
+[ECO "A41"]
+[WhiteElo "2337"]
+[BlackElo "2300"]
+[PlyCount "91"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 c6 2. c4 d6 3. Nf3 Nd7 4. g3 h6 5. Bg2 g5 6. O-O Bg7 7. e4 Nf8 8. Nc3 Ne6
+9. h3 Qa5 10. Be3 h5 11. Nh2 h4 12. g4 Nf4 13. Bxf4 gxf4 14. Nf3 e5 15. dxe5
+dxe5 16. a3 Be6 17. b4 Qc7 18. c5 Rd8 19. Qe2 Ne7 20. Rfd1 Ng6 21. Rxd8+ Kxd8
+22. b5 Ke7 23. bxc6 bxc6 24. Ng5 Rb8 25. Nxe6 Kxe6 26. Qc4+ Kf6 27. Rd1 Bf8 28.
+Bf1 f3 29. Rd3 Nf4 30. Rxf3 Rb2 31. Ne2 Kg5 32. Nxf4 exf4 33. Qd4 Rb1 34. e5
+Kh6 35. Qxf4+ Kg7 36. Qg5+ Kh8 37. Qh5+ Kg8 38. Qg5+ Bg7 39. Kg2 Qd7 40. Bd3
+Qd5 41. Bxb1 Qxc5 42. Qh5 Qe7 43. Ba2 Bxe5 44. Bxf7+ Kg7 45. Qg6+ Kh8 46. Qg8#
+1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Midnight_Mushroom"]
+[Black "yaguigor"]
+[Result "0-1"]
+[ECO "A11"]
+[WhiteElo "2442"]
+[BlackElo "2435"]
+[PlyCount "90"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. c4 c6 2. Nf3 d5 3. e3 Nf6 4. b3 Bg4 5. Bb2 e6 6. Be2 Nbd7 7. O-O Be7 8. Nc3
+O-O 9. Qc1 Re8 10. h3 Bh5 11. Ba3 h6 12. Bxe7 Qxe7 13. d4 Ne4 14. Re1 f5 15.
+Ne5 Bxe2 16. Nxe2 Nxe5 17. dxe5 Qc7 18. f3 Nc5 19. Qc3 dxc4 20. bxc4 Rad8 21.
+Red1 Rxd1+ 22. Rxd1 Rd8 23. Rxd8+ Qxd8 24. Qd4 Qe7 25. Nf4 Kf7 26. Kh2 b6 27.
+Ne2 g5 28. Ng3 Qd7 29. Ne2 Ke7 30. h4 Nd3 31. hxg5 hxg5 32. Qc3 c5 33. f4 g4
+34. Ng3 Nb4 35. a3 Qd3 36. Qc1 Nc2 37. Qb1 Qxc4 38. Qd1 Nxe3 39. Qd6+ Ke8 40.
+Nh5 g3+ 41. Kh3 Nd5 42. Qxe6+ Kd8 43. Qd6+ Kc8 44. Qe6+ Kb7 45. Nf6 Nxf4+ 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Slava50"]
+[Black "InsaneTryhard"]
+[Result "1-0"]
+[ECO "B51"]
+[WhiteElo "2403"]
+[BlackElo "2371"]
+[PlyCount "99"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 c5 2. Nf3 d6 3. Bb5+ Nc6 4. O-O a6 5. Bxc6+ bxc6 6. h3 e5 7. c3 Nf6 8. d4
+cxd4 9. cxd4 exd4 10. Nxd4 c5 11. Nf5 Bxf5 12. exf5 Be7 13. Nc3 O-O 14. Nd5
+Nxd5 15. Qxd5 Bf6 16. Bf4 Bxb2 17. Rab1 Be5 18. Bxe5 dxe5 19. Qxe5 Rc8 20. Rfd1
+Qc7 21. Rd6 Rfe8 22. Qg3 f6 23. Rbd1 Re7 24. Qf3 Re1+ 25. Rxe1 Qxd6 26. Qb7 Rb8
+27. Qa7 Kh8 28. g3 c4 29. Re7 Rg8 30. h4 Qd1+ 31. Kg2 c3 32. Qc5 c2 33. Rc7
+c1=Q 34. Qxc1 Qd5+ 35. Kh2 Qxf5 36. Qf4 Qxf4 37. gxf4 Ra8 38. Rb7 Kg8 39. a4 a5
+40. f5 Kf8 41. Kg3 h6 42. h5 Rc8 43. Kf4 Rc4+ 44. Ke3 Rxa4 45. f3 Ra3+ 46. Ke4
+Ra4+ 47. Kd5 Rb4 48. Ra7 a4 49. Ke6 Rh4 50. Ra8# 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "victorchartres"]
+[Black "mux77"]
+[Result "0-1"]
+[ECO "A01"]
+[WhiteElo "2408"]
+[BlackElo "2423"]
+[PlyCount "76"]
+[EventDate "2020.??.??"]
+
+1. b3 Nf6 2. Bb2 g6 3. e3 Bg7 4. Nf3 O-O 5. d4 d5 6. Be2 c5 7. O-O Ne4 8. Nbd2
+Nc6 9. Nxe4 dxe4 10. Ne5 Nxe5 11. dxe5 Qc7 12. f4 exf3 13. Bxf3 Bxe5 14. Bxe5
+Qxe5 15. Qd5 Qxe3+ 16. Kh1 Qd4 17. Rae1 Qxd5 18. Bxd5 e6 19. Bc4 Rb8 20. a4 b6
+21. a5 Bb7 22. Be2 Rfd8 23. axb6 axb6 24. Bf3 Bxf3 25. Rxf3 Rd2 26. Ref1 Rb7
+27. Rc3 Rbd7 28. h3 Re2 29. Kg1 Rdd2 30. Rg3 Rxc2 31. Rff3 Rc1+ 32. Kh2 Ree1
+33. Rg4 h5 34. Rgf4 f5 35. Ra4 Kf7 36. Ra7+ Kf6 37. Rd3 h4 38. g4 Re2# 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Allshad"]
+[Black "azikom"]
+[Result "1-0"]
+[ECO "B40"]
+[WhiteElo "2314"]
+[BlackElo "2522"]
+[PlyCount "91"]
+[EventDate "2020.??.??"]
+
+1. e4 c5 2. Nf3 e6 3. c3 a6 4. d4 d5 5. e5 Nc6 6. Bd3 Bd7 7. O-O Qb6 8. dxc5
+Bxc5 9. b4 Bf8 10. Nbd2 Nge7 11. Nb3 Qc7 12. Re1 Ng6 13. Nc5 Bxc5 14. bxc5 Nce7
+15. h4 h6 16. h5 Nf8 17. Ba3 Bb5 18. c6 Nxc6 19. Bd6 Qc8 20. Bxb5 axb5 21. Qd3
+Ra5 22. Reb1 Nh7 23. Rxb5 Ng5 24. Nd4 Rxb5 25. Qxb5 Ne4 26. Rc1 f5 27. c4 Kf7
+28. cxd5 Nxd4 29. Rxc8 Nxb5 30. Rxh8 exd5 31. Rf8+ Ke6 32. Re8+ Kd7 33. Re7+
+Kc6 34. Rxg7 d4 35. Bb4 d3 36. e6 Nd4 37. e7 Kd7 38. Rg8 Nf6 39. Rd8+ Ke6 40.
+Rxd4 Ne8 41. Rxd3 Kf7 42. Rd8 Nf6 43. Rf8+ Ke6 44. e8=Q+ Nxe8 45. Rxe8+ Kd7 46.
+Rh8 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "sleepylock"]
+[Black "Caochonewell"]
+[Result "0-1"]
+[ECO "A01"]
+[WhiteElo "2503"]
+[BlackElo "2413"]
+[PlyCount "82"]
+[EventDate "2020.??.??"]
+
+1. b3 Nf6 2. Bb2 g6 3. Bxf6 exf6 4. d4 Bg7 5. e3 f5 6. g3 O-O 7. Bg2 d6 8. Ne2
+c6 9. O-O Re8 10. c4 Nd7 11. Nbc3 Nf6 12. b4 Bd7 13. Qd3 a5 14. b5 cxb5 15.
+Nxb5 Bxb5 16. cxb5 d5 17. Rfc1 a4 18. Rc2 Ne4 19. Rac1 Qb6 20. Nf4 Red8 21. Bf1
+Bh6 22. Ne2 Re8 23. Nc3 Nxc3 24. Rxc3 Bf8 25. Rc7 Bd6 26. R7c2 a3 27. Bg2 Ra5
+28. Rb1 Rd8 29. Bxd5 Bxg3 30. Bxf7+ Kxf7 31. hxg3 Kf6 32. Kg2 Qe6 33. Qc3 Qd5+
+34. Kg1 Rxb5 35. Qc7 Rxb1+ 36. Rc1 Rxc1+ 37. Qxc1 Qxa2 38. e4 fxe4 39. Qf4+ Kg7
+40. Qe5+ Kg8 41. Qf6 Rf8 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Karabakh-Azerbaijan"]
+[Black "Frogkiller"]
+[Result "1-0"]
+[ECO "A01"]
+[WhiteElo "2444"]
+[BlackElo "2378"]
+[PlyCount "105"]
+[EventDate "2020.??.??"]
+
+1. b3 Nf6 2. Bb2 g6 3. Nf3 Bg7 4. d4 O-O 5. e3 d6 6. Be2 Nc6 7. O-O e5 8. Nbd2
+exd4 9. Nxd4 Bd7 10. Nxc6 Bxc6 11. Bf3 Bxf3 12. Nxf3 Re8 13. Nd4 a6 14. c4 Qd7
+15. Qc2 Ne4 16. Rad1 Qe7 17. b4 Rad8 18. Nb3 Bxb2 19. Qxb2 Qf6 20. Qxf6 Nxf6
+21. Rd4 Re4 22. Rfd1 Rde8 23. c5 Rxd4 24. Nxd4 dxc5 25. bxc5 Re5 26. c6 bxc6
+27. Nxc6 Rc5 28. Nd4 Ra5 29. Rd2 Ne4 30. Rc2 c5 31. Nb3 Rb5 32. f3 Nf6 33. Rxc5
+Rb6 34. Rc8+ Kg7 35. Ra8 Nd5 36. Kf2 Nb4 37. Nc5 Nxa2 38. Nxa6 Rb2+ 39. Kg3 Nc3
+40. Nc5 Nd1 41. e4 Ne3 42. Nd7 Rxg2+ 43. Kf4 Nc4 44. h4 Rf2 45. Ra7 Nd2 46. Ne5
+Kg8 47. Ra8+ Kg7 48. Ra7 Kg8 49. h5 gxh5 50. Rxf7 Rxf3+ 51. Nxf3 Nxf3 52. Rf5
+Nd4 53. Rg5+ 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Maxterlopez"]
+[Black "FerociousLion98999"]
+[Result "1-0"]
+[ECO "C41"]
+[WhiteElo "2629"]
+[BlackElo "2608"]
+[PlyCount "65"]
+[EventDate "2020.??.??"]
+
+1. e4 e5 2. Nf3 d6 3. Bc4 Be7 4. d4 Nd7 5. dxe5 dxe5 6. Qd5 Nh6 7. Bxh6 O-O 8.
+Be3 c6 9. Qd2 Qc7 10. a4 Nb6 11. Bb3 Be6 12. Bxe6 fxe6 13. Qe2 Rad8 14. O-O Nc8
+15. Nbd2 Rf6 16. Bg5 Rg6 17. Bxe7 Nxe7 18. Rad1 Rf8 19. Nc4 Rgf6 20. Ncxe5 Qb6
+21. Nd7 Qxb2 22. Nxf8 Rxf8 23. Rd7 Ng6 24. Qc4 Nf4 25. g3 Nh3+ 26. Kg2 Qf6 27.
+Kxh3 Qxf3 28. Qxe6+ Kh8 29. Qg4 Qf6 30. e5 Qxe5 31. Kg2 h6 32. Re1 Qxe1 33.
+Qxg7# 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Mia_Khaliffa"]
+[Black "Abouyahya1983"]
+[Result "0-1"]
+[ECO "B21"]
+[WhiteElo "2444"]
+[BlackElo "2557"]
+[PlyCount "106"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 c5 2. d4 cxd4 3. c3 d3 4. c4 Nc6 5. Bxd3 Nf6 6. Nf3 d6 7. h3 g6 8. Nc3
+Bg7 9. Bg5 h6 10. Be3 O-O 11. O-O Be6 12. Qd2 Kh7 13. Nd5 Rc8 14. Rae1 Nd7 15.
+b3 a6 16. a4 a5 17. Bb1 Nc5 18. Bc2 Bd7 19. Nd4 e6 20. Nc3 Nb4 21. Ncb5 Bxb5
+22. Nxb5 d5 23. exd5 exd5 24. cxd5 Qxd5 25. Qxd5 Nxd5 26. Bxc5 Rxc5 27. Be4 b6
+28. Bxd5 Rxd5 29. Rd1 Rfd8 30. Rxd5 Rxd5 31. Rc1 Bf8 32. g3 Bc5 33. Rc2 Rd3 34.
+Rb2 Rxg3+ 35. Kh2 Rd3 36. Kg2 h5 37. Nc7 g5 38. Ne8 Kg6 39. Nc7 f5 40. Ne6 h4
+41. Nxc5 bxc5 42. Rc2 Rd5 43. Re2 g4 44. Re6+ Kg5 45. Ra6 Rd2 46. hxg4 fxg4 47.
+Rxa5 g3 48. Rxc5+ Kg6 49. Kh3 gxf2 50. Kg2 h3+ 51. Kf1 h2 52. Rc6+ Kg5 53. Rc5+
+Kg4 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Ogrilla"]
+[Black "MiroMiljkovic"]
+[Result "1-0"]
+[ECO "D12"]
+[WhiteElo "2827"]
+[BlackElo "2605"]
+[PlyCount "71"]
+[EventDate "2020.??.??"]
+
+1. Nf3 c6 2. d4 d5 3. c4 Nf6 4. e3 Bg4 5. Nc3 Bxf3 6. Qxf3 e6 7. b3 Nbd7 8. Bd2
+Bb4 9. a3 Qa5 10. Nb1 Bxd2+ 11. Nxd2 Ne4 12. b4 Nxd2 13. bxa5 Nxf3+ 14. gxf3
+O-O 15. Kd2 b6 16. cxd5 exd5 17. Bd3 bxa5 18. Rhc1 Rfc8 19. Bf5 Rc7 20. Bxd7
+Rxd7 21. Rxc6 Rb8 22. Rac1 Rdd8 23. R6c5 a4 24. Ra5 Rb2+ 25. Rc2 Rb1 26. Rxa4
+Rh1 27. Rxa7 Rxh2 28. Kd3 h5 29. a4 h4 30. a5 h3 31. Rac7 Rg2 32. Rc1 Rxf2 33.
+Rh1 h2 34. Rc2 Rxf3 35. Rcxh2 Rf8 36. Rh8# 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "gaupasa"]
+[Black "Lavi12"]
+[Result "1-0"]
+[ECO "B22"]
+[WhiteElo "2329"]
+[BlackElo "2319"]
+[PlyCount "87"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 c5 2. c3 Nf6 3. e5 Nd5 4. d4 cxd4 5. Nf3 Nc6 6. Bc4 Nb6 7. Bb3 d6 8. exd6
+Qxd6 9. O-O Be6 10. Na3 dxc3 11. Bxe6 Qxd1 12. Bxf7+ Kxf7 13. Rxd1 cxb2 14.
+Bxb2 h6 15. Rac1 e6 16. Nb5 Be7 17. Re1 Rac8 18. Rcd1 Rhd8 19. Rxd8 Rxd8 20.
+Nc7 Nc4 21. Bxg7 Kxg7 22. Nxe6+ Kf7 23. Nxd8+ Bxd8 24. Rd1 Be7 25. Nd4 Nxd4 26.
+Rxd4 b5 27. g4 a5 28. Kg2 Ke6 29. Kg3 a4 30. h4 Bd6+ 31. f4 Ne3 32. Re4+ Kd5
+33. Rxe3 b4 34. Kf3 Kc4 35. g5 hxg5 36. fxg5 b3 37. axb3+ axb3 38. h5 b2 39.
+Re1 Be7 40. Kg4 Kd3 41. h6 Kd2 42. Rb1 Kc2 43. Rxb2+ Kxb2 44. h7 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Northridgehawk"]
+[Black "zenon011"]
+[Result "1-0"]
+[ECO "C25"]
+[WhiteElo "2359"]
+[BlackElo "2334"]
+[PlyCount "61"]
+[EventDate "2020.??.??"]
+
+1. e4 e5 2. Nc3 Nc6 3. Bc4 d6 4. d3 f5 5. f4 Nf6 6. Nf3 fxe4 7. dxe4 Bg4 8. h3
+Bh5 9. g4 Bf7 10. Bd3 exf4 11. Bxf4 Be7 12. Qe2 O-O 13. O-O-O Nb4 14. Kb1 Nxd3
+15. cxd3 b5 16. Bc1 b4 17. Na4 c5 18. d4 Qd7 19. b3 c4 20. e5 cxb3 21. axb3 Nd5
+22. exd6 Bxd6 23. Ne5 Bxe5 24. dxe5 Bg6+ 25. Ka2 Nc3+ 26. Nxc3 bxc3 27. Rxd7
+Rab8 28. Qc4+ Kh8 29. e6 Rfc8 30. Qd4 Rb5 31. Qxg7# 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "FinalCut"]
+[Black "RigelStar"]
+[Result "1-0"]
+[ECO "A01"]
+[WhiteElo "2443"]
+[BlackElo "2415"]
+[PlyCount "133"]
+[EventDate "2020.??.??"]
+
+1. b3 a5 2. Bb2 a4 3. Nf3 d5 4. e3 e6 5. c4 a3 6. Nxa3 Bxa3 7. Bxg7 f6 8. Bxh8
+Nh6 9. Qc2 Qe7 10. cxd5 exd5 11. Bd3 Qf8 12. Bxh7 Qxh8 13. Qxc7 Nc6 14. Bg6+
+Kf8 15. O-O Qg7 16. Qxg7+ Kxg7 17. Bd3 Bf5 18. Bxf5 Nxf5 19. d4 Rg8 20. g3 Kf7
+21. Ne1 Nd6 22. Nd3 Ne4 23. Rfe1 Ng5 24. Kg2 Ne4 25. Re2 Nd6 26. Rc2 Re8 27.
+Nc5 Bxc5 28. Rxc5 Ne4 29. Rb5 Re7 30. Rc1 Nd6 31. Rb6 Ke6 32. Rbxc6 bxc6 33.
+Rxc6 Ra7 34. a4 Kd7 35. Rb6 Rc7 36. a5 Nc8 37. Rb5 Rc3 38. Rxd5+ Ke6 39. Rb5
+Nd6 40. Rb6 Rc1 41. b4 Rb1 42. b5 Kd5 43. a6 Nxb5 44. a7 Nxa7 45. Rxb1 Nc6 46.
+Rb5+ Ke6 47. Rb6 Kd6 48. Rxc6+ Kxc6 49. h4 Kd6 50. h5 Ke6 51. h6 Kf7 52. d5 Ke7
+53. d6+ Kxd6 54. h7 Ke6 55. h8=Q f5 56. Qh6+ Ke5 57. Qf4+ Kf6 58. g4 Ke6 59.
+Qxf5+ Kd6 60. f4 Kc6 61. g5 Kd6 62. g6 Kc6 63. g7 Kb6 64. g8=Q Kc6 65. Qgg6+
+Kc7 66. Qff7+ Kb8 67. Qgg8# 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "gmdakajustine"]
+[Black "MissMariposa"]
+[Result "1-0"]
+[ECO "A41"]
+[WhiteElo "2380"]
+[BlackElo "2323"]
+[PlyCount "79"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 d6 2. Nf3 g6 3. e4 Bg7 4. c4 c5 5. Nc3 cxd4 6. Nxd4 Nc6 7. Nc2 Nf6 8. Be2
+O-O 9. O-O b6 10. Be3 Bb7 11. Rc1 Rc8 12. b3 Nd7 13. Nd5 Nc5 14. f3 Bb2 15. Rb1
+Bg7 16. Kh1 e6 17. Nf4 Qc7 18. Qd2 Rcd8 19. Rbd1 Ne7 20. Nh3 d5 21. exd5 exd5
+22. Qe1 dxc4 23. Bxc4 Nf5 24. Bf4 Rxd1 25. Qxd1 Qd7 26. Qxd7 Nxd7 27. Rd1 Nf6
+28. Ng5 Nh6 29. Kg1 Nh5 30. Be3 Kh8 31. Kf2 f6 32. Ne6 Re8 33. Rd7 Bc8 34. Nxg7
+Nxg7 35. Rxa7 Nhf5 36. Bxb6 Ne6 37. Ra8 Nf4 38. Ne3 Nxe3 39. Bxe3 Ne6 40. Bxe6
+1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "hungzhao"]
+[Black "chipmunknau"]
+[Result "1-0"]
+[ECO "B12"]
+[WhiteElo "2625"]
+[BlackElo "2577"]
+[PlyCount "51"]
+[EventDate "2020.??.??"]
+
+1. e4 c6 2. d4 d5 3. Nd2 h6 4. Ngf3 Bg4 5. h3 Bxf3 6. Qxf3 e6 7. c3 Nf6 8. e5
+Nfd7 9. Bd3 c5 10. O-O Nc6 11. Qe3 cxd4 12. cxd4 Qb6 13. Nf3 Be7 14. a3 O-O 15.
+b4 Rfc8 16. Bb2 a5 17. b5 Na7 18. a4 Qd8 19. Qf4 Nb6 20. Qg4 Nc4 21. Bc1 Kf8
+22. Bf4 Nb2 23. Bh7 Rc3 24. Bxh6 Bf6 25. exf6 Qxf6 26. Bg5 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "vassiukov"]
+[Black "chesslismab"]
+[Result "1-0"]
+[ECO "A46"]
+[WhiteElo "2374"]
+[BlackElo "2453"]
+[PlyCount "95"]
+[EventDate "2020.??.??"]
+
+1. d4 Nf6 2. Nf3 e6 3. Bf4 b6 4. e3 Bb7 5. Nbd2 d6 6. h3 Nbd7 7. Bd3 Be7 8. Qe2
+O-O 9. O-O h6 10. Bh2 a6 11. a4 c5 12. c3 Rc8 13. Bxa6 Bxa6 14. Qxa6 d5 15. Ne5
+c4 16. Nxd7 Nxd7 17. Qb5 Rb8 18. e4 Nf6 19. Bxb8 Qxb8 20. e5 Nh7 21. f4 f6 22.
+Nf3 g5 23. a5 gxf4 24. Qxb6 Qxb6 25. axb6 Rb8 26. Ra7 Kf8 27. b7 Kf7 28. Rfa1
+Ng5 29. R1a6 Nxf3+ 30. gxf3 fxe5 31. dxe5 Bc5+ 32. Kg2 Bxa7 33. Rxa7 Ke7 34. h4
+Kd7 35. Kh3 Kc7 36. Kg4 Rxb7 37. Rxb7+ Kxb7 38. Kxf4 Kc6 39. Ke3 Kc5 40. f4 d4+
+41. cxd4+ Kd5 42. h5 Kc6 43. Ke4 Kb5 44. d5 exd5+ 45. Kxd5 Kb4 46. e6 Kb3 47.
+e7 Kxb2 48. Kxc4 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "estocastico"]
+[Black "two64brocc"]
+[Result "1-0"]
+[ECO "B06"]
+[WhiteElo "2574"]
+[BlackElo "2646"]
+[PlyCount "59"]
+[EventDate "2020.??.??"]
+
+1. e4 g6 2. d4 Bg7 3. Bc4 f6 4. h4 Nh6 5. h5 Nf7 6. h6 Bf8 7. c3 e6 8. Nf3 g5
+9. e5 Bxh6 10. Rxh6 Nxh6 11. exf6 Qxf6 12. Bxg5 Qg7 13. Kf1 Rg8 14. g3 Nc6 15.
+Nbd2 Nf7 16. Bh4 Ne7 17. Ne4 Nf5 18. Nf6+ Kf8 19. Nxg8 Kxg8 20. d5 N7d6 21. Bb3
+Nxh4 22. Nxh4 e5 23. Qh5 b6 24. Re1 Ba6+ 25. Kg1 Nf7 26. Re4 Kh8 27. Rg4 Be2
+28. f3 Qf6 29. Ng6+ Kg7 30. Nxe5+ 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "MrMania"]
+[Black "lord_barre"]
+[Result "1-0"]
+[ECO "A00"]
+[WhiteElo "2378"]
+[BlackElo "2416"]
+[PlyCount "135"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. g3 Nf6 2. Bg2 d5 3. Nf3 e6 4. O-O Be7 5. d4 O-O 6. c4 dxc4 7. Na3 Bxa3 8.
+bxa3 Nc6 9. Bg5 h6 10. Bxf6 Qxf6 11. e4 e5 12. d5 Nd4 13. Nxd4 exd4 14. Re1 c5
+15. dxc6 Qxc6 16. Qxd4 Be6 17. e5 Qc7 18. Rac1 Rfd8 19. Qc3 Qb6 20. Rb1 Qc5 21.
+Rxb7 Rd3 22. Qb4 Qd4 23. Rb8+ Rxb8 24. Qxb8+ Kh7 25. Be4+ g6 26. Bxd3 cxd3 27.
+Qd6 Qc3 28. Rd1 Bc4 29. e6 fxe6 30. Rb1 Qg7 31. a4 h5 32. h4 Bd5 33. Rd1 g5 34.
+hxg5 Qxg5 35. Qc7+ Kg6 36. Rxd3 Qf5 37. Qc3 Qe4 38. f3 Qe2 39. Re3 Qd1+ 40. Kg2
+Bxa2 41. Qd3+ Qxd3 42. Rxd3 Bd5 43. Kf2 Kf5 44. f4 Kf6 45. Rd4 Ke7 46. a5 Kd6
+47. Rb4 Kc5 48. Rb2 a6 49. Kg1 Bc4 50. Kh2 Bb5 51. Kh3 Kc4 52. Kh4 Kc3 53. Rb1
+Kc2 54. Rxb5 axb5 55. a6 b4 56. a7 b3 57. a8=Q b2 58. Qc6+ Kd2 59. Qb5 Kc1 60.
+Kxh5 Kd1 61. Qxb2 e5 62. fxe5 Ke1 63. Qc2 Kf1 64. Qd2 Kg1 65. Qe2 Kh1 66. Kg4
+Kg1 67. Kf3 Kh1 68. Qg2# 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "LordBendtner99"]
+[Black "barbosean"]
+[Result "1-0"]
+[ECO "A00"]
+[WhiteElo "2486"]
+[BlackElo "2450"]
+[PlyCount "25"]
+[EventDate "2020.??.??"]
+
+1. g3 e6 2. f3 d5 3. Nh3 c5 4. Nf2 Nc6 5. Bg2 e5 6. O-O Nf6 7. d3 Be7 8. e4 Be6
+9. Nc3 d4 10. Ne2 h6 11. f4 Qc7 12. a4 a6 13. b3 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Johnnyballgame"]
+[Black "QMagico"]
+[Result "0-1"]
+[ECO "E20"]
+[WhiteElo "2309"]
+[BlackElo "2399"]
+[PlyCount "52"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 Nf6 2. c4 e6 3. Nc3 Bb4 4. f3 d5 5. a3 Bxc3+ 6. bxc3 O-O 7. e3 Nbd7 8.
+cxd5 exd5 9. Bd3 c6 10. Ne2 Re8 11. O-O Nf8 12. Ng3 Ng6 13. e4 Qc7 14. e5 Nd7
+15. f4 c5 16. f5 Ngf8 17. Qg4 g6 18. Qh4 Qb6 19. Rb1 Qa5 20. Bd2 cxd4 21. fxg6
+hxg6 22. Bg5 Qxc3 23. Rf3 Nxe5 24. Rc1 Nxf3+ 25. gxf3 Qxd3 26. Bf6 Nh7 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "lucrecio777"]
+[Black "Maybach77"]
+[Result "0-1"]
+[ECO "D38"]
+[WhiteElo "2407"]
+[BlackElo "2361"]
+[PlyCount "118"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 Nf6 2. c4 e6 3. Nf3 d5 4. Nc3 Bb4 5. Bg5 h6 6. Bxf6 Qxf6 7. e3 c5 8. Bd3
+Nc6 9. O-O cxd4 10. exd4 dxc4 11. Bxc4 O-O 12. d5 Bxc3 13. bxc3 Rd8 14. d6 e5
+15. Re1 Rxd6 16. Qb3 Bg4 17. Re3 Na5 18. Qa4 Nxc4 19. Qxc4 Bxf3 20. Rxf3 Qe6
+21. Qb4 Rb6 22. Qa3 a6 23. Re3 Qd5 24. Rae1 f6 25. h3 Rc8 26. Qa4 Rbc6 27. Qb4
+Rc4 28. Qb3 R4c5 29. Qxd5+ Rxd5 30. Rb1 b5 31. Kf1 Rd2 32. Ra1 Rc2 33. a4 R8xc3
+34. Rxc3 Rxc3 35. axb5 axb5 36. Ra8+ Kf7 37. Rb8 Rc5 38. Ke2 Ke6 39. Kd3 Kd5
+40. Rb7 g5 41. Rh7 e4+ 42. Kd2 Kc4 43. Rxh6 Rf5 44. Ke3 b4 45. Rh8 b3 46. Rd8
+b2 47. Rd1 Kc3 48. Kxe4 Rxf2 49. g4 Kc2 50. Re1 b1=Q 51. Rxb1 Kxb1 52. Ke3 Rf4
+53. h4 Kc1 54. h5 Rxg4 55. h6 Rh4 56. Kf3 Rxh6 57. Kg3 Kd2 58. Kg4 Ke2 59. Kf5
+Kf3 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "BravadoChess"]
+[Black "DarkKnightXx"]
+[Result "1/2-1/2"]
+[ECO "A13"]
+[WhiteElo "2471"]
+[BlackElo "2373"]
+[PlyCount "84"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. c4 e6 2. Nc3 d5 3. e3 Nf6 4. Nf3 Nbd7 5. b3 Be7 6. Bb2 O-O 7. cxd5 exd5 8.
+d4 c6 9. g3 Bd6 10. Bg2 Qe7 11. O-O Ne4 12. Qc2 f5 13. Ne2 Ndf6 14. Ne5 Be6 15.
+Nf4 Bf7 16. f3 Ng5 17. Qxf5 Ne6 18. Nxe6 Bxe6 19. Qc2 Nd7 20. Nxd7 Qxd7 21. e4
+dxe4 22. fxe4 Bh3 23. Bxh3 Qxh3 24. Qg2 Qg4 25. Rae1 Rxf1+ 26. Rxf1 Rf8 27.
+Rxf8+ Bxf8 28. h3 Qd1+ 29. Kh2 h5 30. e5 Be7 31. Qf2 Qd3 32. e6 Kh7 33. Bc1 h4
+34. Bf4 Bf6 35. Be5 Bxe5 36. dxe5 Qe4 37. Qf4 Qe2+ 38. Kg1 Qe1+ 39. Kg2 Qe2+
+40. Kg1 Qe1+ 41. Kg2 Qe2+ 42. Kg1 Qe1+ 1/2-1/2
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Sash22"]
+[Black "delagente"]
+[Result "1-0"]
+[ECO "A00"]
+[WhiteElo "2378"]
+[BlackElo "2315"]
+[PlyCount "89"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. g3 Nf6 2. Bg2 g6 3. e4 Bg7 4. d3 d6 5. Nc3 O-O 6. h4 c5 7. Bg5 h6 8. Bf4 e5
+9. Be3 Nc6 10. f3 Be6 11. Qd2 Kh7 12. O-O-O Nd4 13. Kb1 b5 14. h5 g5 15. Nce2
+b4 16. Nc1 a5 17. Bh3 a4 18. Bxe6 fxe6 19. Nh3 Nxf3 20. Qg2 g4 21. Nf2 Qa5 22.
+Rdf1 Nd4 23. Rh4 b3 24. cxb3 axb3 25. a3 Nc2 26. Nd1 Qa4 27. Bd2 Nxa3+ 28. bxa3
+Qxa3 29. Bc3 b2 30. Bxb2 Rfb8 31. Rxf6 Bxf6 32. Rxg4 Bg5 33. Rxg5 hxg5 34. Qh3
+Ra6 35. Qxe6 Ra7 36. Qg6+ Kh8 37. Qxd6 Rab7 38. Qxe5+ Kg8 39. Qxg5+ Kf8 40.
+Qf5+ Ke8 41. Qe6+ Kd8 42. Qa2 Qb4 43. Qd5+ Kc8 44. Qe6+ Rd7 45. Qc6+ 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "FerociousLion98999"]
+[Black "Maxterlopez"]
+[Result "0-1"]
+[ECO "C70"]
+[WhiteElo "2603"]
+[BlackElo "2634"]
+[PlyCount "70"]
+[EventDate "2020.??.??"]
+
+1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nge7 5. c3 g6 6. O-O b5 7. Bb3 Bg7 8. d4
+exd4 9. cxd4 O-O 10. d5 Na5 11. Bc2 d6 12. Bd2 Nc4 13. Bc3 Nxb2 14. Qc1 Nc4 15.
+Bxg7 Kxg7 16. Bd3 Bg4 17. Qc3+ Kg8 18. Bxc4 Bxf3 19. Qxf3 bxc4 20. Nd2 c6 21.
+Nxc4 cxd5 22. exd5 Nf5 23. Rfd1 Rc8 24. Rac1 Re8 25. Qa3 Re4 26. Na5 Rxc1 27.
+Rxc1 Nd4 28. Nc6 Qb6 29. Qxd6 Ne2+ 30. Kf1 Qb5 31. a4 Qd3 32. Qb8+ Kg7 33. Qb2+
+Kh6 34. Re1 Ng3+ 35. Kg1 Rxe1# 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "mixo23"]
+[Black "Dimitriy1975"]
+[Result "1-0"]
+[ECO "A31"]
+[WhiteElo "2423"]
+[BlackElo "2381"]
+[PlyCount "91"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 Nf6 2. c4 c5 3. Nf3 cxd4 4. Nxd4 g6 5. g3 Bg7 6. Bg2 Nc6 7. O-O O-O 8.
+Nc3 d6 9. Nc2 Qa5 10. Bd2 Qh5 11. e4 Bg4 12. f3 Be6 13. b3 a6 14. Qe2 Rac8 15.
+Rac1 Qc5+ 16. Kh1 Rfe8 17. Qe1 Nd4 18. Nxd4 Qxd4 19. Be3 Qe5 20. Nd5 Nxd5 21.
+exd5 Bf5 22. f4 Qb2 23. Rf2 Qa3 24. Bb6 a5 25. Re2 Bf6 26. Bf3 a4 27. g4 Bd7
+28. g5 Bg7 29. Rb1 axb3 30. axb3 Qa5 31. Bxa5 Ra8 32. Bb6 Ra6 33. Bg1 Bf8 34.
+b4 b5 35. c5 dxc5 36. bxc5 Bf5 37. c6 Rc8 38. Rxb5 Bd3 39. Reb2 Bxb5 40. Rxb5
+Ra3 41. Bg2 Ra4 42. d6 exd6 43. Qc3 Rxf4 44. Bd4 Re8 45. h3 h5 46. c7 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "sutcunuri"]
+[Black "ajedrez2021"]
+[Result "1-0"]
+[ECO "A39"]
+[WhiteElo "2523"]
+[BlackElo "2589"]
+[PlyCount "99"]
+[EventDate "2020.??.??"]
+
+1. c4 g6 2. g3 Nf6 3. Bg2 Bg7 4. Nc3 O-O 5. Nf3 c5 6. O-O Nc6 7. d4 cxd4 8.
+Nxd4 Qb6 9. Nc2 d6 10. b3 Be6 11. Ne3 Rfc8 12. Bb2 Rab8 13. Qd2 Qa5 14. Rfd1 a6
+15. a4 Qb4 16. Ba3 Qa5 17. Rac1 Ne5 18. Ncd5 Qxd2 19. Nxe7+ Kf8 20. Rxd2 Kxe7
+21. Bxd6+ Ke8 22. Bxe5 Ra8 23. Bxb7 Nh5 24. Bxg7 Nxg7 25. Bxa8 Rxa8 26. Nd5 Rb8
+27. Nc7+ Ke7 28. Nxa6 Rxb3 29. Nc5 Ra3 30. Rd3 Ra2 31. Nxe6 Nxe6 32. c5 Rxa4
+33. c6 Ra7 34. Re3 Rc7 35. Kg2 Kd6 36. Rxe6+ fxe6 37. Kf3 Ke5 38. Ke3 h6 39. f3
+Kd5 40. h4 Ke5 41. Rc2 Kd5 42. Kf4 Rf7+ 43. Kg4 Rc7 44. e4+ Ke5 45. Rc4 Kd6 46.
+f4 Ke7 47. h5 gxh5+ 48. Kxh5 Kd8 49. Kxh6 Rg7 50. Kxg7 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Yoseqpuedo"]
+[Black "murderoflegends"]
+[Result "1/2-1/2"]
+[ECO "A00"]
+[WhiteElo "2417"]
+[BlackElo "2425"]
+[PlyCount "61"]
+[EventDate "2020.??.??"]
+
+1. e3 d5 2. f4 c6 3. Nf3 Nf6 4. Be2 Bg4 5. O-O Nbd7 6. d3 Bxf3 7. Bxf3 e5 8.
+fxe5 Nxe5 9. Be2 Bd6 10. d4 Ng6 11. c4 Qc7 12. h3 O-O 13. Nc3 Rfe8 14. cxd5
+cxd5 15. Qb3 Rad8 16. Bf3 Bh2+ 17. Kh1 Nh4 18. Bd2 Nxf3 19. Rxf3 Ne4 20. Nxe4
+dxe4 21. Rf5 g6 22. Rc5 Qg3 23. Rf1 Rf8 24. Qxb7 Rb8 25. Qe7 Rxb2 26. Rc8 Rxc8
+27. Qxf7+ Kh8 28. Qf6+ Kg8 29. Qf7+ Kh8 30. Qf6+ Kg8 31. Qf7+ 1/2-1/2
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Sergei_Yudin01"]
+[Black "Kralj56"]
+[Result "1-0"]
+[ECO "A04"]
+[WhiteElo "2321"]
+[BlackElo "2461"]
+[PlyCount "93"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. Nf3 g6 2. e3 Bg7 3. c4 c5 4. Nc3 Nc6 5. b3 Nf6 6. Bb2 O-O 7. Be2 a6 8. O-O
+Rb8 9. d4 d6 10. dxc5 dxc5 11. Qxd8 Rxd8 12. Na4 b6 13. Rad1 Bg4 14. h3 Bf5 15.
+Rxd8+ Nxd8 16. Be5 Rb7 17. Rd1 Nc6 18. Bb2 Ne4 19. Bxg7 Kxg7 20. Nh4 b5 21.
+Nxf5+ gxf5 22. cxb5 axb5 23. Nxc5 Nxc5 24. Rc1 Ne4 25. Rxc6 b4 26. Bf3 Ra7 27.
+Bxe4 fxe4 28. Rc4 f5 29. Rxb4 Rxa2 30. g4 e6 31. Kg2 Kf6 32. Kg3 h5 33. gxh5
+Kg5 34. Rb6 e5 35. Rb5 Kf6 36. h6 Ra7 37. Rb6+ Kg5 38. Re6 f4+ 39. Kh2 Kf5 40.
+Rb6 Kg5 41. b4 Kh4 42. exf4 exf4 43. Re6 e3 44. fxe3 Ra2+ 45. Kg1 Kg3 46. Rg6+
+Kf3 47. exf4 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Training88"]
+[Black "alireza3700"]
+[Result "1/2-1/2"]
+[ECO "A00"]
+[WhiteElo "2345"]
+[BlackElo "2366"]
+[PlyCount "137"]
+[EventDate "2020.??.??"]
+
+1. b4 b6 2. Bb2 Bb7 3. b5 e6 4. e3 c5 5. Be2 d5 6. Bf3 Nf6 7. c4 dxc4 8. Bxb7
+Nbd7 9. Bxa8 Qb8 10. Bc6 Bd6 11. a4 O-O 12. Na3 Ne5 13. Nf3 Nd3+ 14. Ke2 Nxb2
+15. Qc2 Nd3 16. Nxc4 Nb4 17. Qb3 Rd8 18. Rhd1 a5 19. d4 cxd4 20. Nxd4 Bc5 21.
+Nf3 h6 22. Rxd8+ Qxd8 23. Rd1 Qc7 24. Nce5 g5 25. h3 Kg7 26. g4 Nbd5 27. Qb2
+Bb4 28. Nd7 Kg6 29. Nxf6 Nxf6 30. Qe5 Qe7 31. Be4+ Kg7 32. Nd4 Bc5 33. Nf5+
+exf5 34. Qxe7 Bxe7 35. gxf5 Nxe4 36. f3 Nc3+ 37. Kd2 Nxd1 38. Kxd1 Kf6 39. e4
+Ke5 40. Ke2 Bc5 41. Kd3 Kf4 42. Kc3 Kxf3 43. f6 g4 44. e5 gxh3 45. e6 fxe6 46.
+f7 Bf8 47. Kd3 h2 48. Kd4 h1=Q 49. Ke5 Qd1 50. Kxe6 Qd8 51. Kf5 Qe7 52. Kg6
+Qxf7+ 53. Kxf7 Ke4 54. Kxf8 Kd4 55. Kg7 Kc4 56. Kxh6 Kb4 57. Kg5 Kxa4 58. Kf4
+Kxb5 59. Ke3 Kb4 60. Kd3 Kb3 61. Kd2 a4 62. Kc1 a3 63. Kb1 a2+ 64. Ka1 Kc3 65.
+Kxa2 b5 66. Kb1 b4 67. Kc1 Kb3 68. Kb1 Kc3 69. Ka1 1/2-1/2
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "G0DZILLA"]
+[Black "DoctorFromGallifrey"]
+[Result "0-1"]
+[ECO "A40"]
+[WhiteElo "2641"]
+[BlackElo "2555"]
+[PlyCount "94"]
+[EventDate "2020.??.??"]
+
+1. d4 g6 2. Bf4 Bg7 3. e3 c5 4. c3 Qb6 5. Qb3 Qxb3 6. axb3 cxd4 7. exd4 Nc6 8.
+Nf3 a6 9. Nbd2 Nf6 10. Nc4 Nd5 11. Bg3 b5 12. Ne3 Nxe3 13. fxe3 Bb7 14. Bc4
+bxc4 15. bxc4 O-O 16. b4 d6 17. Kd2 Nb8 18. Ra5 Nd7 19. Rha1 Rfc8 20. c5 d5 21.
+Bh4 f6 22. Ne1 e5 23. Nd3 f5 24. Be7 Kf7 25. Bd6 Ke6 26. Rb1 Bc6 27. Rba1 Bb5
+28. Ne1 f4 29. Nc2 fxe3+ 30. Kxe3 exd4+ 31. Nxd4+ Bxd4+ 32. Kxd4 Nf6 33. Re1+
+Ne4 34. c4 Bxc4 35. Rxe4+ dxe4 36. Kxc4 e3 37. Ra3 Kd7 38. Rxe3 Re8 39. Rd3 Kc6
+40. Bg3 Re4+ 41. Kc3 Re6 42. Bf4 Rae8 43. Bg3 Re3 44. Kd4 R8e4+ 45. Kc3 Kb5 46.
+Rxe3 Rxe3+ 47. Kd4 Rb3 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Garrincha1"]
+[Black "pupilochess86"]
+[Result "1-0"]
+[ECO "D00"]
+[WhiteElo "2492"]
+[BlackElo "2508"]
+[PlyCount "65"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 d5 2. d4 dxe4 3. Nc3 Nf6 4. f3 exf3 5. Nxf3 Bg4 6. Be3 e6 7. Bd3 Nbd7 8.
+Qe2 c6 9. h3 Bh5 10. O-O-O Qa5 11. Bd2 Bb4 12. a3 Bxc3 13. Bxc3 Qc7 14. Rhf1
+O-O-O 15. Bd2 b5 16. Kb1 Nd5 17. Rc1 N7b6 18. c4 bxc4 19. Bxc4 Bxf3 20. Ba6+
+Kb8 21. Rxf3 Rhe8 22. Rb3 e5 23. Qf1 e4 24. a4 e3 25. Be1 e2 26. Bxe2 Ka8 27.
+Bg3 Qe7 28. Bf3 Rc8 29. a5 Nd7 30. Rxc6 Rxc6 31. Bxd5 Rec8 32. Qf3 Qd6 33. Bxd6
+1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "chipmunknau"]
+[Black "gomelbel"]
+[Result "1-0"]
+[ECO "A49"]
+[WhiteElo "2572"]
+[BlackElo "2443"]
+[PlyCount "87"]
+[EventDate "2020.??.??"]
+
+1. d4 d5 2. Nf3 e6 3. g3 c5 4. Bg2 Nc6 5. O-O Nf6 6. c4 cxd4 7. cxd5 Nxd5 8.
+Nxd4 Nxd4 9. Qxd4 Qf6 10. Qa4+ Bd7 11. Qb3 Bc6 12. Nc3 Nxc3 13. Bxc6+ bxc6 14.
+bxc3 Be7 15. Qb7 O-O 16. Bf4 e5 17. Be3 Rfc8 18. Rab1 h6 19. Rfd1 Qe6 20. Rd7
+Bf6 21. Rbd1 Qxa2 22. Rc7 Rf8 23. Qxc6 e4 24. Bxh6 Qe6 25. Be3 Qxc6 26. Rxc6
+Rfc8 27. Ra6 Rxc3 28. Rd7 Rcc8 29. Kg2 Rd8 30. Rdxa7 Rxa7 31. Rxa7 Re8 32. h4
+g6 33. Kh3 Kg7 34. g4 Re7 35. Ra6 Re6 36. Ra4 Be7 37. g5 f6 38. Kg4 f5+ 39. Kg3
+Bd6+ 40. Bf4 Bxf4+ 41. Kxf4 Re7 42. Ra6 Kf7 43. Rf6+ Kg7 44. e3 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "PimponNicois"]
+[Black "fedateam"]
+[Result "1-0"]
+[ECO "B21"]
+[WhiteElo "2329"]
+[BlackElo "2351"]
+[PlyCount "73"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 c5 2. Nf3 a6 3. d4 cxd4 4. c3 dxc3 5. Nxc3 Nc6 6. Bc4 e6 7. O-O b5 8. Bb3
+Qc7 9. a4 b4 10. Nd5 exd5 11. exd5 Na5 12. Re1+ Kd8 13. Ne5 d6 14. Nc6+ Nxc6
+15. dxc6 Nf6 16. Qf3 a5 17. Bg5 Be7 18. h3 Ra6 19. Rac1 Rf8 20. Re2 h6 21. Bf4
+Be6 22. Bxe6 fxe6 23. Rxe6 g5 24. Bxd6 Bxd6 25. Rxf6 Rxf6 26. Qxf6+ Kc8 27.
+Qh8+ Qd8 28. Qxh6 Bf4 29. Qe6+ Kc7 30. Qf7+ Kd6 31. Rd1+ Ke5 32. Rxd8 Rxc6 33.
+Qe8+ Re6 34. Qb5+ Kf6 35. g3 Bc7 36. Rf8+ Kg7 37. Re8 1-0
+
+[Event "Rated Blitz tournament hM7PUvgg"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "GlennTipton"]
+[Black "Velociraptorblue"]
+[Result "1-0"]
+[ECO "C42"]
+[WhiteElo "2451"]
+[BlackElo "2389"]
+[PlyCount "81"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 e5 2. Nf3 Nf6 3. Nxe5 d6 4. Nf3 Nxe4 5. c3 Be7 6. Qa4+ Nc6 7. Qxe4 O-O 8.
+Bd3 g6 9. O-O Re8 10. Qa4 Bd7 11. Qc2 Bf6 12. h3 Qc8 13. Nh2 Ne5 14. Be4 c6 15.
+d4 Nc4 16. Bd3 d5 17. Nd2 Nd6 18. Ndf3 h5 19. Bg5 Bg7 20. Rae1 Nf5 21. Ne5 f6
+22. Nxd7 Qxd7 23. Bxf5 gxf5 24. Bf4 Re4 25. Rxe4 fxe4 26. Qd2 Kh7 27. Re1 Rg8
+28. Re3 Bh8 29. Rg3 Qf5 30. Rxg8 Kxg8 31. Nf1 Kf7 32. Ng3 Qg6 33. h4 Bg7 34.
+Qe2 Qg4 35. Qxg4 hxg4 36. Nh5 Bf8 37. Kh2 f5 38. Be5 Be7 39. Kg3 c5 40. Nf4
+cxd4 41. cxd4 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "mux77"]
+[Black "zaqvili"]
+[Result "1-0"]
+[ECO "A05"]
+[WhiteElo "2428"]
+[BlackElo "2339"]
+[PlyCount "95"]
+[EventDate "2020.??.??"]
+
+1. Nf3 Nf6 2. g3 g6 3. Bg2 Bg7 4. O-O O-O 5. d4 c5 6. c4 cxd4 7. Nxd4 d6 8. Nc3
+Nc6 9. b3 Nxd4 10. Qxd4 Qa5 11. Bd2 Qh5 12. f3 Ng4 13. Qxg7+ Kxg7 14. fxg4 Bxg4
+15. Ne4 Bh3 16. Bc3+ f6 17. c5 Bxg2 18. Kxg2 Qxe2+ 19. Nf2 dxc5 20. Rae1 Qc2
+21. Rxe7+ Rf7 22. Re3 Kg8 23. Kg1 Rd8 24. Ne4 Rd1 25. Nxf6+ Rxf6 26. Bxf6 Rxf1+
+27. Kxf1 Qc1+ 28. Kf2 Qd2+ 29. Kf3 Qd5+ 30. Ke2 Qg2+ 31. Kd3 Qxh2 32. Bg5 Qxa2
+33. Ke4 Qc2+ 34. Kf4 b5 35. Re8+ Kf7 36. Re7+ Kf8 37. Re5 Qd2+ 38. Kg4 c4 39.
+bxc4 bxc4 40. Bxd2 Kf7 41. Bc3 Kf6 42. Ra5+ Ke6 43. Kg5 h5 44. Kxg6 h4 45. gxh4
+a6 46. h5 Kd6 47. h6 Kc6 48. h7 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "hungzhao"]
+[Black "Nurgyul"]
+[Result "0-1"]
+[ECO "B15"]
+[WhiteElo "2630"]
+[BlackElo "2551"]
+[PlyCount "112"]
+[EventDate "2020.??.??"]
+
+1. e4 c6 2. d4 d5 3. Nd2 dxe4 4. Nxe4 Nf6 5. Nxf6+ exf6 6. c3 Bd6 7. Bd3 O-O 8.
+Ne2 Re8 9. Qc2 h5 10. Bd2 Nd7 11. O-O-O Nf8 12. h3 Be6 13. Kb1 b5 14. g4 h4 15.
+Rhg1 g6 16. f4 Bd5 17. b3 a5 18. c4 bxc4 19. bxc4 Bf3 20. Rde1 Bxe2 21. Rxe2
+Qb6+ 22. Qb2 Qc7 23. Rxe8 Rxe8 24. Qc2 Bxf4 25. Bc3 Ne6 26. Bxg6 fxg6 27. Qxg6+
+Ng7 28. Qxf6 Rb8+ 29. Kc2 Qf7 30. Qxf7+ Kxf7 31. g5 Kg6 32. Rg4 Bxg5 33. Bxa5
+Nf5 34. Bd2 Nxd4+ 35. Rxd4 Bxd2 36. Rxd2 Ra8 37. Kb3 Rf8 38. Rd4 Rf3+ 39. Kb4
+Rxh3 40. Rd6+ Kf5 41. Rxc6 Rh2 42. Rc8 Rxa2 43. c5 Rh2 44. c6 Rc2 45. Kb5 Ke6
+46. Re8+ Kf7 47. Rh8 h3 48. Rxh3 Rb2+ 49. Kc5 Rc2+ 50. Kd6 Rd2+ 51. Kc7 Rc2 52.
+Re3 Kf6 53. Kd7 Rd2+ 54. Kc8 Rc2 55. c7 Rc4 56. Re1 Kf7 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "LordBendtner99"]
+[Black "Chipodejunin"]
+[Result "0-1"]
+[ECO "A00"]
+[WhiteElo "2491"]
+[BlackElo "2463"]
+[PlyCount "124"]
+[EventDate "2020.??.??"]
+
+1. g3 Nf6 2. f3 e6 3. Nh3 Be7 4. Nf2 O-O 5. Bg2 b6 6. O-O Bb7 7. d3 d5 8. e4
+Nbd7 9. c3 c5 10. f4 Qc7 11. e5 Ne8 12. Nd2 f5 13. d4 Ba6 14. Re1 g6 15. Nf3
+Ng7 16. Bf1 Bxf1 17. Kxf1 c4 18. Kg2 b5 19. Be3 a5 20. Qd2 b4 21. h4 a4 22. Ng5
+h6 23. Nf3 h5 24. Ng5 a3 25. cxb4 axb2 26. Qxb2 Rfb8 27. a3 Nb6 28. Nd1 Qc6 29.
+Nc3 Na4 30. Nxa4 Rxa4 31. Nf3 Ne8 32. Qc3 Nc7 33. Nd2 Nb5 34. Qc1 Rba8 35. Nb1
+c3 36. Re2 Qc4 37. Kf2 Bd8 38. Rc2 Rc8 39. Qd1 Bb6 40. Kf3 Bxd4 41. Nxc3 Bxc3
+42. Rac1 d4 43. Rxc3 Nxc3 44. Qxd4 Qxd4 45. Bxd4 Rxa3 46. Kg2 Rc4 47. Bc5 Rb3
+48. Kh3 Kf7 49. Ra1 Nd5 50. Ra7+ Ke8 51. Ra8+ Kd7 52. Ra7+ Kc6 53. Ra6+ Kb5 54.
+Rxe6 Rcc3 55. Rxg6 Kc4 56. Rg5 Rxg3+ 57. Rxg3 Nxf4+ 58. Kh2 Rb2+ 59. Rg2 Nxg2
+60. Kh1 Ne3 61. e6 Nd5 62. e7 Nxe7 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Antropterix"]
+[Black "Realblindmuddy"]
+[Result "1/2-1/2"]
+[ECO "A45"]
+[WhiteElo "2316"]
+[BlackElo "2393"]
+[PlyCount "106"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 Nf6 2. g3 e6 3. Bg2 d5 4. Nf3 Be7 5. O-O O-O 6. b3 b6 7. Bb2 Bb7 8. Nbd2
+c5 9. e3 Nbd7 10. Re1 Rc8 11. c4 dxc4 12. Nxc4 cxd4 13. Qxd4 Nc5 14. Red1 Qxd4
+15. Rxd4 Rfd8 16. Rad1 Rxd4 17. Nxd4 Bxg2 18. Kxg2 h6 19. Ne5 Kf8 20. Nec6 Rc7
+21. Nxe7 Kxe7 22. Ba3 Nfd7 23. Nb5 Rb7 24. Nd6 Rb8 25. Ne4 Rc8 26. Rc1 a5 27.
+Kf1 f5 28. Nxc5 Nxc5 29. Bxc5+ Rxc5 30. Rxc5 bxc5 31. Ke2 Kd6 32. Kd3 Kd5 33.
+f3 g5 34. h4 g4 35. fxg4 fxg4 36. e4+ Ke5 37. Ke3 h5 38. a4 Kf6 39. Kf4 e5+ 40.
+Ke3 Ke6 41. Kd3 Kd6 42. Kc3 Kc7 43. Kc2 Kd6 44. Kd2 Kc7 45. Kc3 Kd6 46. Kd3 Kc7
+47. Ke3 Kd6 48. Ke2 Kd7 49. Kd2 Kd6 50. Kd3 Kc7 51. Kc3 Kd6 52. Kc4 Kc6 53. Kd3
+Kd6 1/2-1/2
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "zenon011"]
+[Black "Northridgehawk"]
+[Result "1-0"]
+[ECO "C50"]
+[WhiteElo "2329"]
+[BlackElo "2364"]
+[PlyCount "41"]
+[EventDate "2020.??.??"]
+
+1. e4 e5 2. Nf3 Nc6 3. Bc4 Bc5 4. d3 d6 5. Nc3 Bg4 6. Bb3 Nge7 7. Be3 O-O 8. h3
+Bh5 9. g4 Bg6 10. Qd2 Nd4 11. Bxd4 exd4 12. Ne2 d5 13. e5 Nc6 14. h4 h5 15.
+O-O-O Re8 16. Nf4 Nxe5 17. Nxe5 Rxe5 18. gxh5 Bf5 19. Rdg1 Qf6 20. Nxd5 Qh6 21.
+Qxh6 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Morphysher"]
+[Black "fusionpro"]
+[Result "0-1"]
+[ECO "E67"]
+[WhiteElo "2319"]
+[BlackElo "2432"]
+[PlyCount "68"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. c4 Nf6 2. Nf3 g6 3. g3 Bg7 4. Bg2 d6 5. O-O O-O 6. d4 Nbd7 7. Nc3 e5 8. dxe5
+dxe5 9. e4 Re8 10. Bg5 c6 11. Qd2 Qc7 12. Rad1 Nc5 13. Bxf6 Bxf6 14. b3 Bg4 15.
+h3 Bxf3 16. Bxf3 Ne6 17. Ne2 Be7 18. Bg2 Bc5 19. Qc3 Bd4 20. Nxd4 Nxd4 21. Rfe1
+c5 22. Rd2 Rad8 23. Qe3 Re6 24. Red1 Rf6 25. Kh2 Kg7 26. h4 h5 27. Qg5 Qe7 28.
+Qe3 Qc7 29. Qg5 b6 30. Kh1 a5 31. f4 exf4 32. e5 Rf5 33. Rxd4 cxd4 34. gxf4
+Rxg5 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Olaffo"]
+[Black "telodijomonstruo"]
+[Result "0-1"]
+[ECO "A04"]
+[WhiteElo "2519"]
+[BlackElo "2513"]
+[PlyCount "106"]
+[EventDate "2020.??.??"]
+
+1. Nf3 Nc6 2. b3 e5 3. Bb2 e4 4. Nd4 Nf6 5. Nxc6 dxc6 6. c4 Bd6 7. g3 Ng4 8.
+Bg2 h5 9. Bxe4 Qe7 10. Bg2 h4 11. Nc3 hxg3 12. hxg3 Rxh1+ 13. Bxh1 Qf6 14. Bf3
+Qh6 15. Qc2 Nxf2 16. Ne4 Nxe4 17. Qxe4+ Be6 18. O-O-O O-O-O 19. Rh1 Qg5 20. g4
+Bb4 21. Qe5 Bxd2+ 22. Kb1 Qxe5 23. Bxe5 f6 24. Bb2 Rd7 25. Rh8+ Rd8 26. Rh7 Rg8
+27. Be4 Bg5 28. Bf5 Bxf5+ 29. gxf5 Kd7 30. Kc2 Ke7 31. Kd3 Kf7 32. Ke4 Rd8 33.
+Bd4 Re8+ 34. Kd3 b6 35. b4 Rd8 36. c5 a5 37. a3 axb4 38. axb4 Ra8 39. e4 bxc5
+40. Bxc5 Ra3+ 41. Kc4 Ra1 42. Rh8 Rc1+ 43. Kd3 Rd1+ 44. Ke2 Rd2+ 45. Ke1 g6 46.
+Rf8+ Kg7 47. Rc8 gxf5 48. Rxc7+ Kg6 49. exf5+ Kxf5 50. Rf7 Ke4 51. Kf1 Kd3 52.
+Kg1 Rd1+ 53. Kg2 Rd2+ 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "LordGrim2500"]
+[Black "AlexMitAlex"]
+[Result "1-0"]
+[ECO "B95"]
+[WhiteElo "2463"]
+[BlackElo "2310"]
+[PlyCount "65"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. Qd2 Be7 8. f3
+h6 9. Be3 Bd7 10. O-O-O Nc6 11. Nb3 b5 12. Kb1 b4 13. Ne2 a5 14. Ned4 Ne5 15.
+Nb5 Bxb5 16. Bxb5+ Ned7 17. e5 Nd5 18. Nd4 O-O 19. Nc6 Qe8 20. Nxe7+ Qxe7 21.
+exd6 Qxd6 22. Bxd7 Qxd7 23. Bxh6 gxh6 24. Qxh6 Rfe8 25. Rd4 f5 26. g4 Qg7 27.
+Qd2 f4 28. Rd1 Rac8 29. h4 Rb8 30. Re1 Nc3+ 31. Ka1 Nd5 32. h5 Rbd8 33. g5 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Frogkiller"]
+[Black "Karabakh-Azerbaijan"]
+[Result "0-1"]
+[ECO "A00"]
+[WhiteElo "2374"]
+[BlackElo "2449"]
+[PlyCount "80"]
+[EventDate "2020.??.??"]
+
+1. g3 Nf6 2. Bg2 g6 3. Nf3 Bg7 4. O-O O-O 5. d4 d6 6. c4 Nbd7 7. Nc3 Re8 8. e4
+e5 9. h3 exd4 10. Nxd4 a6 11. Be3 Rb8 12. Qc2 Ne5 13. b3 c5 14. Rad1 b5 15.
+Nde2 bxc4 16. bxc4 Nxc4 17. Bc1 Bb7 18. f4 Na5 19. e5 Bxg2 20. Kxg2 Nh5 21.
+Rxd6 Qc7 22. Nd5 Qb7 23. Kh2 Rbd8 24. Rxd8 Rxd8 25. Ndc3 Nc4 26. Qe4 Qxe4 27.
+Nxe4 f5 28. Nxc5 Bf8 29. Ne6 Rc8 30. Nxf8 Kxf8 31. Nd4 Ng7 32. Rf2 Ke7 33. Rc2
+Ne6 34. Nxe6 Kxe6 35. Kg2 Kd5 36. Kf2 a5 37. Ke2 a4 38. Kd3 Rc6 39. Be3 Nxe3
+40. Rc5+ Rxc5 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "JLeon"]
+[Black "Evgen_88"]
+[Result "1/2-1/2"]
+[ECO "A45"]
+[WhiteElo "2558"]
+[BlackElo "2549"]
+[PlyCount "101"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 Nf6 2. Bg5 Ne4 3. h4 c5 4. dxc5 Nxg5 5. hxg5 Qa5+ 6. Nc3 g6 7. Qd4 Rg8 8.
+Rxh7 Nc6 9. Qd2 Qxc5 10. Nf3 d6 11. e4 Bg4 12. Qd5 Qxd5 13. Nxd5 Rc8 14. Bc4
+Be6 15. Bb3 Na5 16. Ba4+ Kd8 17. O-O-O Rc4 18. Nc3 Bg7 19. Bb3 Nxb3+ 20. axb3
+Rc5 21. Nd5 Kd7 22. Kb1 a5 23. c4 b5 24. Nd4 bxc4 25. bxc4 Bxd4 26. Rxd4 Rb8
+27. f4 a4 28. Ka2 Rb3 29. f5 gxf5 30. exf5 Bxd5 31. Rxd5 Rxc4 32. Rd2 Rg4 33.
+Rxf7 Rxg5 34. f6 Re3 35. fxe7 Rxe7 36. Rf4 Rg3 37. Rxa4 Reg7 38. Rad4 Ke6 39.
+Rxd6+ Ke5 40. R6d5+ Ke6 41. R5d4 Rxg2 42. Rxg2 Rxg2 43. Ka3 Ke5 44. b3 Rg3 45.
+Rd8 Ke6 46. Rd1 Ke7 47. Ka4 Rd3 48. b4 Rxd1 49. Kb5 Rb1 50. Kc4 Rxb4+ 51. Kxb4
+1/2-1/2
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "cubanito2002"]
+[Black "ivanoob"]
+[Result "1-0"]
+[ECO "D14"]
+[WhiteElo "2673"]
+[BlackElo "2630"]
+[PlyCount "89"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 d5 2. c4 c6 3. Nf3 Nf6 4. cxd5 cxd5 5. Nc3 Nc6 6. Bf4 Bf5 7. e3 e6 8. Qb3
+Bb4 9. Bb5 Bxc3+ 10. Qxc3 O-O 11. O-O Rc8 12. Rac1 a6 13. Bxc6 Rxc6 14. Qa3 Bc2
+15. Ne5 Rc8 16. b3 Qb6 17. Qb2 Bf5 18. f3 h6 19. g4 Bh7 20. Rc3 Qa7 21. Rfc1
+Qa8 22. h4 Rfe8 23. Rc7 Rxc7 24. Rxc7 Rc8 25. Qc1 Rxc7 26. Qxc7 Qf8 27. Qxb7
+Bb1 28. Qxa6 Qb4 29. Qe2 Qa3 30. g5 hxg5 31. Bxg5 Bxa2 32. Bxf6 gxf6 33. Ng4 f5
+34. Nf6+ Kg7 35. Qg2+ Kf8 36. Qg8+ Ke7 37. Qg5 Qc1+ 38. Kh2 Kf8 39. h5 Qd2+ 40.
+Kh3 Bxb3 41. h6 Qd1 42. Qg2 Bc2 43. h7 Ke7 44. h8=Q f4 45. Ng8+ 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "vava05"]
+[Black "FedaMaster"]
+[Result "0-1"]
+[ECO "B01"]
+[WhiteElo "2399"]
+[BlackElo "2569"]
+[PlyCount "122"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 d5 2. exd5 Qxd5 3. Nc3 Qd6 4. Nb5 Qd8 5. d4 Nf6 6. Be2 a6 7. Na3 b5 8. c3
+Bb7 9. Bf3 Bxf3 10. Qxf3 Nbd7 11. Ne2 e6 12. Nc2 Bd6 13. Bf4 O-O 14. O-O Re8
+15. Bxd6 cxd6 16. Ne3 Nb6 17. Rfe1 a5 18. Rad1 b4 19. c4 Rc8 20. b3 a4 21. Nf4
+axb3 22. axb3 d5 23. cxd5 Nbxd5 24. Nfxd5 Nxd5 25. Nxd5 Qxd5 26. Qxd5 exd5 27.
+Rxe8+ Rxe8 28. Ra1 f6 29. f3 Re3 30. Ra5 Rxb3 31. Rxd5 Rb1+ 32. Kf2 b3 33. Rb5
+b2 34. Rb7 Kf8 35. d5 Ke8 36. d6 Kd8 37. d7 g5 38. Kg3 h5 39. h4 Ke7 40. hxg5
+fxg5 41. Kf2 h4 42. Rb3 Kxd7 43. Rd3+ Kc6 44. Rd2 Kc5 45. Re2 Kd4 46. Rd2+ Kc3
+47. Rd8 Rc1 48. Rc8+ Kd4 49. Rb8 b1=Q 50. Rxb1 Rxb1 51. f4 Rb2+ 52. Kf3 Rb3+
+53. Kg4 Rg3+ 54. Kf5 gxf4 55. Kxf4 Rxg2 56. Kf5 Rg7 57. Ke6 Rg1 58. Kd7 Ke3 59.
+Kc7 Kf2 60. Kd7 Kf3 61. Ke8 Kf4 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "gg-gm-gmg"]
+[Black "HoldenHc"]
+[Result "1-0"]
+[ECO "E14"]
+[WhiteElo "2675"]
+[BlackElo "2565"]
+[PlyCount "55"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 Nf6 2. c4 e6 3. Nf3 b6 4. e3 Bb7 5. Bd3 Be7 6. O-O O-O 7. Nc3 d5 8. Qe2
+Ne4 9. Qc2 f5 10. b3 Nd7 11. Bb2 a6 12. Ne2 Bd6 13. Ne5 Bxe5 14. dxe5 Ndc5 15.
+Rad1 Qe7 16. f3 Nxd3 17. Rxd3 Nc5 18. Ba3 dxc4 19. Qxc4 a5 20. Bxc5 bxc5 21.
+Qc2 Rfd8 22. Rxd8+ Rxd8 23. Rc1 Rd5 24. Qc3 Qd7 25. Nf4 Rd1+ 26. Rxd1 Qxd1+ 27.
+Kf2 Ba6 28. h4 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "vassiukov"]
+[Black "vaillant77"]
+[Result "0-1"]
+[ECO "A00"]
+[WhiteElo "2381"]
+[BlackElo "2410"]
+[PlyCount "64"]
+[EventDate "2020.??.??"]
+
+1. a3 e5 2. b3 g6 3. c3 Bg7 4. d3 Ne7 5. e3 O-O 6. f3 d6 7. g3 Nbc6 8. Bg2 f5
+9. Ne2 Be6 10. O-O Qd7 11. c4 d5 12. Nbc3 e4 13. cxd5 Nxd5 14. Nxd5 Bxa1 15.
+dxe4 fxe4 16. Nef4 exf3 17. Bxf3 Rad8 18. Nxe6 Qxe6 19. Bd2 Be5 20. Nf4 Bxf4
+21. gxf4 Qd6 22. Rf2 Qxa3 23. Qc2 Rf7 24. Be2 Rfd7 25. Bc4+ Kf8 26. Bc3 Qe7 27.
+f5 g5 28. f6 Rd1+ 29. Kg2 Qxe3 30. Qxh7 Qe4+ 31. Rf3 Qxh7 32. Bb4+ Nxb4 0-1
+
+[Event "Rated Rapid game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "BettyBoop53"]
+[Black "Mivo11"]
+[Result "0-1"]
+[ECO "B20"]
+[WhiteElo "2345"]
+[BlackElo "2427"]
+[PlyCount "60"]
+[EventDate "2020.??.??"]
+[EventType "rapid"]
+
+1. e4 c5 2. b4 cxb4 3. d4 e6 4. Nf3 Nf6 5. Bd3 d5 6. e5 Ne4 7. O-O Be7 8. Qe2
+Nc6 9. a3 O-O 10. axb4 Nxb4 11. Bxe4 dxe4 12. Qxe4 Qd5 13. Qg4 Rd8 14. Bh6 Bf8
+15. Nc3 Qc6 16. Ne4 b5 17. h4 Bb7 18. Rfe1 Nxc2 19. Rac1 Nxe1 20. Rxc6 Nxf3+
+21. gxf3 Bxc6 22. h5 Kh8 23. Be3 h6 24. Ng3 b4 25. d5 Bxd5 26. f4 b3 27. Bd4
+Rab8 28. Bb2 Rb4 29. Ne2 Be4 30. Qh4 Rd1+ 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Ayosi"]
+[Black "giorbinky"]
+[Result "0-1"]
+[ECO "B18"]
+[WhiteElo "2369"]
+[BlackElo "2342"]
+[PlyCount "58"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 c6 2. d4 d5 3. Nc3 dxe4 4. Nxe4 Bf5 5. Ng3 Bg6 6. h4 h6 7. N1e2 e5 8. Be3
+exd4 9. Nxd4 Nd7 10. Bd3 Bxd3 11. Qxd3 Ngf6 12. O-O-O Qa5 13. Bd2 Qxa2 14.
+Rhe1+ Kd8 15. Bc3 Nd5 16. Nb3 Nc5 17. Qf5 Nxb3+ 18. cxb3 Qxb3 19. Qxf7 Ba3 20.
+Qxg7 Re8 21. Bf6+ Be7 22. Bxe7+ Kc8 23. Qg4+ Kc7 24. Ba3 a5 25. Bc5 Rxe1 26.
+Rxe1 Rd8 27. Qg7+ Kb8 28. Qe5+ Ka8 29. Ne4 Nb4 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "RigelStar"]
+[Black "FinalCut"]
+[Result "1-0"]
+[ECO "A43"]
+[WhiteElo "2410"]
+[BlackElo "2448"]
+[PlyCount "107"]
+[EventDate "2020.??.??"]
+
+1. d4 c5 2. Nf3 cxd4 3. Nxd4 Nc6 4. Nxc6 dxc6 5. e4 Qxd1+ 6. Kxd1 Nf6 7. f3 g6
+8. Be3 Bg7 9. c3 Be6 10. Kc2 O-O-O 11. Nd2 h5 12. Bxa7 h4 13. Bb6 Rd7 14. Rd1
+h3 15. g3 g5 16. Nc4 Bxc4 17. Bxc4 e6 18. Rxd7 Nxd7 19. Be3 Bf6 20. Rd1 Rg8 21.
+b4 g4 22. f4 Rd8 23. Be2 Nf8 24. Rxd8+ Bxd8 25. Bxg4 Ng6 26. Bxh3 Kc7 27. Bf1
+Bf6 28. e5 Be7 29. h4 Nf8 30. h5 Nd7 31. g4 Bf8 32. g5 b6 33. h6 c5 34. bxc5
+Nxc5 35. h7 Bg7 36. Bg2 Nd7 37. Kd3 Nf8 38. Be4 b5 39. Kd4 Nd7 40. c4 bxc4 41.
+Kxc4 Nf8 42. Kb5 Kb8 43. Bb6 Nd7 44. a4 Nxb6 45. Kxb6 Bf8 46. Kc6 Ka7 47. Kd7
+Bg7 48. Ke7 f5 49. Kf7 Bh8 50. Bf3 Bxe5 51. g6 Bxf4 52. h8=Q e5 53. Qd8 e4 54.
+Qd7+ 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Adrian_DelaCruz"]
+[Black "Routmund1976"]
+[Result "1/2-1/2"]
+[ECO "D02"]
+[WhiteElo "2349"]
+[BlackElo "2364"]
+[PlyCount "150"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. Nf3 d5 2. d4 Nf6 3. g3 Bf5 4. c4 c6 5. Bg2 e6 6. O-O h6 7. Nc3 Be7 8. Qb3
+Qb6 9. c5 Qc7 10. Bf4 Qc8 11. Rfe1 Nbd7 12. Ne5 O-O 13. e4 Nxe4 14. Nxe4 Bxe4
+15. Bxe4 dxe4 16. Rxe4 Nf6 17. Ree1 Nd5 18. Bd2 Bf6 19. Re2 Bxe5 20. Rxe5 b6
+21. Rc1 b5 22. Qf3 Ne7 23. Qg4 Ng6 24. h4 Nxe5 25. dxe5 f5 26. exf6 Rxf6 27.
+Bc3 Rf7 28. Rd1 b4 29. Be5 Qf8 30. Qxe6 Kh7 31. Bd6 Qe8 32. Qg4 Rd8 33. Qxb4
+Qe2 34. Rf1 Re8 35. Qd4 Re6 36. a3 Re4 37. Qc3 Rf3 38. Qc1 Rb3 39. Bf4 Rxb2 40.
+Be3 Qc2 41. Qe1 Rb3 42. a4 Rxa4 43. Bf4 Re4 44. Qa1 Qxc5 45. Rc1 Qd5 46. Qxa7
+Rb2 47. Be3 Qe6 48. Qa3 Rb7 49. Qd3 Qg6 50. Kg2 Rbe7 51. Bc5 R4e6 52. Qxg6+
+Kxg6 53. Bxe7 Rxe7 54. Rxc6+ Kh7 55. h5 Re5 56. g4 Re4 57. Kg3 Ra4 58. Rc7 Rb4
+59. Re7 Rc4 60. f4 Rc3+ 61. Kf2 Rc4 62. Kf3 Rc3+ 63. Ke4 Rc4+ 64. Kf5 Rc5+ 65.
+Re5 Rc6 66. g5 hxg5 67. fxg5 Rc1 68. Re8 Rf1+ 69. Kg4 Rg1+ 70. Kf4 Rf1+ 71. Kg3
+Rg1+ 72. Kf4 Rf1+ 73. Kg4 Rg1+ 74. Kh4 Rh1+ 75. Kg4 Rg1+ 1/2-1/2
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "allan-cantonjos"]
+[Black "Pharaohs-Curse"]
+[Result "1-0"]
+[ECO "D01"]
+[WhiteElo "2405"]
+[BlackElo "2357"]
+[PlyCount "79"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 d5 2. Nc3 Nf6 3. Nf3 Bf5 4. Bg5 Nbd7 5. Qd2 e6 6. Ne5 Be7 7. f3 O-O 8. h4
+h6 9. Bxf6 Nxf6 10. g4 Bh7 11. g5 hxg5 12. hxg5 Nd7 13. f4 Nxe5 14. dxe5 d4 15.
+Nb5 c5 16. Na3 b5 17. Bg2 Rb8 18. O-O-O c4 19. Qxd4 Qxd4 20. Rxd4 Bxa3 21. bxa3
+Rfc8 22. Rd7 a5 23. Rhd1 b4 24. axb4 axb4 25. Bb7 Rf8 26. Rc7 Bf5 27. Rdd7 Bg6
+28. Rxc4 Rfd8 29. Rcc7 Rxd7 30. Rxd7 Bf5 31. e4 Bg4 32. Kb2 Be2 33. Kb3 Bb5 34.
+Rc7 Rd8 35. Kxb4 Bf1 36. f5 Rd4+ 37. c4 Rd1 38. g6 Rb1+ 39. Ka3 exf5 40. Rc8#
+1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Northridgehawk"]
+[Black "zenon011"]
+[Result "0-1"]
+[ECO "C28"]
+[WhiteElo "2358"]
+[BlackElo "2335"]
+[PlyCount "76"]
+[EventDate "2020.??.??"]
+
+1. e4 e5 2. Nc3 Nc6 3. Bc4 Nf6 4. d3 Bc5 5. f4 d6 6. f5 Bd7 7. g4 h6 8. h4 Qe7
+9. Qf3 O-O-O 10. Be3 Nd4 11. Qg2 Nxc2+ 12. Qxc2 Bxe3 13. Ke2 Bd4 14. Nf3 Bc6
+15. g5 hxg5 16. hxg5 Ng4 17. Nd5 Bxd5 18. Bxd5 Ne3 19. Qa4 Kb8 20. Qb5 Bb6 21.
+Rac1 c6 22. Bxc6 bxc6 23. Qxc6 Rxh1 24. Rxh1 Qc7 25. Qxc7+ Kxc7 26. Rh7 Rg8 27.
+Nh4 Nc2 28. f6 Nd4+ 29. Kd2 Ne6 30. g6 fxg6 31. f7 Rf8 32. Nxg6 Rxf7 33. Rh8
+Rf6 34. Ne7 Kd7 35. Nd5 Rf2+ 36. Kc3 Bd4+ 37. Kc4 Rxb2 38. Ra8 Nc7 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Ganziitoo"]
+[Black "estocastico"]
+[Result "0-1"]
+[ECO "B10"]
+[WhiteElo "2408"]
+[BlackElo "2581"]
+[PlyCount "82"]
+[EventDate "2020.??.??"]
+
+1. e4 c6 2. Nf3 d5 3. exd5 cxd5 4. d4 Nf6 5. Bb5+ Nc6 6. c4 Bg4 7. Qa4 Bd7 8.
+O-O a6 9. Bxc6 Bxc6 10. Qb3 dxc4 11. Qxc4 Bxf3 12. gxf3 e6 13. Nc3 Be7 14. Re1
+O-O 15. Bg5 Rc8 16. Qb3 b5 17. Rad1 Nd5 18. Bxe7 Nxe7 19. d5 exd5 20. Nxd5 Nxd5
+21. Rxd5 Qh4 22. Qe3 Rc6 23. Rg5 h6 24. Rg3 Re6 25. Qd2 Rd8 26. Qc1 Qc4 27. Qb1
+Qd3 28. Qxd3 Rxe1+ 29. Qf1 Rdd1 30. Qxe1 Rxe1+ 31. Kg2 Re2 32. f4 Rc2 33. Ra3
+Rxb2 34. Rxa6 g6 35. Kg3 Kg7 36. Rb6 b4 37. h4 h5 38. Rb5 Rb1 39. Kf3 Rc1 40.
+f5 Rc3+ 41. Kf4 gxf5 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "UptownExpress"]
+[Black "Gambitopy"]
+[Result "1-0"]
+[ECO "B08"]
+[WhiteElo "2303"]
+[BlackElo "2306"]
+[PlyCount "75"]
+[EventDate "2020.??.??"]
+
+1. e4 d6 2. d4 Nf6 3. Nc3 g6 4. h3 Bg7 5. Nf3 O-O 6. Be3 a5 7. Bc4 c6 8. a4
+Nbd7 9. e5 Ne8 10. e6 fxe6 11. Bxe6+ Kh8 12. Ng5 Nef6 13. Nf7+ Rxf7 14. Bxf7
+Nf8 15. Bc4 Bf5 16. Bd3 Qd7 17. O-O Ne6 18. Bxf5 gxf5 19. Qf3 Nc7 20. Rad1 Ncd5
+21. Nxd5 cxd5 22. Bg5 Ne4 23. Bf4 e6 24. Rfe1 Qxa4 25. c3 Qb3 26. Qh5 Rg8 27.
+Qf7 e5 28. dxe5 dxe5 29. Bc1 Qb6 30. Qxf5 Nd6 31. Qe6 e4 32. Qxd5 Nb5 33. Qxe4
+Qc7 34. Qe3 Nd6 35. Qd3 Nc4 36. Qd6 Qc8 37. Rd3 Bf6 38. Rg3 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Maxterlopez"]
+[Black "FerociousLion98999"]
+[Result "1-0"]
+[ECO "C58"]
+[WhiteElo "2639"]
+[BlackElo "2597"]
+[PlyCount "49"]
+[EventDate "2020.??.??"]
+
+1. e4 e5 2. Nf3 Nc6 3. Bc4 Nf6 4. Ng5 d5 5. exd5 Na5 6. Bb5+ c6 7. dxc6 bxc6 8.
+Bd3 h6 9. Ne4 Nd5 10. O-O Be7 11. Re1 O-O 12. Ng3 Nf4 13. Bf5 Nc4 14. d3 Nd6
+15. Bxc8 Rxc8 16. Rxe5 Ng6 17. Re1 Bf6 18. Nd2 Qb6 19. Nde4 Nxe4 20. Nxe4 Be5
+21. Qh5 Rfe8 22. Rb1 Qa5 23. Bd2 Bxh2+ 24. Qxh2 Qh5 25. Qxh5 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "ajedrez2021"]
+[Black "sutcunuri"]
+[Result "0-1"]
+[ECO "A04"]
+[WhiteElo "2582"]
+[BlackElo "2530"]
+[PlyCount "44"]
+[EventDate "2020.??.??"]
+
+1. Nf3 c5 2. g3 g6 3. Bg2 Bg7 4. O-O Nc6 5. d4 cxd4 6. b3 e5 7. Bb2 Nge7 8. c3
+dxc3 9. Nxc3 d5 10. e4 d4 11. Ne2 O-O 12. Ne1 f5 13. Nd3 fxe4 14. Bxe4 Bf5 15.
+f3 Bxe4 16. fxe4 Qd7 17. Qc2 Qh3 18. Qc4+ Kh8 19. Rf7 Rxf7 20. Qxf7 Rf8 21. Qc4
+Bh6 22. Bc1 Rf1# 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "kingcobra23"]
+[Black "wsxcde"]
+[Result "1-0"]
+[ECO "B06"]
+[WhiteElo "2303"]
+[BlackElo "2370"]
+[PlyCount "75"]
+[EventDate "2020.??.??"]
+
+1. e4 g6 2. h4 h5 3. d4 Bg7 4. Nc3 d6 5. Bg5 Nf6 6. e5 dxe5 7. dxe5 Qxd1+ 8.
+Rxd1 Ng4 9. Nd5 f6 10. Nxc7+ Kf7 11. exf6 exf6 12. Bf4 Be6 13. Nxa8 Nc6 14. Nc7
+Bxa2 15. b3 f5 16. Bc4+ Ke7 17. Bg5+ Kf8 18. Ne6+ Kg8 19. Rd7 Bc3+ 20. Kf1 b5
+21. Bd5 Nb4 22. Nf4+ Nxd5 23. Nxd5 Rh7 24. Rxh7 Kxh7 25. Nxc3 a6 26. Nxa2 Ne5
+27. Nc3 Nc6 28. Nf3 Nd4 29. Nxd4 b4 30. Rh3 a5 31. Ncb5 a4 32. Re3 f4 33. Re7+
+Kg8 34. bxa4 Kf8 35. Ne6+ Kg8 36. Nd6 f3 37. Rg7+ Kh8 38. Nf7# 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "BillyLaimbeer"]
+[Black "pmlmail"]
+[Result "0-1"]
+[ECO "A49"]
+[WhiteElo "2377"]
+[BlackElo "2479"]
+[PlyCount "138"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. Nf3 Nf6 2. d4 g6 3. Nc3 d5 4. Bg5 Ne4 5. e3 Nxc3 6. bxc3 c6 7. c4 Qa5+ 8.
+Qd2 Qxd2+ 9. Nxd2 e6 10. Rb1 b6 11. cxd5 cxd5 12. c4 Bb7 13. cxd5 Bxd5 14. Rb2
+Bd6 15. Bf6 Rg8 16. e4 Bb7 17. Bb5+ Nd7 18. O-O Be7 19. Bxe7 Kxe7 20. Rc1 Rgc8
+21. Rbc2 Rxc2 22. Rxc2 Rc8 23. Rxc8 Bxc8 24. f3 a6 25. Bc4 b5 26. Bb3 f6 27.
+Kf2 Bb7 28. Ke3 e5 29. f4 g5 30. g3 h6 31. Nf3 Kd6 32. dxe5+ fxe5 33. fxg5 hxg5
+34. Nxg5 Ke7 35. h4 Nf6 36. Bd1 b4 37. Kd3 a5 38. Bf3 Ba6+ 39. Kc2 Bc4 40. Kb2
+a4 41. Nh3 Nd7 42. g4 Nc5 43. Nf2 a3+ 44. Kb1 Nd3 45. Nxd3 Bxd3+ 46. Ka1 Kf6
+47. g5+ Kg6 48. Bg2 Be2 49. Bh3 Kh5 50. Bf5 Kxh4 51. g6 Bh5 52. g7 Bf7 53. Bh7
+Kg5 54. g8=Q+ Bxg8 55. Bxg8 Kf4 56. Bd5 Ke3 57. Kb1 Kd2 58. Bb3 Kd3 59. Kc1
+Kxe4 60. Kd2 Kd4 61. Bf7 e4 62. Kc2 e3 63. Kb3 e2 64. Bh5 e1=Q 65. Ka4 Qc3 66.
+Bf7 Qb2 67. Bb3 Kc3 68. Kb5 Qxb3 69. axb3 Kxb3 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Paanoos"]
+[Black "rudolf85"]
+[Result "0-1"]
+[ECO "B01"]
+[WhiteElo "2396"]
+[BlackElo "2406"]
+[PlyCount "96"]
+[EventDate "2020.??.??"]
+
+1. e4 d5 2. exd5 Qxd5 3. Nc3 Qd8 4. d4 Nf6 5. Bc4 e6 6. Nge2 Be7 7. O-O c6 8.
+a3 b5 9. Ba2 a5 10. Ng3 O-O 11. Qf3 Na6 12. Nxb5 Bb7 13. Nc3 Qc8 14. Qf4 c5 15.
+Be3 c4 16. Rad1 Nd5 17. Qg4 Nxc3 18. bxc3 Bd5 19. Bh6 g6 20. Bxf8 Bxf8 21. Ne4
+Bg7 22. Nd2 Qc7 23. Rb1 Rc8 24. Rb5 h5 25. Qg3 Qd8 26. Rfb1 Bf8 27. a4 Bd6 28.
+Qe3 Kg7 29. h3 Qc7 30. Ne4 Be7 31. Nc5 Nxc5 32. dxc5 Bxc5 33. Qd2 Be7 34. Qd4+
+Bf6 35. Qb6 Qf4 36. Qe3 Qd6 37. Rxd5 exd5 38. Re1 Qc6 39. Qe2 Qc7 40. Bxc4 Qc6
+41. Bxd5 Qxd5 42. Qd3 Qc6 43. Qc4 Qc5 44. Qxc5 Rxc5 45. Re3 Rxc3 46. Rf3 Rxc2
+47. Rf5 Rc1+ 48. Kh2 gxf5 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "zpxocivubyntmraeswdq"]
+[Black "starkspieler"]
+[Result "1-0"]
+[ECO "D52"]
+[WhiteElo "2680"]
+[BlackElo "2418"]
+[PlyCount "77"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 d5 2. c4 c6 3. Nf3 Nf6 4. Nc3 e6 5. Bg5 Nbd7 6. e3 h6 7. Bh4 Bb4 8. Qc2
+Qa5 9. Bd3 dxc4 10. Bxc4 Nd5 11. Rc1 b6 12. O-O Bxc3 13. bxc3 Ba6 14. Nd2 O-O
+15. Rfe1 Bxc4 16. Nxc4 Qa6 17. Qb3 c5 18. e4 Nf4 19. Rcd1 b5 20. Ne3 c4 21. Qb1
+Nd3 22. Re2 f5 23. exf5 exf5 24. Be7 Rfe8 25. Nxf5 Qg6 26. Ng3 a6 27. Re3 Nf6
+28. Bxf6 Qxf6 29. Rf3 Qg6 30. h4 Rf8 31. h5 Qg5 32. Rdxd3 cxd3 33. Qxd3 Rxf3
+34. Qxf3 Rc8 35. Ne4 Qe7 36. Nc5 Qf7 37. Qg4 Re8 38. Qd1 Rf8 39. f3 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Mondesespoir2700"]
+[Black "JiangoFett"]
+[Result "1-0"]
+[ECO "B30"]
+[WhiteElo "2423"]
+[BlackElo "2388"]
+[PlyCount "131"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 c5 2. Nf3 Nc6 3. g3 g6 4. d3 Bg7 5. Bg2 e5 6. O-O Nge7 7. c4 O-O 8. Nc3
+d6 9. Nh4 Nd4 10. f4 exf4 11. gxf4 f5 12. Nf3 fxe4 13. Nxe4 Bg4 14. h3 Nxf3+
+15. Bxf3 Bxh3 16. Re1 Nc6 17. Ng5 Qd7 18. Qe2 Nd4 19. Bd5+ Kh8 20. Qh2 Qg4+ 21.
+Kh1 Rae8 22. Bd2 Nf5 23. Qxh3 Qxh3+ 24. Nxh3 Bd4 25. Rxe8 Rxe8 26. Re1 Rxe1+
+27. Bxe1 Bxb2 28. Ng5 b6 29. Nf7+ Kg7 30. Ng5 h5 31. Kg2 Bd4 32. Ne6+ Kf6 33.
+Nc7 Ne3+ 34. Kf3 Nc2 35. Bh4+ Kg7 36. Ne8+ Kh7 37. Nxd6 Nb4 38. Be6 Nxd3 39.
+Nf7 Nc1 40. Be7 Nxa2 41. Bf8 Nc3 42. Ng5+ Kh8 43. Bf7 a5 44. Bxg6 a4 45. Bc2 a3
+46. Bb3 a2 47. Bxa2 Nxa2 48. Nf7+ Kg8 49. Nd6 Kxf8 50. Nc8 Ke8 51. Nxb6 Ke7 52.
+Kg3 Nb4 53. Kh4 Nc2 54. Kxh5 Ne3 55. Kg5 Nxc4 56. Nxc4 Bf6+ 57. Kf5 Bd4 58. Ke4
+Kf7 59. Nd6+ Kf6 60. Nb5 Ke6 61. Nxd4+ Kd6 62. Nc2 Ke6 63. f5+ Kf6 64. Kf4 c4
+65. Ke4 c3 66. Kf4 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "gomelbel"]
+[Black "chipmunknau"]
+[Result "1-0"]
+[ECO "D15"]
+[WhiteElo "2440"]
+[BlackElo "2576"]
+[PlyCount "119"]
+[EventDate "2020.??.??"]
+
+1. Nf3 d5 2. d4 c6 3. c4 Nf6 4. Nc3 Bf5 5. cxd5 Nxd5 6. Bg5 Qa5 7. Bd2 Nxc3 8.
+Bxc3 Qc7 9. e3 e6 10. Bd3 Bxd3 11. Qxd3 Nd7 12. O-O Be7 13. Rab1 O-O 14. Rfd1
+Rfd8 15. h3 a5 16. Qe4 Nf6 17. Qh4 Rd5 18. e4 Rh5 19. Qg3 Qxg3 20. fxg3 Nxe4
+21. g4 Rd5 22. Rd3 Rad8 23. Rbd1 c5 24. Kf1 c4 25. Re3 f5 26. gxf5 exf5 27. Nd2
+Bg5 28. Re2 Ng3+ 29. Kf2 Nxe2 30. Kxe2 b5 31. Bxa5 Re8+ 32. Kf3 Rxd4 33. Bc3
+Rd3+ 34. Kf2 Red8 35. Ke2 Kf7 36. a3 g6 37. Ke1 Bf4 38. Ke2 g5 39. g3 Be3 40.
+g4 f4 41. Ke1 Kg6 42. Ke2 h5 43. Ke1 hxg4 44. hxg4 R8d7 45. Ke2 Rh7 46. Nf3
+Rxd1 47. Kxd1 Rd7+ 48. Ke2 Rd8 49. Ne5+ Kh7 50. Nc6 Re8 51. Kf3 Bc5 52. Ne5 b4
+53. axb4 Bxb4 54. Bd4 Bc3 55. Ke4 Bxd4 56. Kxd4 Rxe5 57. Kxe5 f3 58. Ke4 f2 59.
+Kd4 f1=Q 60. Kc3 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "WildBreath"]
+[Black "murderoflegends"]
+[Result "1-0"]
+[ECO "B23"]
+[WhiteElo "2413"]
+[BlackElo "2425"]
+[PlyCount "41"]
+[EventDate "2020.??.??"]
+
+1. e4 c5 2. Nc3 e6 3. g3 a6 4. Bg2 Qc7 5. Nh3 g6 6. d3 Bg7 7. O-O d6 8. f4 Ne7
+9. Ne2 Nbc6 10. c3 O-O 11. g4 b5 12. Ng3 Bb7 13. f5 exf5 14. gxf5 d5 15. f6
+dxe4 16. fxg7 Rfd8 17. Nxe4 Kxg7 18. Qd2 Ng8 19. Qf4 Qxf4 20. Bxf4 Rxd3 21.
+Nxc5 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Training88"]
+[Black "alireza3700"]
+[Result "0-1"]
+[ECO "A00"]
+[WhiteElo "2345"]
+[BlackElo "2366"]
+[PlyCount "86"]
+[EventDate "2020.??.??"]
+
+1. b4 c6 2. Bb2 Qb6 3. b5 Qxb5 4. Qc1 Nf6 5. e4 Nxe4 6. Bxb5 cxb5 7. Nf3 Nc6 8.
+O-O f6 9. c3 e5 10. d4 d6 11. a4 bxa4 12. Rxa4 Bd7 13. dxe5 Nc5 14. Rb4 Nd3 15.
+Qe3 Ncxb4 16. exf6+ Kf7 17. cxb4 Nxb2 18. fxg7 Bxg7 19. Rd1 Rae8 20. Qb3+ Be6
+21. Qc2 Nxd1 22. Qxd1 Bf5 23. Nbd2 Rc8 24. h3 h6 25. Qb3+ Be6 26. Qd3 Bc4 27.
+Qf5+ Bf6 28. Qd7+ Kg6 29. Qxd6 Rhd8 30. Qg3+ Kf7 31. Nxc4 Rxc4 32. h4 Rc1+ 33.
+Kh2 Rdd1 34. Qf4 Rh1+ 35. Kg3 Rhd1 36. Ne5+ Ke7 37. Ng6+ Ke6 38. h5 Be5 39.
+Qxe5+ Kd7 40. Qe7+ Kc6 41. Qe6+ Kb5 42. Qe4 Ka4 43. Qe3 Rc4 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "alirezafirulais"]
+[Black "Elhlwagy11"]
+[Result "1-0"]
+[ECO "A43"]
+[WhiteElo "2355"]
+[BlackElo "2311"]
+[PlyCount "65"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 c5 2. Nf3 cxd4 3. Nxd4 Nc6 4. c4 g6 5. Nc3 Bg7 6. Nc2 Qa5 7. Bd2 Qc7 8.
+g3 Nf6 9. Bg2 O-O 10. O-O a6 11. Rc1 d6 12. Bg5 Ne5 13. Bxf6 Bxf6 14. Nd5 Qxc4
+15. Nb6 Qxa2 16. Nxa8 Qxb2 17. Nc7 e6 18. Qxd6 Rd8 19. Qb4 Qa2 20. Bxb7 Bxb7
+21. Qxb7 a5 22. Ne3 Qxe2 23. Qb5 Qf3 24. Rfd1 Rxd1+ 25. Rxd1 Qe4 26. Qb8+ Kg7
+27. Ne8+ Kh6 28. Nxf6 Nf3+ 29. Kh1 Qc6 30. Qf8+ Kg5 31. Nxh7+ Kh5 32. g4+ Kh4
+33. Qh6# 1-0
+
+[Event "Rated Blitz tournament hM7PUvgg"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Derrotado"]
+[Black "matussalen"]
+[Result "1/2-1/2"]
+[ECO "A00"]
+[WhiteElo "2413"]
+[BlackElo "2324"]
+[PlyCount "212"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. a4 Nf6 2. g3 e6 3. Bg2 d5 4. d3 a6 5. Nd2 c5 6. e4 Nc6 7. Ngf3 Bd6 8. O-O
+O-O 9. Qe2 Be7 10. c3 b6 11. exd5 exd5 12. Re1 Bf5 13. Nh4 Be6 14. Ndf3 Bd6 15.
+Ng5 Bg4 16. Bf3 Re8 17. Qd1 Rxe1+ 18. Qxe1 Bxf3 19. Ngxf3 Qd7 20. Bg5 Re8 21.
+Qd2 Ng4 22. Re1 Nge5 23. Nxe5 Nxe5 24. Kg2 d4 25. c4 Qc6+ 26. Kg1 h6 27. Bf4 g5
+28. Bxe5 Rxe5 29. Rxe5 Bxe5 30. Qe2 Qf6 31. Nf3 Bd6 32. Qe4 Kg7 33. Kg2 Qe6 34.
+g4 Qxe4 35. dxe4 Kf6 36. Ne1 Ke5 37. Kf3 Ke6 38. Nd3 Bxh2 39. Kg2 Bd6 40. f3
+Kf6 41. b3 Kg6 42. e5 Bc7 43. Kg3 f6 44. f4 fxe5 45. fxe5 Kf7 46. Kf3 Ke6 47.
+Ke4 Bb8 48. a5 Bc7 49. b4 cxb4 50. Nxb4 bxa5 51. Nxa6 Bxe5 52. Nc5+ Kd6 53.
+Nb7+ Ke6 54. Nxa5 Bd6 55. Nb3 Be5 56. Nxd4+ Kf6 57. Nf3 Bf4 58. c5 Ke6 59. Ne1
+Bg3 60. Nd3 Bh2 61. c6 Kd6 62. Kf5 Kxc6 63. Kg6 Kd5 64. Kxh6 Ke4 65. Nc5+ Kf4
+66. Kh5 Bg1 67. Ne6+ Ke5 68. Nxg5 Kf6 69. Nf3 Be3 70. Nh4 Bf4 71. Nf5 Be3 72.
+Kh4 Bd2 73. Kg3 Kg5 74. Kf3 Bf4 75. Ng3 Bxg3 76. Kxg3 Kg6 77. Kh3 Kg5 78. Kg3
+Kg6 79. Kh4 Kh6 80. g5+ Kg6 81. Kg4 Kg7 82. Kg3 Kg6 83. Kf4 Kg7 84. Kg4 Kg6 85.
+Kh4 Kg7 86. Kh5 Kh7 87. Kg4 Kg6 88. Kf4 Kg7 89. Kf5 Kf7 90. Kf4 Kg6 91. Kg4 Kg7
+92. Kg3 Kg6 93. Kh4 Kg7 94. Kh5 Kh7 95. g6+ Kg7 96. Kg5 Kg8 97. Kg4 Kg7 98. Kf5
+Kg8 99. Kf4 Kg7 100. Kg5 Kg8 101. Kh4 Kg7 102. Kh5 Kg8 103. Kg5 Kg7 104. Kf5
+Kg8 105. Kf6 Kf8 106. Kg5 Kg8 1/2-1/2
+
+[Event "Rated Blitz tournament hM7PUvgg"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "vangulio"]
+[Black "lama17"]
+[Result "0-1"]
+[ECO "A10"]
+[WhiteElo "2435"]
+[BlackElo "2315"]
+[PlyCount "20"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. c4 g6 2. Nf3 Bg7 3. d4 d6 4. g3 Nd7 5. Bg2 e5 6. O-O Ne7 7. Nc3 O-O 8. b3
+exd4 9. Nxd4 c5 10. Ndb5 a6 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Nurgyul"]
+[Black "DoctorFromGallifrey"]
+[Result "1-0"]
+[ECO "A01"]
+[WhiteElo "2558"]
+[BlackElo "2562"]
+[PlyCount "105"]
+[EventDate "2020.??.??"]
+
+1. b3 Nf6 2. Bb2 g6 3. g3 Bg7 4. Bg2 O-O 5. e3 d6 6. Ne2 e5 7. c4 Nc6 8. d3 Re8
+9. Qd2 Bg4 10. h3 Bxe2 11. Qxe2 d5 12. c5 e4 13. d4 Nb4 14. O-O Nd3 15. Bc3 c6
+16. Rd1 b6 17. b4 a5 18. cxb6 axb4 19. b7 Rb8 20. Bd2 Rxb7 21. Be1 Nd7 22. Nd2
+c5 23. dxc5 Bxa1 24. c6 N7c5 25. cxb7 Bc3 26. Nb3 Nxb3 27. Bxc3 bxc3 28. axb3
+Qb6 29. Qc2 Qb4 30. Bf1 Ne5 31. Rxd5 Nf3+ 32. Kh1 Rb8 33. Bc4 Rxb7 34. Rd8+ Kg7
+35. Rd1 Ra7 36. Qxe4 Nd2 37. Qd4+ Kh6 38. Qh4+ Kg7 39. Qd4+ Kh6 40. Qxa7 Qd6
+41. Qd4 Qc6+ 42. e4 Nxe4 43. Bd5 c2 44. Bxc6 Nxf2+ 45. Qxf2 cxd1=Q+ 46. Kg2 Qd4
+47. Bf3 Qxf2+ 48. Kxf2 Kg5 49. g4 Kf6 50. h4 Ke5 51. Kg3 Kd4 52. h5 f5 53. h6
+1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "pro100still"]
+[Black "Johnnyballgame"]
+[Result "1-0"]
+[ECO "B50"]
+[WhiteElo "2351"]
+[BlackElo "2305"]
+[PlyCount "71"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 c5 2. Nf3 d6 3. c3 Nf6 4. Be2 g6 5. O-O Bg7 6. Re1 O-O 7. Bf1 Nc6 8. d4
+cxd4 9. cxd4 Bg4 10. Nc3 Nd7 11. Be3 e6 12. Qd2 a6 13. Be2 Rc8 14. h3 Bxf3 15.
+Bxf3 Nb6 16. b3 d5 17. exd5 Nxd5 18. Nxd5 exd5 19. Bg5 Qb6 20. Bxd5 Nxd4 21.
+Be7 Rfd8 22. Bxd8 Rxd8 23. Qf4 Rxd5 24. Re8+ Bf8 25. Rae1 Ne6 26. R1xe6 Qxe6
+27. Rxe6 fxe6 28. g3 Rd7 29. Qb8 Rf7 30. Kg2 Kg7 31. Qc8 e5 32. h4 Re7 33. h5
+gxh5 34. Qf5 e4 35. Qg5+ Kf7 36. Qxh5+ 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "hungzhao"]
+[Black "chesslismab"]
+[Result "1/2-1/2"]
+[ECO "B02"]
+[WhiteElo "2623"]
+[BlackElo "2450"]
+[PlyCount "125"]
+[EventDate "2020.??.??"]
+
+1. e4 Nf6 2. e5 Nd5 3. Bc4 Nb6 4. Bb3 d5 5. exd6 cxd6 6. Nf3 d5 7. d4 Bg4 8. c3
+Nc6 9. h3 Bh5 10. Nbd2 e6 11. Nf1 Bd6 12. Ng3 Bxg3 13. fxg3 Bg6 14. O-O O-O 15.
+Nh4 Be4 16. Bc2 f5 17. Nf3 h6 18. Bf4 a5 19. Ne5 Nxe5 20. Bxe5 Nd7 21. Bf4 Nf6
+22. Be5 Bxc2 23. Qxc2 Ne4 24. Kh2 b5 25. Rae1 Rc8 26. Qd3 Qd7 27. g4 fxg4 28.
+hxg4 b4 29. c4 Rxf1 30. Rxf1 Rxc4 31. Qf3 Rc8 32. Qh3 Qe7 33. Qh5 Rf8 34. Rxf8+
+Qxf8 35. Qg6 Qf7 36. Qh5 Qxh5+ 37. gxh5 Kf7 38. Kh3 g6 39. Kg4 Nf2+ 40. Kf3 Nd3
+41. Bc7 a4 42. b3 a3 43. Bd6 gxh5 44. Kg3 Kg6 45. Kh4 Kf5 46. Kxh5 Ke4 47. Bxb4
+Nxb4 48. Kxh6 Nxa2 49. Kg6 Nb4 50. Kf6 a2 51. Kxe6 a1=Q 52. g4 Qxd4 53. g5 Qe5+
+54. Kd7 Qxg5 55. Kd6 Qf6+ 56. Kc5 Kd3 57. Kxb4 Kc2 58. Kc5 Kxb3 59. Kxd5 Kc3
+60. Kc5 Qd4+ 61. Kc6 Qe5 62. Kb6 Kc4 63. Kc6 1/2-1/2
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Phoenix-20"]
+[Black "david_gomez"]
+[Result "0-1"]
+[ECO "D37"]
+[WhiteElo "2484"]
+[BlackElo "2455"]
+[PlyCount "52"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 Nf6 2. c4 e6 3. Nf3 d5 4. Nc3 Be7 5. Bf4 O-O 6. e3 a6 7. cxd5 exd5 8. Bd3
+Be6 9. O-O Nbd7 10. Rc1 c5 11. dxc5 Nxc5 12. Bb1 Rc8 13. Nd4 Bg4 14. f3 Bd7 15.
+h3 Re8 16. Qd2 Ne6 17. Be5 Bb4 18. a3 Bxc3 19. Rxc3 Nxd4 20. exd4 Rxc3 21. Qxc3
+Bb5 22. Rc1 Nd7 23. Bg3 Nf8 24. b3 Ne6 25. a4 Qg5 26. Bf2 Nf4 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "QMagico"]
+[Black "davidcm92"]
+[Result "1/2-1/2"]
+[ECO "B40"]
+[WhiteElo "2403"]
+[BlackElo "2322"]
+[PlyCount "123"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 c5 2. Nf3 e6 3. g3 g6 4. Bg2 Bg7 5. O-O Ne7 6. Re1 O-O 7. c3 b6 8. Qc2
+Bb7 9. d3 d5 10. Nbd2 Nbc6 11. a3 Qd7 12. Nf1 Rfe8 13. h4 Rad8 14. N1h2 Ba6 15.
+Bg5 dxe4 16. dxe4 Qd3 17. Qxd3 Bxd3 18. Bf1 h6 19. Bxe7 Rxe7 20. Rad1 Red7 21.
+Bxd3 Rxd3 22. Rxd3 Rxd3 23. Kf1 Na5 24. Ke2 Rd7 25. Nd2 Kf8 26. Nhf3 Ke7 27.
+Rd1 b5 28. g4 a6 29. h5 g5 30. Ne1 c4 31. Nc2 Be5 32. Nb4 Kf6 33. Nxa6 Nb7 34.
+Nf3 Rxd1 35. Kxd1 Bf4 36. Nd4 Nc5 37. f3 Nd3 38. Kc2 Ne1+ 39. Kd1 Nd3 40. Kc2
+Be3 41. Nxb5 Ne1+ 42. Kd1 Nxf3 43. Ke2 Bc1 44. Kxf3 Bxb2 45. a4 Ke5 46. Nac7 f5
+47. exf5 exf5 48. gxf5 Kxf5 49. a5 g4+ 50. Kg2 Bc1 51. a6 Be3 52. Nd4+ Bxd4 53.
+cxd4 c3 54. Nd5 Ke4 55. Nxc3+ Kxd4 56. a7 Kxc3 57. a8=Q Kd4 58. Kg3 Ke5 59.
+Kxg4 Kf6 60. Qf3+ Kg7 61. Qf5 Kh8 62. Qg6 1/2-1/2
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "sutcunuri"]
+[Black "ajedrez2021"]
+[Result "0-1"]
+[ECO "A39"]
+[WhiteElo "2537"]
+[BlackElo "2575"]
+[PlyCount "72"]
+[EventDate "2020.??.??"]
+
+1. c4 g6 2. Nc3 Bg7 3. g3 c5 4. Bg2 Nf6 5. Nf3 O-O 6. O-O Nc6 7. d4 cxd4 8.
+Nxd4 Qb6 9. Nc2 d6 10. b3 Be6 11. Ne3 Rfc8 12. Bb2 Rab8 13. Qd2 Qa5 14. Rfd1 a6
+15. a4 h5 16. h3 Nd7 17. Ned5 Bxd5 18. Nxd5 Qxd2 19. Rxd2 Bxb2 20. Rxb2 e6 21.
+Nc3 Kf8 22. Rd1 Ke7 23. Ne4 Nc5 24. Nxc5 dxc5 25. Rbd2 Rd8 26. Rxd8 Nxd8 27. f4
+b5 28. cxb5 axb5 29. a5 Rc8 30. a6 Rc7 31. Kf2 Ra7 32. Ra1 Kd6 33. Ke3 Nc6 34.
+b4 Nxb4 35. g4 hxg4 36. hxg4 Nc2+ 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Karabakh-Azerbaijan"]
+[Black "Frogkiller"]
+[Result "1-0"]
+[ECO "A43"]
+[WhiteElo "2453"]
+[BlackElo "2369"]
+[PlyCount "105"]
+[EventDate "2020.??.??"]
+
+1. d4 c5 2. Nf3 cxd4 3. Nxd4 Nc6 4. c4 Nf6 5. Nc3 g6 6. e4 d6 7. Be3 Bg7 8. Be2
+O-O 9. O-O Bd7 10. Nxc6 Bxc6 11. f3 a5 12. Bd4 Nd7 13. Be3 Nc5 14. Qd2 Qb6 15.
+b3 Qb4 16. Rac1 a4 17. Nd5 Qxd2 18. Nxe7+ Kh8 19. Bxd2 axb3 20. axb3 Nxb3 21.
+Rc2 Rfe8 22. Nxc6 bxc6 23. Be3 c5 24. Rd1 Bd4 25. Kf2 Bxe3+ 26. Kxe3 Nd4 27.
+Rxd4 cxd4+ 28. Kxd4 Ra3 29. f4 Rc8 30. Bf3 Kg7 31. Kd5 Ra6 32. Rb2 Rc5+ 33. Kd4
+Ra4 34. Be2 f5 35. exf5 Rxf5 36. Bd3 Rxf4+ 37. Kd5 Rf6 38. Rb6 Ra5+ 39. Kd4 Rg5
+40. g3 h5 41. Rb7+ Kh6 42. Rb6 h4 43. gxh4 Rh5 44. Kc3 Rxh4 45. c5 Rf3 46. Rxd6
+Rxh2 47. Rd4 Rf1 48. Kc4 Rc1+ 49. Kd5 Rd2 50. Bc4 Rxd4+ 51. Kxd4 g5 52. c6 Rd1+
+53. Kc5 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "vaillant77"]
+[Black "vassiukov"]
+[Result "1-0"]
+[ECO "D00"]
+[WhiteElo "2416"]
+[BlackElo "2376"]
+[PlyCount "109"]
+[EventDate "2020.??.??"]
+
+1. e4 d5 2. d4 dxe4 3. Nc3 Nf6 4. Bc4 Bf5 5. Bg5 Nbd7 6. Nge2 c6 7. Ng3 Bg6 8.
+Qe2 Qa5 9. h4 h6 10. Bxf6 Nxf6 11. O-O-O e6 12. h5 Bh7 13. Ngxe4 Nd5 14. Bb3
+O-O-O 15. Nxd5 cxd5 16. Nc3 Kb8 17. Qf3 Qc7 18. Rhe1 a6 19. Kb1 Rc8 20. Re2 b5
+21. Rde1 Bd6 22. a4 b4 23. Na2 a5 24. Nc1 Qb6 25. Qg4 Rhg8 26. Rd2 Ka7 27. Nd3
+Rc4 28. Bxc4 dxc4 29. Ne5 c3 30. Rdd1 Bf5 31. Qf3 f6 32. g4 Bxc2+ 33. Kxc2 fxe5
+34. dxe5 Be7 35. Rd7+ Kb8 36. Rxe7 Rd8 37. Rd1 b3+ 38. Kc1 cxb2+ 39. Kxb2 Rc8
+40. Rb7+ Qxb7 41. Qxb7+ Kxb7 42. Rd7+ Rc7 43. Rd6 Rc2+ 44. Kxb3 Rxf2 45. Rd7+
+Kc6 46. Rxg7 Rf3+ 47. Kc4 Rf4+ 48. Kd3 Rxa4 49. g5 Ra3+ 50. Ke4 Ra4+ 51. Kf3
+Ra3+ 52. Ke2 Ra2+ 53. Kd3 Ra3+ 54. Kc2 Ra4 55. Kb3 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "telodijomonstruo"]
+[Black "Olaffo"]
+[Result "0-1"]
+[ECO "B00"]
+[WhiteElo "2519"]
+[BlackElo "2513"]
+[PlyCount "100"]
+[EventDate "2020.??.??"]
+
+1. e4 a6 2. Nc3 b6 3. d4 Bb7 4. Nf3 e6 5. Bd3 Bb4 6. e5 Ne7 7. Ng5 h6 8. Qh5 g6
+9. Qh3 Nd5 10. Bd2 Nxc3 11. bxc3 Bxc3 12. Bxc3 Qxg5 13. O-O Nc6 14. f4 Qe7 15.
+Be4 Qa3 16. d5 Ne7 17. dxe6 Bxe4 18. exf7+ Kxf7 19. Rae1 Bf5 20. Qh4 Qxc3 21.
+Qf6+ Kg8 22. Qxe7 Qc5+ 23. Qxc5 bxc5 24. h3 Kf7 25. Rf2 h5 26. Rd2 Rhb8 27. Kf2
+Rb2 28. Red1 Rxc2 29. Rxc2 Bxc2 30. Rxd7+ Ke6 31. Rxc7 Kd5 32. g4 hxg4 33. hxg4
+c4 34. Ke3 Rb8 35. Rd7+ Kc5 36. Rd6 a5 37. Kd2 Be4 38. Kc3 Rb4 39. Rd8 Ra4 40.
+Rc8+ Kd5 41. Rd8+ Kc5 42. Rd6 Ra3+ 43. Kb2 Rf3 44. f5 c3+ 45. Kc1 Rf1+ 46. Rd1
+Rxd1+ 47. Kxd1 gxf5 48. gxf5 Bxf5 49. Kc1 Kd5 50. e6 Kxe6 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "FerociousLion98999"]
+[Black "Maxterlopez"]
+[Result "0-1"]
+[ECO "C70"]
+[WhiteElo "2592"]
+[BlackElo "2644"]
+[PlyCount "80"]
+[EventDate "2020.??.??"]
+
+1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nge7 5. O-O g6 6. c3 Bg7 7. d4 exd4 8.
+Nxd4 b5 9. Bb3 O-O 10. Be3 Bb7 11. Nd2 Na5 12. Bc2 d5 13. Re1 c5 14. N4f3 d4
+15. cxd4 cxd4 16. Bf4 Rc8 17. Bd3 Qd7 18. e5 Nd5 19. Bg3 Nc4 20. Rb1 Rfe8 21.
+Ne4 Nxe5 22. Nxe5 Bxe5 23. Bxe5 Rxe5 24. Nf6+ Nxf6 25. Rxe5 Qd6 26. Qe2 Kg7 27.
+Re7 Bd5 28. f3 Bxa2 29. Ra1 Be6 30. Ra7 Rc6 31. Rd1 Nd5 32. Be4 Nf4 33. Qf2 Rc4
+34. Kh1 Rb4 35. g3 Nh3 36. Qd2 Ng5 37. Kg2 Nxe4 38. fxe4 Qe5 39. Qxb4 Qxe4+ 40.
+Kg1 Qe3+ 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "mux77"]
+[Black "LordBendtner99"]
+[Result "0-1"]
+[ECO "A04"]
+[WhiteElo "2433"]
+[BlackElo "2485"]
+[PlyCount "90"]
+[EventDate "2020.??.??"]
+
+1. Nf3 g6 2. g3 f6 3. d4 Nh6 4. Bg2 Nf7 5. c4 Bg7 6. Nc3 O-O 7. d5 d6 8. Nd4 c5
+9. dxc6 Nxc6 10. Nxc6 bxc6 11. Bxc6 Rb8 12. O-O e5 13. Bg2 Be6 14. Nd5 f5 15.
+b3 Kh8 16. Bb2 h6 17. Rc1 g5 18. Qd2 f4 19. e3 Bxd5 20. Bxd5 Qf6 21. exf4 gxf4
+22. gxf4 Rg8 23. Kh1 Qh4 24. Bxf7 Rgf8 25. Bd5 Rxf4 26. f3 Rbf8 27. Rg1 Bf6 28.
+Rg3 Bg5 29. Rcg1 R4f5 30. Qg2 Qf4 31. Rg4 Qe3 32. h4 Rxf3 33. Bxf3 Rxf3 34. Rf1
+Rh3+ 35. Qxh3 Qxh3+ 36. Kg1 Qxg4+ 37. Kf2 Qxh4+ 38. Ke2 Qh2+ 39. Rf2 Qh5+ 40.
+Kf1 Qg6 41. Bxe5+ dxe5 42. Re2 Kg7 43. Rg2 Qf5+ 44. Rf2 Qd3+ 45. Re2 Qf3+ 0-1
+
+[Event "Rated Blitz tournament hM7PUvgg"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "vangulio"]
+[Black "juancruzariasTDF"]
+[Result "1-0"]
+[ECO "C02"]
+[WhiteElo "2427"]
+[BlackElo "2436"]
+[PlyCount "65"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 e6 2. d4 d5 3. e5 c5 4. c3 Qb6 5. Nf3 Nc6 6. a3 f6 7. Bd3 c4 8. Bc2 fxe5
+9. Nxe5 Nxe5 10. dxe5 g6 11. h4 Bc5 12. O-O Bd7 13. h5 Ne7 14. Nd2 O-O-O 15. b4
+cxb3 16. Nxb3 Bb5 17. Nxc5 Qxc5 18. Be3 Qc7 19. Re1 Nf5 20. Bxa7 gxh5 21. Rb1
+Bc6 22. Bb6 Qg7 23. Bxf5 exf5 24. Bxd8 d4 25. f3 Rg8 26. Qe2 d3 27. Bf6 Qg3 28.
+Qf2 Qf4 29. Rb4 Qh6 30. Rc4 d2 31. Rd1 h4 32. Rxc6+ bxc6 33. Qxd2 1-0
+
+[Event "Rated Blitz tournament hM7PUvgg"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Lidiodelgado"]
+[Black "Tenessy"]
+[Result "1-0"]
+[ECO "D02"]
+[WhiteElo "2367"]
+[BlackElo "2363"]
+[PlyCount "31"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 d5 2. Nf3 e6 3. c4 c6 4. Qc2 f5 5. g4 fxg4 6. Ne5 Nf6 7. h3 g3 8. fxg3
+Nbd7 9. Bf4 Bb4+ 10. Nd2 Nxe5 11. dxe5 Ne4 12. Bg2 Nxd2 13. Bxd2 Bxd2+ 14. Qxd2
+O-O 15. cxd5 exd5 16. O-O-O 1-0
+
+[Event "Rated Blitz tournament hM7PUvgg"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "lama17"]
+[Black "RCSA007"]
+[Result "0-1"]
+[ECO "D01"]
+[WhiteElo "2323"]
+[BlackElo "2424"]
+[PlyCount "106"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 d5 2. Nc3 Nf6 3. Bg5 Nbd7 4. Nf3 h6 5. Bh4 e6 6. a3 c5 7. e3 Be7 8. Bd3
+a6 9. a4 b6 10. O-O Bb7 11. Bg3 O-O 12. Ne5 Nxe5 13. Bxe5 Nd7 14. Bg3 Bf6 15.
+Qg4 Re8 16. Rad1 Qe7 17. Rfe1 e5 18. Bf5 Nf8 19. dxe5 Bxe5 20. Nxd5 Bxd5 21.
+Rxd5 Bxb2 22. Bd6 Qf6 23. Bd3 Be5 24. Bxf8 Kxf8 25. f4 Bc3 26. Re2 Qc6 27. Qd7
+Qxd7 28. Rxd7 Re7 29. Rxe7 Kxe7 30. Kf2 Kd6 31. Kf3 Ra7 32. e4 Kc6 33. e5 b5
+34. axb5+ axb5 35. Be4+ Kb6 36. Bd5 c4 37. Ke4 Kc5 38. e6 fxe6 39. Bxe6 b4 40.
+f5 Re7 41. Re3 Bd4 42. Rg3 Bf6 43. h3 Ra7 44. Rf3 Ra2 45. Rf2 b3 46. Bxc4 bxc2
+47. Rf1 Kxc4 48. g4 Ra1 49. h4 Rxf1 50. g5 hxg5 51. hxg5 Bxg5 52. Ke5 c1=Q 53.
+Ke6 Qe3+ 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "soldier14"]
+[Black "Atomrod"]
+[Result "1-0"]
+[ECO "B17"]
+[WhiteElo "2409"]
+[BlackElo "2492"]
+[PlyCount "107"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 c6 2. d4 d5 3. Nc3 dxe4 4. Nxe4 Nd7 5. Qe2 Ndf6 6. Nxf6+ Nxf6 7. c3 Bg4
+8. f3 Bf5 9. g4 Bg6 10. h4 h5 11. g5 Nd5 12. Nh3 e6 13. Nf4 Nxf4 14. Bxf4 Bd6
+15. Qe3 Qc7 16. Bxd6 Qxd6 17. f4 Qd5 18. Rh2 O-O-O 19. Bg2 Qf5 20. Rd1 Rd6 21.
+Qe5 Rhd8 22. Qxf5 Bxf5 23. Bh3 Bxh3 24. Rxh3 c5 25. Rhd3 cxd4 26. Rxd4 Rxd4 27.
+Rxd4 Rxd4 28. cxd4 Kd7 29. Kd2 Kd6 30. Kd3 Kd5 31. b4 b5 32. a3 g6 33. Ke3 Kc4
+34. Ke4 Kb3 35. Ke5 Kxa3 36. Kf6 Kxb4 37. Kxf7 a5 38. Kxg6 a4 39. f5 a3 40. f6
+a2 41. f7 a1=Q 42. f8=Q+ Kc4 43. Qc5+ Kd3 44. Qxb5+ Kxd4 45. Qb6+ Ke5 46. Qc7+
+Kd5 47. Qd7+ Kc5 48. Qxe6 Qd1 49. Kh6 Qf3 50. Qf6 Qg4 51. g6 Kd5 52. g7 Qc8 53.
+Qf7+ Ke5 54. g8=Q 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "ghadanfar"]
+[Black "camilomunoz0107"]
+[Result "1/2-1/2"]
+[ECO "E12"]
+[WhiteElo "2407"]
+[BlackElo "2342"]
+[PlyCount "165"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 Nf6 2. Nf3 e6 3. c4 b6 4. a3 Bb7 5. Nc3 Be7 6. d5 O-O 7. e4 d6 8. Bd3 e5
+9. O-O a5 10. Rb1 Nbd7 11. b4 h6 12. Nd2 g5 13. Nb3 axb4 14. axb4 Re8 15. c5
+Nf8 16. c6 Bc8 17. Ne2 Ng6 18. Ng3 Nf4 19. Nf5 Bf8 20. Bxf4 gxf4 21. Nd2 Bxf5
+22. exf5 e4 23. Bc2 Qc8 24. Re1 Qxf5 25. f3 Qxd5 26. fxe4 Qd4+ 27. Kh1 Ra2 28.
+Nb3 Qxd1 29. Bxd1 Rxe4 30. Bf3 Rxb4 31. Nd2 Rxb1 32. Nxb1 Ra1 33. Rd1 Kg7 34.
+Kg1 Be7 35. Kf2 Nh7 36. Ke2 Ng5 37. Kd3 Nxf3 38. gxf3 Bf6 39. Kc2 Ra2+ 40. Kb3
+Rxh2 41. Nc3 Bxc3 42. Kxc3 Rf2 43. Rxd6 Rxf3+ 44. Kc2 Rf2+ 45. Kc3 Rf3+ 46. Kc2
+Re3 47. Rd7 Re5 48. Rxc7 f3 49. Rd7 Rc5+ 50. Kd3 Rxc6 51. Ke3 Rf6 52. Kf2 h5
+53. Rd5 Kg6 54. Rd4 Rf5 55. Rd6+ Rf6 56. Rd4 b5 57. Rd5 Rf5 58. Rd6+ f6 59. Rd8
+Kg5 60. Rg8+ Kf4 61. Rb8 Re5 62. Rf8 Re2+ 63. Kf1 Ke3 64. Rxf6 Rf2+ 65. Ke1
+Re2+ 66. Kf1 Rf2+ 67. Ke1 Ra2 68. Re6+ Kf4 69. Rf6+ Kg4 70. Rg6+ Kh3 71. Rg5
+f2+ 72. Kf1 h4 73. Rxb5 Kh2 74. Rg5 h3 75. Rg6 Kh1 76. Rg7 h2 77. Rg8 Rc2 78.
+Rg7 Rc1+ 79. Kxf2 Rc2+ 80. Kf1 Rc1+ 81. Kf2 Rc2+ 82. Kf1 Rc1+ 83. Kf2 1/2-1/2
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "yaguigor"]
+[Black "Odirovski"]
+[Result "0-1"]
+[ECO "B05"]
+[WhiteElo "2441"]
+[BlackElo "2442"]
+[PlyCount "102"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 Nf6 2. e5 Nd5 3. d4 d6 4. Nf3 Bg4 5. Be2 e6 6. h3 Bh5 7. c4 Nb6 8. exd6
+cxd6 9. Nc3 Be7 10. d5 e5 11. g4 Bg6 12. h4 h5 13. g5 Bf5 14. Be3 g6 15. Bd3
+Bg4 16. Rc1 Kf8 17. Ne4 N8d7 18. Kf1 Nc8 19. Kg2 Kg7 20. b4 a5 21. a3 axb4 22.
+axb4 Ra3 23. Ra1 Rxa1 24. Qxa1 Bf5 25. Qa3 Kh7 26. c5 Bf8 27. Rd1 Bg7 28. c6
+bxc6 29. dxc6 Ndb6 30. Ng3 Bg4 31. Qa6 d5 32. Be2 d4 33. Bc1 Qd5 34. Qa5 Qxc6
+35. Qc5 Qb7 36. b5 Rd8 37. Qc6 Qxc6 38. bxc6 Ne7 39. c7 Rc8 40. Ne4 Rxc7 41.
+Nf6+ Bxf6 42. gxf6 Nf5 43. Bg5 e4 44. Nxd4 Rd7 45. Nxf5 Rxd1 46. Bxd1 Bxd1 47.
+Nd6 Bf3+ 48. Kg3 Kg8 49. Kf4 Nd5+ 50. Ke5 Nc3 51. Kd4 Nd1 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "estocastico"]
+[Black "cmvaracalov"]
+[Result "1-0"]
+[ECO "B43"]
+[WhiteElo "2584"]
+[BlackElo "2400"]
+[PlyCount "83"]
+[EventDate "2020.??.??"]
+
+1. e4 c5 2. Nf3 e6 3. d4 cxd4 4. Nxd4 a6 5. Nc3 Qc7 6. Bd3 Nf6 7. f4 d6 8. O-O
+Nc6 9. Nf3 Be7 10. Kh1 O-O 11. Qe1 Nb4 12. Qg3 Nxd3 13. cxd3 Kh8 14. Be3 b5 15.
+Rac1 Qd7 16. e5 dxe5 17. Nxe5 Qe8 18. Qf3 Rb8 19. Ba7 Bb7 20. Qh3 Ra8 21. Be3
+Rc8 22. Rce1 Nd5 23. Ne4 f6 24. Ng4 Nxe3 25. Nxe3 f5 26. Ng5 Bxg5 27. fxg5 Qc6
+28. Nd1 Rcd8 29. Nf2 Rd4 30. g6 h6 31. Kg1 Rfd8 32. Re3 R4d5 33. Rfe1 Qc2 34.
+Rxe6 Rf8 35. Re7 Rdd8 36. Qe3 Qxb2 37. Rxb7 Qe5 38. Qxe5 Rg8 39. Qc3 f4 40. Re5
+f3 41. Rh5 fxg2 42. Rxh6# 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "murderoflegends"]
+[Black "Yoseqpuedo"]
+[Result "1-0"]
+[ECO "A40"]
+[WhiteElo "2419"]
+[BlackElo "2417"]
+[PlyCount "91"]
+[EventDate "2020.??.??"]
+
+1. d4 e6 2. Nf3 f5 3. c3 Nf6 4. Bg5 Be7 5. Nbd2 d5 6. e3 O-O 7. Bd3 c5 8. O-O
+c4 9. Bc2 b5 10. a3 a5 11. Ne5 Qc7 12. Ndf3 Nc6 13. Bf4 Bd6 14. Re1 Ne4 15.
+Nxc6 Bxf4 16. exf4 Qxc6 17. Ne5 Qc7 18. f3 Nd6 19. Qe2 Rb8 20. Qf2 b4 21. axb4
+axb4 22. h3 bxc3 23. bxc3 Rb2 24. Rab1 Ra2 25. g4 Qa5 26. Qd2 Qa4 27. Rbd1 Qa3
+28. gxf5 Nxf5 29. Qg2 Qb2 30. Rd2 Ne3 31. Ree2 Nxg2 32. Bxh7+ Kxh7 33. Rxb2
+Rxb2 34. Rxb2 Nxf4 35. Rb8 Nd3 36. Ng4 Rxf3 37. Nf6+ gxf6 38. Rxc8 Kg6 39. Rh8
+Rg3+ 40. Kh2 Kf5 41. Rh6 Rf3 42. Rh5+ Ke4 43. Rg5 Rf2+ 44. Kg1 Ke3 45. Rg4 Nf4
+46. Rg3+ 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "FinalCut"]
+[Black "RigelStar"]
+[Result "1-0"]
+[ECO "A01"]
+[WhiteElo "2442"]
+[BlackElo "2416"]
+[PlyCount "103"]
+[EventDate "2020.??.??"]
+
+1. b3 d5 2. Bb2 Nf6 3. e3 Bf5 4. Nf3 e6 5. c4 c6 6. Be2 Nbd7 7. O-O Be7 8. d4
+h6 9. Nc3 Ne4 10. Nxe4 Bxe4 11. Nd2 Bg6 12. Bh5 Bxh5 13. Qxh5 O-O 14. Nf3 Bd6
+15. Ne5 Bxe5 16. dxe5 Qg5 17. Qxg5 hxg5 18. cxd5 exd5 19. f4 Rfe8 20. b4 a6 21.
+Rac1 Nb6 22. Bd4 Nc4 23. a4 Kh7 24. g4 Kg6 25. Rf2 Re7 26. h3 Rae8 27. b5 axb5
+28. axb5 f6 29. f5+ Kf7 30. e6+ Kg8 31. b6 Ra8 32. Rcc2 Ree8 33. Ra2 g6 34. Kg2
+Rxa2 35. Rxa2 gxf5 36. gxf5 Rc8 37. Kf3 c5 38. Bc3 Nxb6 39. Ra7 Nc4 40. Bxf6
+Ne5+ 41. Bxe5 c4 42. Bc3 Rc7 43. Ra8+ Kh7 44. f6 Kh6 45. f7 Rxf7+ 46. exf7 g4+
+47. Kxg4 Kg6 48. f8=Q d4 49. Ra7 dxc3 50. Rxb7 c2 51. Rg7+ Kh6 52. Qh8# 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "zenon011"]
+[Black "Northridgehawk"]
+[Result "1-0"]
+[ECO "C50"]
+[WhiteElo "2341"]
+[BlackElo "2352"]
+[PlyCount "47"]
+[EventDate "2020.??.??"]
+
+1. e4 e5 2. Nf3 Nc6 3. Bc4 Nf6 4. d3 Bc5 5. Nc3 d6 6. Bb3 Be6 7. Be3 O-O 8. O-O
+Bb6 9. Ne2 Ne7 10. Ng3 Ng6 11. Qd2 c6 12. Bg5 h6 13. Bxh6 gxh6 14. Qxh6 Bxb3
+15. axb3 Re8 16. Nf5 Nh5 17. Qxh5 Qf6 18. Ng5 Nf4 19. Qh7+ Kf8 20. h4 d5 21. g3
+Ne6 22. Nxe6+ fxe6 23. Nh6 Re7 24. Qg8# 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "taras05"]
+[Black "irakliberadze"]
+[Result "1-0"]
+[ECO "B54"]
+[WhiteElo "2470"]
+[BlackElo "2664"]
+[PlyCount "77"]
+[EventDate "2020.??.??"]
+
+1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. f3 g6 6. c4 Bg7 7. Nc3 O-O 8. Be3
+Nc6 9. Qd2 Bd7 10. Be2 Nxd4 11. Bxd4 Bc6 12. O-O e6 13. Rfd1 d5 14. cxd5 exd5
+15. e5 Nd7 16. f4 Re8 17. Bf3 f6 18. exf6 Nxf6 19. Be5 Ne4 20. Bxe4 dxe4 21.
+Bxg7 Qxd2 22. Rxd2 Kxg7 23. Re1 Rad8 24. Rxd8 Rxd8 25. Kf2 Rd2+ 26. Re2 Rd3 27.
+Re3 Rd4 28. Re2 b5 29. g3 b4 30. Nb1 Bb5 31. Rd2 Rc4 32. b3 Rc1 33. Rb2 Rc3 34.
+Nxc3 bxc3 35. Rc2 g5 36. Rxc3 gxf4 37. gxf4 Kg6 38. Ke3 Kf5 39. Rc5+ 1-0
+
+[Event "Rated Blitz tournament hM7PUvgg"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Pomberito"]
+[Black "GlennTipton"]
+[Result "0-1"]
+[ECO "C96"]
+[WhiteElo "2336"]
+[BlackElo "2456"]
+[PlyCount "82"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3
+O-O 9. h3 Na5 10. Bc2 c5 11. d4 Nd7 12. d5 Nb6 13. b3 f5 14. Nbd2 f4 15. Nf1 g5
+16. N3h2 Qe8 17. Bd2 Nb7 18. Bd3 Nd7 19. a4 bxa4 20. Rxa4 a5 21. Be2 Nf6 22.
+Ng4 Bxg4 23. Bxg4 h5 24. Be6+ Kg7 25. Nh2 Rh8 26. Qe2 Bd8 27. Rea1 Rb8 28. b4
+axb4 29. cxb4 cxb4 30. Bxb4 Bb6 31. Ra7 Bxa7 32. Rxa7 Kh6 33. g3 Nd8 34. Bd2
+Nxe6 35. dxe6 Qxe6 36. g4 Qb3 37. gxh5 Qb1+ 38. Nf1 Qxe4 39. Qa6 Qd5 40. Re7
+Rb1 41. Qa7 Qd3 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Gambitopy"]
+[Black "kingcobra23"]
+[Result "0-1"]
+[ECO "C00"]
+[WhiteElo "2300"]
+[BlackElo "2309"]
+[PlyCount "74"]
+[EventDate "2020.??.??"]
+
+1. e4 c5 2. d4 e6 3. dxc5 Bxc5 4. Bd3 Qf6 5. Nf3 Ne7 6. Bg5 Qxb2 7. Nbd2 Nbc6
+8. O-O f6 9. Bh4 Ng6 10. Bg3 O-O 11. Nc4 Qb4 12. Rb1 Qa4 13. h4 b5 14. Nd6 a6
+15. Nxc8 Raxc8 16. h5 Nge5 17. Nh2 Nxd3 18. Qxd3 Rfd8 19. Kh1 Qc4 20. Qf3 Nd4
+21. Qg4 h6 22. Bf4 f5 23. Qg6 Kf8 24. Bxh6 gxh6 25. Qxh6+ Ke8 26. Rbd1 fxe4 27.
+Qg6+ Ke7 28. Ng4 Nf5 29. Qf6+ Ke8 30. Qg6+ Kf8 31. Qf6+ Ke8 32. Qg6+ Kf8 33.
+Qf6+ Kg8 34. Qg6+ Ng7 35. Nf6+ Kf8 36. Nh7+ Kg8 37. Nf6+ Kf8 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "ChanceTraveler"]
+[Black "cubanitochess"]
+[Result "1-0"]
+[ECO "A12"]
+[WhiteElo "2384"]
+[BlackElo "2310"]
+[PlyCount "119"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. Nf3 c6 2. c4 d5 3. g3 e6 4. Bg2 Nf6 5. O-O Be7 6. b3 O-O 7. Bb2 b6 8. d3 Ba6
+9. Nbd2 Nbd7 10. e4 Rc8 11. Qc2 c5 12. e5 Ne8 13. Rae1 d4 14. h4 Qc7 15. Bc1
+Bb7 16. Qd1 h5 17. Qe2 g6 18. Ng5 Bxg2 19. Kxg2 Ng7 20. f4 Nf5 21. Nde4 Rfd8
+22. Rh1 Nh6 23. Nf2 Qc6+ 24. Kg1 Nf5 25. Nfe4 Bxg5 26. hxg5 Kg7 27. Qg2 Rh8 28.
+Nf6 Qxg2+ 29. Kxg2 Nxf6 30. exf6+ Kg8 31. Bd2 Nd6 32. Kf3 Kf8 33. Kf2 Ke8 34.
+g4 Kd7 35. gxh5 gxh5 36. Kf3 Nf5 37. Reg1 Rcg8 38. Be1 Rh7 39. Bf2 Kd6 40. Rg2
+e5 41. Rgh2 Rgh8 42. Rh3 Ke6 43. Ke4 exf4 44. Kxf4 Nd6 45. Re1+ Kd7 46. Bh4 Kc6
+47. Rh2 Re8 48. Rxe8 Nxe8 49. Re2 Rh8 50. Re7 Nd6 51. Rxa7 Nb7 52. Kf5 Rg8 53.
+a3 Kc7 54. b4 Kc6 55. Ra6 Re8 56. g6 fxg6+ 57. Kxg6 Re6 58. Kg7 Re2 59. f7 Rg2+
+60. Kf8 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "InsaneTryhard"]
+[Black "pipo2016"]
+[Result "0-1"]
+[ECO "B21"]
+[WhiteElo "2366"]
+[BlackElo "2469"]
+[PlyCount "103"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 c5 2. d4 b6 3. dxc5 bxc5 4. Qd5 Nc6 5. Qxc5 Nf6 6. Nc3 e6 7. Qe3 Qa5 8.
+Bd2 Bc5 9. Qg3 Qb6 10. O-O-O O-O 11. Na4 Nxe4 12. Nxb6 Nxg3 13. Nxa8 Nxh1 14.
+Nh3 Nxf2 15. Nxf2 Bxf2 16. Nc7 Bb7 17. Nb5 Bc5 18. c3 d5 19. b4 Be7 20. Be3 Rc8
+21. Kb2 a6 22. Nd4 Ne5 23. a4 Ng4 24. Bg1 Bd6 25. h3 Nf6 26. b5 axb5 27. axb5
+Ne4 28. Rc1 g6 29. c4 e5 30. Nc6 d4 31. Na5 Ba8 32. Nb3 Nc5 33. Nxc5 Bxc5 34.
+Kb3 e4 35. g4 f5 36. Ra1 f4 37. b6 f3 38. Bh2 Bxb6 39. c5 Bxc5 40. Bc4+ Kg7 41.
+Be5+ Kh6 42. h4 e3 43. Bf4+ Kg7 44. Be5+ Kf8 45. Ra6 Be7 46. Ra7 e2 47. Bg7+
+Kxg7 48. Rxe7+ Kf6 49. Rf7+ Ke5 50. Re7+ Kf4 51. Bxe2 fxe2 52. Rxe2 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Glig"]
+[Black "Al_Shima"]
+[Result "0-1"]
+[ECO "B02"]
+[WhiteElo "2464"]
+[BlackElo "2491"]
+[PlyCount "144"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 d5 2. Nc3 Nf6 3. exd5 Nxd5 4. Bc4 Be6 5. Qf3 c6 6. Nge2 Nc7 7. Bb3 Bxb3
+8. axb3 e6 9. d4 Be7 10. Qg3 O-O 11. O-O Re8 12. Bf4 Nd5 13. Nxd5 cxd5 14. c3
+Nc6 15. b4 a6 16. Nc1 Bf6 17. Nd3 a5 18. Bc7 Qc8 19. bxa5 Re7 20. Bb6 e5 21.
+dxe5 Nxe5 22. Nxe5 Bxe5 23. Qf3 Qc6 24. Rad1 Rd7 25. Rfe1 Bf6 26. g3 h6 27. h4
+Qb5 28. Re2 Rc8 29. Rde1 Rd6 30. Qf5 Ra8 31. h5 Qc6 32. Re3 d4 33. Bxd4 Bxd4
+34. cxd4 Rxd4 35. Re7 Rf8 36. Qe5 Rd5 37. Qc7 Qxc7 38. Rxc7 Rxa5 39. Rxb7 Rxh5
+40. b4 Rc8 41. Ree7 Rf5 42. Rbc7 Rb8 43. Rc4 Ra8 44. Rc2 Rb5 45. Rb2 Rab8 46.
+Re4 h5 47. Kf1 g5 48. Ke2 Kg7 49. Kd3 Kg6 50. Kc4 Kf5 51. Rd4 f6 52. Kc3 Rc8+
+53. Rc4 Rh8 54. Rc7 h4 55. Kc4 Rbb8 56. gxh4 gxh4 57. f3 h3 58. Rh2 Kf4 59. Rc6
+Kg3 60. Rh1 Kg2 61. Rc1 h2 62. Rxf6 h1=Q 63. Rg6+ Kf2 64. Rxh1 Rxh1 65. b5 Rc1+
+66. Kd4 Rxb5 67. Rg4 Rb4+ 68. Ke5 Rxg4 69. fxg4 Kg3 70. Kf5 Kh4 71. g5 Rc5+ 72.
+Kf6 Rxg5 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "alireza3700"]
+[Black "Training88"]
+[Result "0-1"]
+[ECO "A40"]
+[WhiteElo "2372"]
+[BlackElo "2340"]
+[PlyCount "76"]
+[EventDate "2020.??.??"]
+
+1. d4 a6 2. Nc3 b5 3. e4 Bb7 4. f3 b4 5. Nce2 e6 6. Be3 a5 7. Qd2 c5 8. dxc5
+Nf6 9. g4 Na6 10. Ng3 Nxc5 11. Bb5 Qb6 12. Ba4 Qc6 13. Bxc6 Bxc6 14. O-O-O Na4
+15. e5 Nd5 16. Ne4 g6 17. Nf6+ Ke7 18. b3 Nac3 19. Ne2 Nxe3 20. Qxe3 h5 21.
+Nxc3 hxg4 22. Nce4 Bh6 23. f4 a4 24. Qd4 Rhc8 25. Nxd7 axb3 26. Qc5+ Ke8 27.
+Nef6+ Kd8 28. Nb6+ Kc7 29. Nxa8+ Rxa8 30. Rd7+ Kb8 31. Qb6+ Kc8 32. Qb7+ Bxb7
+33. axb3 Ra1+ 34. Kb2 Rxh1 35. Rxf7 Bxf4 36. Ne8 Bxe5+ 37. c3 Bxc3+ 38. Kc2
+Be4# 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "rudolf85"]
+[Black "Paanoos"]
+[Result "0-1"]
+[ECO "A00"]
+[WhiteElo "2412"]
+[BlackElo "2390"]
+[PlyCount "50"]
+[EventDate "2020.??.??"]
+
+1. e3 b6 2. d4 Bb7 3. Nf3 e5 4. Be2 e4 5. Nfd2 f5 6. O-O Nf6 7. c4 Bd6 8. d5 a5
+9. Re1 h5 10. Nf1 Ng4 11. h3 Qh4 12. Bxg4 hxg4 13. Nc3 gxh3 14. g3 h2+ 15. Kh1
+Qh3 16. Qe2 Na6 17. Nb5 Nc5 18. Nxd6+ cxd6 19. Bd2 Nd3 20. Bc3 Ba6 21. b3 a4
+22. Red1 Rh7 23. Rxd3 exd3 24. Qxd3 Qg2+ 25. Kxg2 h1=Q# 0-1
+
+[Event "Rated Bullet tournament GAdGz1co"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "RhenzRheann_Auza98"]
+[Black "ScherlockKA"]
+[Result "1-0"]
+[ECO "A07"]
+[WhiteElo "2380"]
+[BlackElo "2326"]
+[PlyCount "97"]
+[EventDate "2020.??.??"]
+
+1. Nf3 d5 2. g3 c6 3. Bg2 Nf6 4. O-O Bf5 5. d4 h6 6. c4 e6 7. Nc3 Nbd7 8. Qb3
+Qb6 9. c5 Qc7 10. Bf4 Qc8 11. Nd2 Be7 12. e4 Bg6 13. exd5 exd5 14. Rfe1 Kf8 15.
+Re2 Bd3 16. Re3 Ba6 17. Rae1 Bd8 18. Bd6+ Kg8 19. Qc2 g6 20. Bh3 Kg7 21. Nf3
+Bc7 22. Re7 Qd8 23. Ne5 Nxe5 24. dxe5 Bxd6 25. exf6+ Kxf6 26. cxd6 Qxd6 27.
+R7e3 d4 28. Ne4+ Kg7 29. Nxd6 dxe3 30. Rxe3 Rhd8 31. Qc3+ Kh7 32. Nxf7 Rd1+ 33.
+Kg2 Bf1+ 34. Kf3 Rf8 35. Be6 Rd5 36. Bxd5 cxd5 37. Qf6 Bh3 38. Ng5+ Kg8 39.
+Qxf8+ Kxf8 40. Ne6+ Kf7 41. Nd4 Kf6 42. Re1 Kg7 43. Ke3 Bg4 44. Kd2 Kf7 45. f4
+Kf8 46. Re3 g5 47. Rc3 Kf7 48. Rc7+ Kf6 49. Rxb7 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Abouyahya1983"]
+[Black "LouiVos"]
+[Result "0-1"]
+[ECO "C28"]
+[WhiteElo "2561"]
+[BlackElo "2748"]
+[PlyCount "80"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 e5 2. Nc3 Nc6 3. Bc4 Nf6 4. d3 Bc5 5. f4 d6 6. Nf3 a6 7. a3 b5 8. Bb3 Nd4
+9. Nxd4 Bxd4 10. f5 c6 11. Bg5 Bd7 12. Qf3 Qb6 13. g4 Rf8 14. h4 O-O-O 15. Bd2
+h5 16. gxh5 a5 17. Bg5 Nh7 18. Bxd8 Qxd8 19. Ne2 Bb6 20. O-O-O Qf6 21. c3 Qh6+
+22. Kb1 Nf6 23. d4 Nxh5 24. a4 Nf6 25. c4 b4 26. c5 Bc7 27. Qd3 Kb7 28. Rc1 Ng4
+29. d5 Qe3 30. Qc4 dxc5 31. Rhd1 Nf2 32. Re1 Qxe4+ 33. Ka2 Qxc4 34. Bxc4 Bxf5
+35. Ng3 Bd7 36. dxc6+ Bxc6 37. Nf5 g6 38. Ne7 Bxa4 39. Rf1 Ne4 40. Nxg6 b3+ 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "ajedrez2021"]
+[Black "sutcunuri"]
+[Result "0-1"]
+[ECO "A10"]
+[WhiteElo "2581"]
+[BlackElo "2532"]
+[PlyCount "70"]
+[EventDate "2020.??.??"]
+
+1. c4 a6 2. Nf3 Ra7 3. g3 b6 4. d4 c6 5. Bg2 d6 6. e4 e6 7. Bg5 f6 8. Be3 g5 9.
+O-O h5 10. Nc3 h4 11. e5 hxg3 12. fxg3 g4 13. Nh4 f5 14. Ng6 Rah7 15. Nxh8 Rxh8
+16. d5 dxe5 17. dxc6 Qc7 18. c5 bxc5 19. Bg5 Nxc6 20. Qa4 Bd7 21. Qxa6 Nd4 22.
+Rae1 Kf7 23. Qd3 Kg6 24. Be3 Bg7 25. Ne2 Ne7 26. h3 gxh3 27. Bxd4 hxg2 28. Nf4+
+exf4 29. Kxg2 Bc6+ 30. Qf3 cxd4 31. Kg1 Bxf3 32. Rxf3 fxg3 33. Ree3 dxe3 34.
+Rxg3+ Qxg3+ 35. Kf1 Qf2# 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Ngc99"]
+[Black "gmdakajustine"]
+[Result "1-0"]
+[ECO "C01"]
+[WhiteElo "2345"]
+[BlackElo "2385"]
+[PlyCount "97"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 e6 2. d4 d5 3. exd5 exd5 4. Bd3 Nf6 5. c3 c6 6. h3 Bd6 7. Nf3 O-O 8. O-O
+h6 9. Re1 Be6 10. Nbd2 Nbd7 11. Ne5 Qc7 12. Ndf3 Rfe8 13. Bf4 Re7 14. Bh2 Rae8
+15. Qd2 Ne4 16. Bxe4 dxe4 17. Rxe4 f6 18. Nxd7 Bxh2+ 19. Nxh2 Bxd7 20. Rxe7
+Rxe7 21. Re1 Qd6 22. Re3 Kf7 23. Qe2 Rxe3 24. fxe3 Qd5 25. b3 Qe4 26. Nf1 Bf5
+27. Ng3 Qb1+ 28. Kh2 Bd3 29. Qh5+ Bg6 30. Qa5 Qd3 31. Qc7+ Kg8 32. Qxb7 Qxc3
+33. Qxa7 h5 34. Qb8+ Kh7 35. Qf4 Qb2 36. a4 Qxb3 37. a5 Qa3 38. Qc7 h4 39. Nf1
+Be4 40. Qf4 f5 41. Qxh4+ Kg6 42. Ng3 Qxe3 43. a6 Qxd4 44. Qh5+ Kf6 45. Nxe4+
+fxe4 46. Qh4+ Kf7 47. Qf4+ Kg6 48. Qc7 e3 49. Qxc6+ 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "tritarov1960"]
+[Black "chipmunknau"]
+[Result "0-1"]
+[ECO "A46"]
+[WhiteElo "2394"]
+[BlackElo "2568"]
+[PlyCount "88"]
+[EventDate "2020.??.??"]
+
+1. d4 Nf6 2. Nf3 e6 3. e3 c5 4. c4 cxd4 5. Nxd4 d5 6. cxd5 Nxd5 7. Be2 Nc6 8.
+Nb3 Be7 9. O-O O-O 10. N1d2 Qc7 11. Nc4 Rd8 12. Qe1 b5 13. Ncd2 a6 14. Nf3 Ndb4
+15. Bd1 Nd3 16. Qe2 Bf6 17. Bc2 Nxc1 18. Raxc1 Bb7 19. Nbd4 Qb6 20. Nxc6 Bxc6
+21. b3 Rac8 22. Bb1 Qb7 23. Rfd1 h6 24. h3 g6 25. Rxd8+ Rxd8 26. Rd1 Rc8 27.
+Ne1 Kg7 28. Rc1 Rd8 29. Rd1 Ra8 30. h4 h5 31. g3 a5 32. e4 a4 33. b4 Be7 34. f4
+Bxb4 35. f5 Bc5+ 36. Kh2 exf5 37. exf5 Re8 38. Qb2+ Kh7 39. fxg6+ fxg6 40. Qf6
+Rf8 41. Bxg6+ Kh6 42. Qg5+ Kg7 43. Be4+ Kh8 44. Bxc6 Qg7 0-1
+
+[Event "Rated Bullet tournament GAdGz1co"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "JeanGoulifet"]
+[Black "dragonwelb"]
+[Result "1-0"]
+[ECO "A45"]
+[WhiteElo "2386"]
+[BlackElo "2387"]
+[PlyCount "129"]
+[EventDate "2020.??.??"]
+
+1. d4 Nf6 2. Bf4 c5 3. e3 e6 4. Nf3 d5 5. c3 Nc6 6. Nbd2 Bd6 7. Bg3 O-O 8. Bd3
+b6 9. Ne5 Ne7 10. f4 Nf5 11. Bxf5 exf5 12. O-O Bb7 13. Qc2 Ne4 14. Nxe4 fxe4
+15. Ng4 h5 16. Nf2 f6 17. h3 Rc8 18. Rae1 cxd4 19. exd4 Qd7 20. Nd1 b5 21. Ne3
+f5 22. a3 a5 23. Qb3 Be7 24. Rd1 g6 25. Rfe1 h4 26. Bf2 Kf7 27. Nf1 Rfd8 28.
+Be3 Rc4 29. Qc2 b4 30. axb4 axb4 31. Qd2 bxc3 32. bxc3 Rdc8 33. Rc1 Qc6 34. Qf2
+Rxc3 35. Rxc3 Qxc3 36. Rc1 Qa5 37. Rxc8 Bxc8 38. Qc2 Ba6 39. Qc1 Qa2 40. Bf2
+Qe2 41. Nh2 Bc4 42. Qe1 Qxe1+ 43. Bxe1 Bf6 44. Nf1 Ke6 45. Bf2 Kd6 46. Ne3 Kc6
+47. g3 Kb5 48. gxh4 Bb3 49. h5 gxh5 50. Nxf5 Bc2 51. Ne3 Bxd4 52. Nxd5 Bxf2+
+53. Kxf2 Kc4 54. Ne3+ Kd3 55. Nxc2 Kxc2 56. Ke3 h4 57. f5 Kc3 58. f6 Kc4 59. f7
+Kd5 60. f8=Q Ke5 61. Qh6 Kd5 62. Qf4 Ke6 63. Qxe4+ Kd7 64. Qxh4 Kc6 65. Qh5 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "chesslismab"]
+[Black "hungzhao"]
+[Result "0-1"]
+[ECO "A06"]
+[WhiteElo "2452"]
+[BlackElo "2621"]
+[PlyCount "54"]
+[EventDate "2020.??.??"]
+
+1. e4 d5 2. Nf3 dxe4 3. Ng5 Nf6 4. d4 h6 5. Nh3 Bg4 6. Be2 Bxh3 7. gxh3 Nc6 8.
+c3 e5 9. dxe5 Qxd1+ 10. Kxd1 Nxe5 11. Kc2 O-O-O 12. Bf4 Ng6 13. Bg3 Bd6 14. Nd2
+Bf4 15. Nc4 h5 16. h4 Rd7 17. Rad1 Rhd8 18. Rxd7 Rxd7 19. a4 c6 20. Ne3 Be5 21.
+Nf5 Nf4 22. Bxf4 Bxf4 23. Nxg7 Rd2+ 24. Kb3 Rxe2 25. Rd1 Rxf2 26. Nf5 Kc7 27.
+Ne7 Bd6 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Frogkiller"]
+[Black "Karabakh-Azerbaijan"]
+[Result "0-1"]
+[ECO "B33"]
+[WhiteElo "2365"]
+[BlackElo "2458"]
+[PlyCount "120"]
+[EventDate "2020.??.??"]
+
+1. e4 c5 2. Nf3 Nc6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 e5 6. Ndb5 d6 7. Bg5 a6 8.
+Na3 b5 9. Nd5 Be7 10. Bxf6 Bxf6 11. g3 O-O 12. Bg2 Be6 13. O-O Bg5 14. c3 Ne7
+15. Nxe7+ Qxe7 16. Nc2 Rad8 17. a4 Bb3 18. axb5 axb5 19. Qb1 f5 20. exf5 Rxf5
+21. Nd4 exd4 22. Qxf5 Bc4 23. Rfe1 Qf6 24. Bd5+ Kh8 25. Qxf6 Bxf6 26. Bxc4 bxc4
+27. cxd4 Bxd4 28. Ra4 d5 29. Rd1 Bxb2 30. Rxc4 h6 31. Rc2 Bf6 32. Kg2 d4 33. h4
+Kh7 34. Rcd2 Kg6 35. Rd3 Kf5 36. Rf3+ Kg6 37. Rdd3 h5 38. Rf4 Rd6 39. Kf3 Be5
+40. Re4 Kf6 41. Rd1 Kf5 42. Re2 Bf6 43. Rd3 Rd5 44. Red2 Rd6 45. Rd1 Ke5 46.
+Kg2 Kd5 47. Kf1 Ke5 48. Ke2 Kd5 49. Kf3 Re6 50. Kf4 Rd6 51. Kf5 Be5 52. Kg5 Rf6
+53. Kxh5 Re6 54. Kg4 Rd6 55. Kf3 Bf6 56. Kg2 Re6 57. f4 Be5 58. Kf3 Bd6 59. g4
+Re4 60. f5 Re6 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Northridgehawk"]
+[Black "zenon011"]
+[Result "1-0"]
+[ECO "C23"]
+[WhiteElo "2346"]
+[BlackElo "2347"]
+[PlyCount "25"]
+[EventDate "2020.??.??"]
+
+1. e4 e5 2. Nc3 Nc6 3. Bc4 Bc5 4. Qg4 Qf6 5. Nd5 Qh6 6. Nxc7+ Kd8 7. Nxa8 d5 8.
+d4 Bxg4 9. Bxh6 Nxd4 10. Bxg7 dxc4 11. f3 Be6 12. O-O-O Ke7 13. Bxh8 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Olaffo"]
+[Black "telodijomonstruo"]
+[Result "1-0"]
+[ECO "A00"]
+[WhiteElo "2519"]
+[BlackElo "2513"]
+[PlyCount "73"]
+[EventDate "2020.??.??"]
+
+1. g3 e5 2. Bg2 Nc6 3. b3 Nf6 4. Bb2 d5 5. e3 Bd6 6. Ne2 e4 7. O-O h5 8. c4
+dxc4 9. bxc4 h4 10. d3 hxg3 11. hxg3 Bh3 12. dxe4 Qd7 13. Nf4 Bxg2 14. Kxg2
+O-O-O 15. c5 g5 16. cxd6 gxf4 17. Rh1 Rxh1 18. Qxh1 f3+ 19. Kxf3 Qg4+ 20. Kg2
+Qxe4+ 21. Kg1 Qc2 22. Bxf6 Qd1+ 23. Kg2 Qd5+ 24. Kh2 Qh5+ 25. Kg1 Qd1+ 26. Kg2
+Qd5+ 27. f3 Rxd6 28. Qh3+ Kb8 29. e4 Nd8 30. exd5 b6 31. Nc3 Kb7 32. Qh8 Rxf6
+33. Qxf6 Nc6 34. dxc6+ Ka6 35. Qd4 b5 36. Qc5 b4 37. Qb5# 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "jpboyeras"]
+[Black "SuperDonald"]
+[Result "1-0"]
+[ECO "D02"]
+[WhiteElo "2333"]
+[BlackElo "2340"]
+[PlyCount "113"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. Nf3 d5 2. d4 Nf6 3. Bf4 c5 4. e3 Nc6 5. c3 Qb6 6. Qb3 c4 7. Qc2 Bf5 8. Qc1
+e6 9. Be2 Be7 10. Bd1 O-O 11. Bc2 Rfc8 12. O-O Qd8 13. Nbd2 b5 14. Re1 a5 15.
+e4 Bg6 16. Ne5 Nxe5 17. Bxe5 Nxe4 18. Nxe4 dxe4 19. Bxe4 Bxe4 20. Rxe4 Bf8 21.
+h3 b4 22. Re2 Bd6 23. Qd2 Rab8 24. Rae1 a4 25. Bxd6 Qxd6 26. cxb4 Rd8 27. a3
+Qxd4 28. Qc2 Qd3 29. Rc1 Qb3 30. Qxc4 Rd1+ 31. Kh2 Rxc1 32. Qxc1 h6 33. Qc3 Qd5
+34. Rd2 Qf5 35. g3 e5 36. Qd3 Qe6 37. Qd5 Qf6 38. Re2 Re8 39. Qb5 Re7 40. Qxa4
+e4 41. Qa8+ Kh7 42. Qa4 Qf3 43. Qc2 f5 44. Re3 Qh5 45. g4 Qg6 46. gxf5 Qxf5 47.
+Qe2 Qf4+ 48. Kg2 Qg5+ 49. Qg4 Qd5 50. b5 h5 51. Qf4 Re5 52. h4 g6 53. Rc3 Qd6
+54. Kg3 Qe6 55. Rc7+ Kh8 56. Qf8+ Qg8 57. Qh6+ 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Maxterlopez"]
+[Black "FerociousLion98999"]
+[Result "1-0"]
+[ECO "C41"]
+[WhiteElo "2649"]
+[BlackElo "2588"]
+[PlyCount "77"]
+[EventDate "2020.??.??"]
+
+1. e4 e5 2. Nf3 d6 3. Bc4 Nc6 4. d4 Bg4 5. dxe5 dxe5 6. Nbd2 Nf6 7. h3 Bh5 8.
+c3 Bg6 9. Qe2 Be7 10. O-O O-O 11. Rd1 Qc8 12. b4 a6 13. Nh4 Nxe4 14. Nxg6 Nxc3
+15. Nxe7+ Nxe7 16. Qf3 Nxd1 17. Qxd1 Rd8 18. Qf3 Qf5 19. Qxf5 Nxf5 20. Bb3 Nd4
+21. Kf1 Kf8 22. Ba3 Nb5 23. Nc4 Rd4 24. Bb2 Rd5 25. Nb6 Rd2 26. Nxa8 Rxb2 27.
+Bc4 Rc2 28. Bxb5 axb5 29. a4 bxa4 30. Rxa4 Ke7 31. Ra7 Kd6 32. Rxb7 f5 33. b5
+e4 34. b6 Ra2 35. Nxc7 f4 36. Nb5+ Kc6 37. Rc7+ Kxb5 38. b7 f3 39. b8=Q+ 1-0
+
+[Event "Rated Bullet tournament GAdGz1co"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "RaylessStarfish"]
+[Black "Zuritadas"]
+[Result "0-1"]
+[ECO "A30"]
+[WhiteElo "2382"]
+[BlackElo "2393"]
+[PlyCount "66"]
+[EventDate "2020.??.??"]
+
+1. c4 c5 2. g3 Nc6 3. Bg2 g6 4. Nf3 Bg7 5. O-O e6 6. Nc3 Nge7 7. e3 O-O 8. d4
+cxd4 9. Nxd4 d5 10. cxd5 Nxd5 11. Nce2 Nxd4 12. Nxd4 Bd7 13. b3 Rc8 14. Bb2 Bc6
+15. Nxc6 Rxc6 16. Bxg7 Kxg7 17. Qd4+ Qf6 18. Qxf6+ Kxf6 19. Rfd1 Rd6 20. e4
+Rfd8 21. exd5 exd5 22. Rd4 g5 23. Rad1 Ke5 24. f4+ gxf4 25. gxf4+ Ke6 26. Bh3+
+Kf6 27. Kf2 b6 28. a4 a5 29. Bg2 Ke6 30. Kf3 f5 31. Kg3 Rg8+ 32. Kh3 Ke7 33.
+Rxd5 Rh6# 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "fusionpro"]
+[Black "Bighamian"]
+[Result "1-0"]
+[ECO "E63"]
+[WhiteElo "2436"]
+[BlackElo "2349"]
+[PlyCount "67"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 Nf6 2. g3 g6 3. Bg2 Bg7 4. Nf3 O-O 5. O-O d6 6. c4 a6 7. Nc3 Nc6 8. e4
+Rb8 9. Re1 e5 10. d5 Na5 11. Bf1 c5 12. dxc6 bxc6 13. h3 Be6 14. b3 Qd7 15. Kh2
+Rfd8 16. Ng5 d5 17. Nxe6 fxe6 18. exd5 exd5 19. cxd5 Nxd5 20. Nxd5 cxd5 21. Bg5
+Rf8 22. Qd2 e4 23. Rad1 Nc6 24. Bxa6 Nd4 25. Be2 Qf5 26. Be3 Ne6 27. Qxd5 Be5
+28. Bg4 Bxg3+ 29. fxg3 Qxd5 30. Rxd5 Nc7 31. Bf4 Nxd5 32. Bxb8 Nc3 33. Be5 Nxa2
+34. Be6+ 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "irakliberadze"]
+[Black "taras05"]
+[Result "1-0"]
+[ECO "B00"]
+[WhiteElo "2655"]
+[BlackElo "2479"]
+[PlyCount "41"]
+[EventDate "2020.??.??"]
+
+1. e4 Nc6 2. Nf3 d5 3. exd5 Qxd5 4. Nc3 Qa5 5. d4 Bg4 6. d5 O-O-O 7. Bd2 Ne5 8.
+Be2 Nxf3+ 9. Bxf3 Bxf3 10. Qxf3 Nf6 11. O-O-O Qb6 12. Kb1 e6 13. Be3 Qa6 14.
+dxe6 Qxe6 15. Rxd8+ Kxd8 16. Qxb7 Bd6 17. Rd1 Ke7 18. Qxa7 Ne4 19. Nxe4 Qxe4
+20. Bc5 Qc6 21. Bxd6+ 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "vassiukov"]
+[Black "vaillant77"]
+[Result "0-1"]
+[ECO "A00"]
+[WhiteElo "2371"]
+[BlackElo "2421"]
+[PlyCount "56"]
+[EventDate "2020.??.??"]
+
+1. a3 g6 2. b3 Bg7 3. c3 e5 4. d3 Ne7 5. e3 O-O 6. f3 d5 7. g3 d4 8. cxd4 exd4
+9. e4 f5 10. Nd2 fxe4 11. Nxe4 Nbc6 12. Bg2 Ne5 13. Ne2 Nd5 14. O-O Ne3 15.
+Bxe3 dxe3 16. Rc1 Nxd3 17. Rc2 Be6 18. Nc1 Nxc1 19. Qxc1 Bxb3 20. Rxc7 e2 21.
+Re1 Qd4+ 22. Kh1 Bd1 23. Nf2 Qxf2 24. Qc4+ Kh8 25. Qb4 Rae8 26. f4 a5 27. Qxa5
+g5 28. Bc6 bxc6 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "fedateam"]
+[Black "PimponNicois"]
+[Result "1-0"]
+[ECO "D10"]
+[WhiteElo "2345"]
+[BlackElo "2335"]
+[PlyCount "85"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 d5 2. c4 c6 3. Nc3 Nf6 4. e3 e6 5. Qc2 Nbd7 6. Bd2 Bd6 7. O-O-O O-O 8. e4
+Nxe4 9. Nxe4 dxe4 10. Qxe4 c5 11. Bc3 Qc7 12. Qh4 Re8 13. Bd3 Nf8 14. Kb1 Be7
+15. Qh5 Bf6 16. Ne2 Bd7 17. dxc5 Bxc3 18. Nxc3 Rac8 19. Ne4 Red8 20. Nd6 g6 21.
+Qf3 f5 22. Nxc8 Rxc8 23. Qe3 Qxc5 24. Qxc5 Rxc5 25. f4 Bc6 26. Rhg1 Nd7 27. g3
+a5 28. Rge1 Kf7 29. b3 Nf6 30. Re5 Rxe5 31. fxe5 Ng4 32. Re1 Nxh2 33. a3 Nf3
+34. Re3 h5 35. b4 axb4 36. axb4 b6 37. c5 bxc5 38. bxc5 Nd4 39. Bf1 Be4+ 40.
+Kb2 Nc6 41. Rc3 Nxe5 42. Bb5 Ke7 43. c6 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Rusticous"]
+[Black "Kralj56"]
+[Result "0-1"]
+[ECO "E67"]
+[WhiteElo "2338"]
+[BlackElo "2453"]
+[PlyCount "106"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. c4 g6 2. Nc3 Bg7 3. d4 d6 4. Nf3 Nd7 5. g3 Ngf6 6. Bg2 O-O 7. O-O e5 8. h3
+c6 9. dxe5 dxe5 10. Qd6 Re8 11. Bg5 Bf8 12. Qd2 Qa5 13. Rfd1 Bg7 14. a3 Qc5 15.
+Rac1 a5 16. Be3 Qe7 17. Ng5 Nc5 18. Qd6 Nb3 19. Qxe7 Rxe7 20. Rd8+ Re8 21. Rcd1
+Be6 22. Rxa8 Rxa8 23. Nxe6 fxe6 24. Na4 Kf7 25. Rd3 Na1 26. Nc5 Rb8 27. Bg5 h6
+28. Bxf6 Bxf6 29. Rd7+ Be7 30. Nxb7 Nc2 31. Bxc6 Nd4 32. Be4 Nxe2+ 33. Kg2 Nd4
+34. c5 Ke8 35. c6 Nf5 36. g4 Nd4 37. Bxg6+ Kf8 38. Be4 Rc8 39. Nd6 Rxc6 40.
+Bxc6 Nxc6 41. Ne4 Ke8 42. Rc7 Nd4 43. Ra7 Bd8 44. Nd6+ Kf8 45. Kg3 e4 46. h4 e3
+47. fxe3 Nc2 48. Ra8 Ke7 49. Rxd8 Kxd8 50. Nc4 a4 51. Kf3 Ke7 52. Ke4 Ne1 53.
+Nd2 Ng2 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Kidefence"]
+[Black "BlueGreensun"]
+[Result "0-1"]
+[ECO "B00"]
+[WhiteElo "2733"]
+[BlackElo "2732"]
+[PlyCount "46"]
+[EventDate "2020.??.??"]
+
+1. e4 e5 2. d4 Nc6 3. dxe5 d6 4. Nf3 Bg4 5. exd6 Bxd6 6. Be2 Nf6 7. Nc3 Qe7 8.
+Bg5 O-O-O 9. h3 Bxf3 10. Bxf3 Bf4 11. Bxf4 Rxd1+ 12. Rxd1 Ne5 13. Be2 Ng6 14.
+Be3 Nxe4 15. Nxe4 Qxe4 16. O-O Qxc2 17. Bg4+ f5 18. Bf3 Ne5 19. Bd5 Kb8 20. Bd4
+Nc6 21. Bxg7 Rd8 22. Bb3 Qxb2 23. Rb1 Qxg7 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Paanoos"]
+[Black "rudolf85"]
+[Result "0-1"]
+[ECO "A01"]
+[WhiteElo "2396"]
+[BlackElo "2406"]
+[PlyCount "66"]
+[EventDate "2020.??.??"]
+
+1. b3 d5 2. Bb2 Nf6 3. e4 dxe4 4. Nc3 e6 5. Qe2 Be7 6. Nxe4 O-O 7. g4 Nbd7 8.
+g5 Nxe4 9. Qxe4 Bxg5 10. O-O-O Bf6 11. d4 c5 12. Nf3 cxd4 13. Nxd4 Qa5 14. Rg1
+Qxa2 15. Bd3 g6 16. h4 Nc5 17. Qf4 Nxd3+ 18. Rxd3 Bg7 19. Qg3 e5 20. Nb5 e4 21.
+Bxg7 Kxg7 22. Qe5+ f6 23. Qxe4 Qa1+ 24. Kd2 Qxg1 25. Nd6 Qh2 26. Kc3 Bf5 27.
+Qe7+ Kh8 28. Nf7+ Rxf7 29. Qxf7 Rc8+ 30. Kb2 Qe5+ 31. Ka2 Bxd3 32. cxd3 Qc3 33.
+Qxf6+ Qxf6 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Realblindmuddy"]
+[Black "Antropterix"]
+[Result "1-0"]
+[ECO "E92"]
+[WhiteElo "2392"]
+[BlackElo "2318"]
+[PlyCount "75"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. Nf3 Nf6 2. c4 g6 3. Nc3 Bg7 4. e4 O-O 5. d4 d6 6. Be2 e5 7. Be3 Nc6 8. d5
+Ne7 9. Nd2 Ne8 10. O-O f5 11. f3 c5 12. dxc6 bxc6 13. b4 Be6 14. Rc1 Rf7 15. b5
+d5 16. cxd5 cxd5 17. exd5 Nxd5 18. Nxd5 Bxd5 19. Bc4 Rd7 20. Qb3 Nf6 21. Rfd1
+h6 22. Bf2 Kh7 23. Bxd5 Nxd5 24. Nc4 Rb8 25. a4 Rc8 26. h3 Qg8 27. Na5 Rxc1 28.
+Rxc1 e4 29. fxe4 fxe4 30. Rd1 Bc3 31. Nc6 Qe6 32. Be1 Bf6 33. Nxa7 Qb6+ 34. Kh1
+Qxa7 35. Rxd5 Rxd5 36. Qxd5 Qxa4 37. Qd7+ Bg7 38. Bc3 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "LordBendtner99"]
+[Black "Ganziitoo"]
+[Result "0-1"]
+[ECO "A00"]
+[WhiteElo "2490"]
+[BlackElo "2408"]
+[PlyCount "120"]
+[EventDate "2020.??.??"]
+
+1. g3 Nf6 2. f3 d6 3. Nh3 Nbd7 4. Nf2 e5 5. Bg2 Be7 6. O-O O-O 7. d3 c6 8. e4
+d5 9. c3 dxe4 10. dxe4 Qc7 11. Be3 Nc5 12. Qe2 Be6 13. Nd2 Rfd8 14. f4 exf4 15.
+gxf4 a5 16. f5 Bc8 17. Ng4 Ncd7 18. Bf4 Qb6+ 19. Kh1 Qxb2 20. e5 Nxg4 21. Qxg4
+Qxc3 22. f6 Nxf6 23. Qh4 Nd5 24. Bg5 Bxg5 25. Qxg5 Be6 26. Nf3 Qe3 27. Qg3 Qf4
+28. Qf2 Ne3 29. Rg1 Nxg2 30. Rxg2 Bd5 31. Rf1 Bxf3 32. Qxf3 Qxf3 33. Rxf3 Rd1+
+34. Rg1 Rxg1+ 35. Kxg1 Rd8 36. Rf2 Rd3 37. Kg2 Kf8 38. Re2 Ke7 39. Kf2 Rd5 40.
+Rc2 Ke6 41. Rb2 b5 42. Rc2 c5 43. Rb2 b4 44. Re2 Rxe5 45. Rd2 Rf5+ 46. Kg3 Rd5
+47. Re2+ Kd6 48. Rf2 c4 49. Rxf7 c3 50. Rxg7 c2 51. Rxh7 c1=Q 52. Rh6+ Qxh6 53.
+h4 Qg6+ 54. Kh3 Rf5 55. h5 Qf6 56. Kh2 Qd4 57. Kg3 Re5 58. Kf3 Re3+ 59. Kf2
+Qd2+ 60. Kf1 Re1# 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "self_service"]
+[Black "allan-cantonjos"]
+[Result "0-1"]
+[ECO "A10"]
+[WhiteElo "2424"]
+[BlackElo "2410"]
+[PlyCount "50"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. c4 b6 2. Nc3 Bb7 3. e4 e6 4. d4 d6 5. f3 Nd7 6. Bd3 Ngf6 7. Nge2 Be7 8. O-O
+O-O 9. f4 c5 10. d5 exd5 11. cxd5 a6 12. Ng3 Re8 13. Nf5 Bf8 14. Rf3 b5 15. Rg3
+g6 16. h4 b4 17. Ne2 Nxe4 18. Bxe4 Rxe4 19. h5 Nf6 20. hxg6 hxg6 21. b3 Nxd5
+22. Bb2 Nf6 23. Rg5 d5 24. Neg3 d4 25. Nxe4 Nxe4 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Dimitriy1975"]
+[Black "mixo23"]
+[Result "1-0"]
+[ECO "A43"]
+[WhiteElo "2376"]
+[BlackElo "2428"]
+[PlyCount "57"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 c5 2. d5 Nf6 3. c4 g6 4. Nc3 Bg7 5. Nf3 O-O 6. e4 e6 7. Bd3 exd5 8. cxd5
+b5 9. O-O c4 10. Bc2 b4 11. Ne2 Re8 12. Ng3 d6 13. h3 a5 14. Re1 Nbd7 15. Nd4
+Bb7 16. Bf4 Ne5 17. Qd2 Qb6 18. Rad1 Rac8 19. Be3 c3 20. bxc3 Nc4 21. Qc1 Nxe3
+22. Qxe3 Rxc3 23. Qd2 Nxd5 24. Ba4 Re7 25. exd5 Rxe1+ 26. Rxe1 Bxd4 27. Re8+
+Kg7 28. Nh5+ gxh5 29. Qg5# 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "RigelStar"]
+[Black "FinalCut"]
+[Result "0-1"]
+[ECO "A43"]
+[WhiteElo "2411"]
+[BlackElo "2447"]
+[PlyCount "56"]
+[EventDate "2020.??.??"]
+
+1. d4 c5 2. Nf3 cxd4 3. Qxd4 Nc6 4. Qd1 g6 5. b3 Bg7 6. c3 d5 7. Bb2 Nf6 8. e3
+O-O 9. Nbd2 e5 10. Bb5 Qc7 11. c4 e4 12. Bxc6 exf3 13. Bxd5 Nxd5 14. Bxg7 Kxg7
+15. cxd5 fxg2 16. Rg1 Qxh2 17. Nf3 Qh3 18. Qd4+ f6 19. Ng5 Qh2 20. Kd2 Bf5 21.
+Rac1 Rac8 22. Nf3 Qh3 23. Ng5 Qh2 24. Nf3 Qh5 25. Ne1 Rxc1 26. Kxc1 Qe2 27. Qd2
+Rc8+ 28. Nc2 Rxc2+ 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "WildBreath"]
+[Black "Nurgyul"]
+[Result "1/2-1/2"]
+[ECO "B13"]
+[WhiteElo "2422"]
+[BlackElo "2564"]
+[PlyCount "137"]
+[EventDate "2020.??.??"]
+
+1. e4 c6 2. d4 d5 3. exd5 cxd5 4. Bd3 Nf6 5. h3 Nc6 6. c3 g6 7. Nf3 Bf5 8. O-O
+Bxd3 9. Qxd3 Bg7 10. Bf4 O-O 11. Nbd2 Rc8 12. Rfe1 Nd7 13. Qe2 e6 14. Bg3 a6
+15. a4 Qb6 16. Rab1 Rfe8 17. Nf1 h6 18. Ne3 Nf6 19. Nd2 Nd7 20. Ng4 Kh7 21. Nf3
+Qd8 22. Nge5 Ndxe5 23. Nxe5 Nxe5 24. Bxe5 Bxe5 25. Qxe5 Qc7 26. Qe3 Qd7 27. Ra1
+Rc4 28. f4 Rxa4 29. Rxa4 Qxa4 30. f5 gxf5 31. Qe5 Qd7 32. Re3 Rg8 33. Qf6 Rg6
+34. Qe5 Qd8 35. Kh2 Qg5 36. Re2 f4 37. Qc7 Qg3+ 38. Kg1 Rg7 39. Rf2 Qxh3 40.
+Qxf4 Qg4 41. Qxg4 Rxg4 42. Rxf7+ Rg7 43. Rf6 Re7 44. Kf2 Kg7 45. Rf4 e5 46. Rf3
+exd4 47. cxd4 Re4 48. Rc3 Rxd4 49. Rc7+ Kf6 50. Rxb7 Rf4+ 51. Kg3 Rc4 52. Rb6+
+Ke5 53. Rxa6 Rb4 54. Rxh6 Rxb2 55. Rh5+ Kd4 56. Kh4 Kc5 57. g4 Rb3 58. g5 Rb4+
+59. Kg3 Re4 60. g6 Re6 61. Kg4 Rxg6+ 62. Rg5 Rxg5+ 63. Kxg5 d4 64. Kf5 Kc4 65.
+Kf6 d3 66. Kf7 d2 67. Ke6 d1=Q 68. Kf6 Qd2 69. Kf7 1/2-1/2
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Dohani"]
+[Black "anonim070"]
+[Result "1-0"]
+[ECO "A04"]
+[WhiteElo "2371"]
+[BlackElo "2341"]
+[PlyCount "100"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. Nf3 Nf6 2. d3 d6 3. e4 c5 4. b3 Nc6 5. Bb2 g6 6. g3 Bg7 7. Bg2 O-O 8. Nbd2
+Rb8 9. O-O b5 10. a4 a6 11. axb5 axb5 12. Re1 h6 13. e5 dxe5 14. Nxe5 Nxe5 15.
+Bxe5 Rb6 16. Ra7 Bg4 17. Qa1 Re6 18. h3 Bh5 19. g4 Bxg4 20. hxg4 Nxg4 21. Bxg7
+Rxe1+ 22. Qxe1 Kxg7 23. Qxe7 Qd4 24. Qe2 Re8 25. Qf1 Qf4 26. Nf3 h5 27. Qa1+
+Kh6 28. Qd1 f6 29. Qd2 Qxd2 30. Nxd2 Re1+ 31. Nf1 Rc1 32. Ra2 b4 33. Bf3 Ne5
+34. Be2 Kg5 35. Kg2 Nc6 36. Nh2 Nd4 37. Nf3+ Nxf3 38. Kxf3 h4 39. Kg2 Kf4 40.
+Ra6 Rxc2 41. Bf1 Kg5 42. Rc6 f5 43. d4 Rc4 44. d5 Rd4 45. d6 Kf4 46. Bc4 g5 47.
+Rxc5 g4 48. Rd5 h3+ 49. Kh2 Re4 50. d7 Kf3 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "lord_barre"]
+[Black "MrMania"]
+[Result "1-0"]
+[ECO "E65"]
+[WhiteElo "2410"]
+[BlackElo "2384"]
+[PlyCount "133"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. Nf3 c5 2. c4 d6 3. g3 Nf6 4. Bg2 g6 5. O-O Bg7 6. Nc3 O-O 7. d4 cxd4 8. Nxd4
+Nc6 9. Nxc6 bxc6 10. Bxc6 Bh3 11. Bg2 Bxg2 12. Kxg2 Rc8 13. Qd3 Qc7 14. b3 d5
+15. Bf4 e5 16. Bg5 dxc4 17. bxc4 Qxc4 18. Qxc4 Rxc4 19. Bxf6 Rxc3 20. Bxg7 Kxg7
+21. Rfd1 Rc2 22. e4 Rb8 23. Rd5 Rbb2 24. Rf1 Kf6 25. Rd6+ Ke7 26. Rd5 f6 27. a4
+Ra2 28. Ra5 Rc7 29. h4 Ke6 30. Ra6+ Kf7 31. Rb1 f5 32. exf5 gxf5 33. Rb5 Re2
+34. Rba5 Rcc2 35. Rxa7+ Ke6 36. R5a6+ Kd5 37. Rd7+ Ke4 38. Rb6 Rxf2+ 39. Kg1
+Rg2+ 40. Kf1 Rgf2+ 41. Ke1 Rh2 42. Rb4+ Kf3 43. Rd3+ Kg2 44. Kd1 Ra2 45. Rd2+
+Kh3 46. Rxh2+ Kxh2 47. Kc1 Kxg3 48. Kb1 Re2 49. a5 Rd2 50. Rb3+ Kg2 51. Rb2
+Rxb2+ 52. Kxb2 f4 53. a6 f3 54. a7 f2 55. a8=Q+ Kg1 56. Qg8+ Kh1 57. Qf7 Kg2
+58. Qg7+ Kh1 59. Qf6 Kg2 60. Qg5+ Kh1 61. Qf5 Kg2 62. Qg4+ Kh1 63. Qf3+ Kg1 64.
+Qg3+ Kf1 65. Kc2 e4 66. Kd2 h5 67. Ke3 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "pupilochess86"]
+[Black "Garrincha1"]
+[Result "1-0"]
+[ECO "A43"]
+[WhiteElo "2502"]
+[BlackElo "2498"]
+[PlyCount "69"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 c5 2. e3 cxd4 3. exd4 d5 4. Bd3 Nc6 5. c3 g6 6. Bf4 Bg7 7. Nf3 Nf6 8.
+Nbd2 Bg4 9. h3 Bxf3 10. Nxf3 O-O 11. O-O a6 12. a4 Ne4 13. Qe2 Nd6 14. Rfe1 Re8
+15. h4 Na5 16. h5 b5 17. axb5 axb5 18. h6 Bf6 19. Bxb5 Nxb5 20. Qxb5 e6 21. Ne5
+Be7 22. b4 Nb3 23. Nc6 Qd7 24. Nxe7+ Qxe7 25. Ra6 Rxa6 26. Qxa6 g5 27. Bd6 Qd7
+28. b5 Nd2 29. Bc5 Ne4 30. b6 Rb8 31. c4 Qc6 32. cxd5 exd5 33. Qa7 Qb7 34. Qxb7
+Rxb7 35. f3 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "DoctorFromGallifrey"]
+[Black "Clark_Kent97"]
+[Result "0-1"]
+[ECO "B00"]
+[WhiteElo "2556"]
+[BlackElo "2560"]
+[PlyCount "116"]
+[EventDate "2020.??.??"]
+
+1. e4 b6 2. d4 Bb7 3. Nc3 e6 4. f3 Nf6 5. Nge2 d5 6. exd5 Nxd5 7. Nxd5 Bxd5 8.
+Nc3 Bb7 9. Be3 Be7 10. Qd2 Nd7 11. O-O-O Nf6 12. g4 h6 13. Bb5+ c6 14. Be2 Qd7
+15. h4 O-O-O 16. g5 hxg5 17. hxg5 Nd5 18. Nxd5 Qxd5 19. c4 Qd7 20. Qc3 f6 21.
+gxf6 gxf6 22. a4 Qc7 23. a5 c5 24. axb6 axb6 25. dxc5 bxc5 26. Rxh8 Rxh8 27.
+Qd2 Rd8 28. Qc2 Rxd1+ 29. Bxd1 Qe5 30. Qd2 Qd6 31. f4 Be4 32. Qa5 Qd3 33. Qa6+
+Kd7 34. Qa7+ Ke8 35. Qa3 Qxc4+ 36. Kd2 Qd5+ 37. Ke1 c4 38. Ba4+ Kf7 39. Qc3 Bd3
+40. Bc2 Qf3 41. Qd2 Bxc2 42. f5 Bxf5 43. Bf2 Bd3 44. Qe3 Qxe3+ 45. Bxe3 Bb4+
+46. Kf2 Ke8 47. Bd4 e5 48. Bc3 Bxc3 49. bxc3 Kd7 50. Ke3 Ke6 51. Kf3 f5 52. Kg3
+Kd5 53. Kh4 e4 54. Kg3 e3 55. Kh4 e2 56. Kg5 e1=Q 57. Kf6 Qxc3+ 58. Kg5 Qe5 0-1
+
+[Event "Rated Bullet tournament Ty5yUoqy"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Superman89"]
+[Black "RyanX4FleteChavale"]
+[Result "1-0"]
+[ECO "A51"]
+[WhiteElo "2327"]
+[BlackElo "2362"]
+[PlyCount "103"]
+[EventDate "2020.??.??"]
+
+1. d4 Nf6 2. c4 e5 3. Nc3 exd4 4. Qxd4 Nc6 5. Qd2 Bc5 6. f3 d6 7. e4 Bb4 8. Bd3
+Ne5 9. Nge2 Be6 10. a3 Nxd3+ 11. Qxd3 Bc5 12. Nd5 Bxd5 13. cxd5 a5 14. Be3 Bb6
+15. Bxb6 cxb6 16. O-O O-O 17. Nc3 Nd7 18. Nb5 Nc5 19. Qe3 a4 20. Rac1 Nb3 21.
+Rc3 Nc5 22. Qf4 Ra5 23. Nxd6 Qa8 24. Nc4 Ra7 25. Ne5 f6 26. Ng4 Qe8 27. h4 Nd7
+28. Qf5 Ne5 29. Nxe5 fxe5 30. Qe6+ Qxe6 31. dxe6 Re8 32. Rd1 b5 33. Rd7 Kf8 34.
+Rcc7 Rxe6 35. Rf7+ Ke8 36. Rxg7 Kf8 37. Rxh7 Kg8 38. Rcg7+ Kf8 39. Rf7+ Kg8 40.
+Rc7 Ra8 41. Rhg7+ Kh8 42. Rh7+ Kg8 43. Rhg7+ Kf8 44. Rgd7 Rg6 45. Rh7 Kg8 46.
+Rcf7 b6 47. Rd7 Rc8 48. Kh2 Rc1 49. Rhg7+ Kh8 50. Rd8+ Kxg7 51. Rd7+ Kh6 52.
+Rd6 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "zenon011"]
+[Black "Northridgehawk"]
+[Result "0-1"]
+[ECO "C50"]
+[WhiteElo "2342"]
+[BlackElo "2352"]
+[PlyCount "44"]
+[EventDate "2020.??.??"]
+
+1. e4 e5 2. Nf3 Nc6 3. Bc4 Nf6 4. d3 Bc5 5. Nc3 d6 6. Bb3 Bg4 7. Be3 O-O 8. h3
+Be6 9. Ne2 Bb6 10. Ng3 d5 11. O-O h6 12. Qe2 Re8 13. Bd2 Qd7 14. Nh4 Bxh3 15.
+gxh3 Qxh3 16. Nhf5 Ng4 17. Qxg4 Qxg4 18. Bxd5 Nd4 19. Kg2 Nxf5 20. exf5 c6 21.
+Bf3 Qd4 22. Rh1 Qxf2+ 0-1
+
+[Event "Rated Blitz tournament hM7PUvgg"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "emmacristal"]
+[Black "TioCridineno"]
+[Result "1-0"]
+[ECO "E63"]
+[WhiteElo "2332"]
+[BlackElo "2372"]
+[PlyCount "103"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 Nf6 2. c4 g6 3. Nf3 Bg7 4. g3 O-O 5. Bg2 d6 6. O-O Nc6 7. Nc3 a6 8. h3
+Rb8 9. a4 a5 10. b3 Nb4 11. Bb2 c6 12. Qd2 Bf5 13. Rfe1 Qc8 14. Kh2 Ne4 15.
+Nxe4 Bxe4 16. Bc3 c5 17. Bxb4 axb4 18. Rad1 Bxf3 19. exf3 Bxd4 20. Rxe7 Re8 21.
+Rde1 Rxe7 22. Rxe7 Qf8 23. Qe2 b6 24. Re4 h5 25. f4 Rd8 26. h4 Kg7 27. f5 Bf6
+28. fxg6 fxg6 29. Re6 Rd7 30. f4 Re7 31. f5 Qe8 32. Bd5 Rxe6 33. fxe6 Be5 34.
+Qf3 Qe7 35. Qf7+ Qxf7 36. exf7 Kf8 37. Kg2 Ke7 38. Kf3 Bf6 39. Kf4 Kf8 40. Be6
+Ke7 41. Ke4 Bg7 42. Kd5 Be5 43. Kc6 Bxg3 44. Kxb6 Bxh4 45. a5 Kf8 46. a6 Bd8+
+47. Kc6 Ke7 48. a7 Kxe6 49. f8=Q Bf6 50. a8=Q Kf5 51. Qae8 h4 52. Qef7 1-0
+
+[Event "Rated Blitz tournament hM7PUvgg"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "balachess2006"]
+[Black "AGG2020"]
+[Result "1/2-1/2"]
+[ECO "D02"]
+[WhiteElo "2407"]
+[BlackElo "2480"]
+[PlyCount "100"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. Nf3 d5 2. d4 e6 3. Bf4 Bd6 4. e3 Nf6 5. Nbd2 Bxf4 6. exf4 c5 7. c3 Qc7 8.
+Ne5 O-O 9. Bd3 b6 10. g4 Ba6 11. Bb1 cxd4 12. cxd4 Nfd7 13. g5 Nxe5 14. fxe5
+Nc6 15. Nb3 Rac8 16. f4 Nb4 17. Kf2 Nc2 18. Bxc2 Qxc2+ 19. Qxc2 Rxc2+ 20. Ke3
+Rxb2 21. Rhc1 Bc4 22. Nd2 b5 23. a4 a6 24. axb5 axb5 25. Rab1 Rxb1 26. Rxb1 Ra8
+27. Rb2 g6 28. h4 Ra3+ 29. Kf2 Rh3 30. Nf3 Kg7 31. Kg2 Bf1+ 32. Kf2 Rh1 33. Rb1
+Bg2 34. Rxh1 Bxh1 35. Nd2 Kf8 36. Ke3 Ke7 37. Kd3 Kd7 38. Kc3 Kc6 39. Kb4 Be4
+40. Nb3 Bd3 41. Na5+ Kd7 42. Nb3 Bc4 43. Nc5+ Kc6 44. Na6 Kb7 45. Ka5 Kc6 46.
+Nb4+ Kb7 47. Nc2 Ka7 48. Nb4 Kb7 49. Na6 Kc6 50. Nb4+ Kb7 1/2-1/2
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Schachpanda_YT"]
+[Black "Illustrado"]
+[Result "0-1"]
+[ECO "D04"]
+[WhiteElo "2320"]
+[BlackElo "2377"]
+[PlyCount "88"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 Nf6 2. Nf3 d5 3. e3 g6 4. Be2 Bg7 5. b3 O-O 6. Bb2 c6 7. O-O Bg4 8. c4 e6
+9. Nbd2 Nbd7 10. h3 Bxf3 11. Bxf3 a5 12. a3 Re8 13. Rc1 Bh6 14. g3 Qe7 15. Bg2
+Rad8 16. Qe2 Qf8 17. f4 Bg7 18. Nf3 Ne4 19. Ne5 Nxg3 20. Qg4 Nxf1 21. Rxf1 f5
+22. Qg3 Nxe5 23. fxe5 Bh6 24. Bc1 Rc8 25. c5 b6 26. cxb6 Rb8 27. e4 Bxc1 28.
+Rxc1 dxe4 29. Rxc6 Qxa3 30. h4 Qa1+ 31. Kh2 Qxd4 32. h5 Qd2 33. hxg6 Qh6+ 34.
+Kg1 Qxg6 35. Qc3 f4 36. Kf2 f3 37. Bh3 Kh8 38. b7 Rg8 39. Qc1 Qg3+ 40. Ke3 f2+
+41. Kxe4 Qxh3 42. Rc8 Qg2+ 43. Kd4 Rxb7 44. Rxg8+ Qxg8 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "BerserkAdopter"]
+[Black "estocastico"]
+[Result "0-1"]
+[ECO "C20"]
+[WhiteElo "2437"]
+[BlackElo "2587"]
+[PlyCount "88"]
+[EventDate "2020.??.??"]
+
+1. e4 e5 2. d3 Nc6 3. Nd2 Bc5 4. Ngf3 h6 5. h3 Nf6 6. c3 d5 7. Qe2 O-O 8. g3
+Re8 9. Bg2 a5 10. O-O b6 11. Re1 Ba6 12. exd5 Nxd5 13. Ne4 Bf8 14. Nh4 g6 15.
+Qg4 Bg7 16. Nxg6 fxg6 17. Qxg6 Nce7 18. Qh5 Bxd3 19. Bxh6 Bxe4 20. Bxe4 Qd6 21.
+Bxg7 Kxg7 22. Qh7+ Kf8 23. Rad1 Qe6 24. Qh8+ Qg8 25. Qh6+ Qg7 26. Qh5 Nf6 27.
+Qf3 Rad8 28. Rxd8 Rxd8 29. Bf5 Nxf5 30. Qxf5 e4 31. Rxe4 Kg8 32. Rh4 Re8 33.
+Kg2 Qe7 34. Rf4 Kg7 35. Qg5+ Kf7 36. Rh4 Rg8 37. Rh7+ Nxh7 38. Qxe7+ Kxe7 39.
+f4 Nf6 40. Kf3 Nd5 41. g4 Nxc3 42. f5 Nxa2 43. Kf4 Nb4 44. g5 Nd5+ 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "GoropadniPoni"]
+[Black "delagente"]
+[Result "1-0"]
+[ECO "C45"]
+[WhiteElo "2309"]
+[BlackElo "2311"]
+[PlyCount "77"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 e5 2. Nf3 Nc6 3. d4 exd4 4. Nxd4 Bc5 5. Nb3 Bb6 6. Nc3 Nf6 7. Qe2 d6 8.
+Be3 O-O 9. O-O-O Re8 10. f3 Qe7 11. Kb1 Bxe3 12. Qxe3 Be6 13. Bb5 a6 14. Bxc6
+bxc6 15. Nd4 Rab8 16. Nxc6 Qd7 17. Nxb8 Rxb8 18. e5 Ne8 19. Qa7 Rd8 20. Qxa6 h6
+21. Ne4 Rb8 22. exd6 cxd6 23. Nc5 Qe7 24. Nxe6 Qxe6 25. Rhe1 Qf6 26. b3 Qg6 27.
+Rd2 Qg5 28. Red1 Nf6 29. Qxd6 Re8 30. Qg3 Qa5 31. Qf4 Ra8 32. a4 Kh7 33. g4 Ra7
+34. h4 Ra6 35. g5 hxg5 36. hxg5 Nh5 37. Qe4+ g6 38. Rd8 Rb6 39. Qd4 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Tigerscot"]
+[Black "LordGrim2500"]
+[Result "0-1"]
+[ECO "D01"]
+[WhiteElo "2463"]
+[BlackElo "2467"]
+[PlyCount "108"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 Nf6 2. Nc3 d5 3. Bf4 c6 4. e3 g6 5. Nf3 Bg7 6. Bd3 Nh5 7. Bg3 Nxg3 8.
+hxg3 O-O 9. Kd2 Bg4 10. Rxh7 Bxf3 11. Rxg7+ Kxg7 12. Qxf3 Nd7 13. Ne2 Nf6 14.
+Nf4 Qd6 15. g4 e5 16. Nh5+ gxh5 17. Qf5 e4 18. Qg5+ Kh8 19. Qh6+ Kg8 20. Qg5+
+Kh7 21. Qf5+ Kh6 22. g5+ Kg7 23. gxf6+ Qxf6 24. Qxf6+ Kxf6 25. Be2 h4 26. Rh1
+Rh8 27. Bg4 Rag8 28. Bh3 Rg5 29. Rf1 Ke7 30. f3 exf3 31. Rxf3 Rh6 32. Rf4 b6
+33. b3 Rgh5 34. e4 Rf6 35. Rxf6 Kxf6 36. e5+ Ke7 37. c4 f6 38. exf6+ Kxf6 39.
+Bg4 Rg5 40. Bf3 Rf5 41. Ke3 Kg5 42. cxd5 cxd5 43. a3 a5 44. b4 Kf6 45. Kf2 Ke7
+46. Ke3 axb4 47. axb4 Kd6 48. Kd3 Kc6 49. Ke3 Kb5 50. Bg4 Rf6 51. Bf3 Kc4 52.
+b5 Rd6 53. Be2+ Kc3 54. Bd3 Re6+ 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "hungzhao"]
+[Black "chesslismab"]
+[Result "1-0"]
+[ECO "B03"]
+[WhiteElo "2624"]
+[BlackElo "2449"]
+[PlyCount "93"]
+[EventDate "2020.??.??"]
+
+1. e4 Nf6 2. e5 Nd5 3. d4 d6 4. Bc4 Nb6 5. Bb3 d5 6. c3 a5 7. a4 Na6 8. Ne2 g6
+9. Ng3 Bg7 10. h4 h5 11. Bg5 Be6 12. f4 Bg4 13. Qd3 Qd7 14. O-O e6 15. Na3 c5
+16. Qb5 Qc6 17. Kh2 c4 18. Bd1 Bf8 19. Bxg4 hxg4 20. h5 Bxa3 21. Rxa3 Qxb5 22.
+axb5 Nc7 23. Kg1 Nxb5 24. Ra2 gxh5 25. f5 h4 26. Ne2 h3 27. fxe6 fxe6 28. Nf4
+Kd7 29. Ng6 Rh7 30. Nf8+ Rxf8 31. Rxf8 h2+ 32. Kh1 g3 33. Rxa5 Nc7 34. Bf6 Na6
+35. Rg8 Kc6 36. Rxg3 Nd7 37. Rh3 Rf7 38. Rh6 Kb6 39. Rxa6+ Kb5 40. g4 bxa6 41.
+g5 Nf8 42. Kxh2 Ka4 43. g6 Kb3 44. gxf7 Kxb2 45. Rh8 a5 46. Rxf8 a4 47. Rb8+
+1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "DarkKnightXx"]
+[Black "sergiul"]
+[Result "0-1"]
+[ECO "B06"]
+[WhiteElo "2374"]
+[BlackElo "2387"]
+[PlyCount "82"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 g6 2. e4 Bg7 3. Nc3 d6 4. h3 a6 5. a4 b6 6. g3 Bb7 7. Bg2 Nd7 8. Nge2 e5
+9. O-O Ngf6 10. Be3 O-O 11. g4 Re8 12. Ng3 c5 13. dxc5 Nxc5 14. g5 Nfd7 15.
+Qxd6 Ne6 16. Rfd1 Nd4 17. Nd5 Bf8 18. Nf6+ Nxf6 19. Qxf6 Qxf6 20. gxf6 Nxc2 21.
+Rac1 Nxe3 22. fxe3 Bc5 23. Kf2 Rad8 24. Bf1 h5 25. h4 Kf8 26. Bc4 Bc6 27. b3 a5
+28. Bd5 Bd7 29. Ne2 Bg4 30. Rd3 Rd6 31. Ng1 Rxf6+ 32. Kg3 Rd8 33. Rdc3 Ke7 34.
+Rxc5 bxc5 35. Rxc5 Rf1 36. Kg2 Re1 37. Rxa5 Rxe3 38. Ra7+ Rd7 39. Ra6 Rc7 40.
+Rc6 Rxc6 41. Bxc6 Rxb3 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "taras05"]
+[Black "irakliberadze"]
+[Result "0-1"]
+[ECO "B54"]
+[WhiteElo "2476"]
+[BlackElo "2659"]
+[PlyCount "88"]
+[EventDate "2020.??.??"]
+
+1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. f3 e5 6. Nb3 d5 7. Bg5 dxe4 8. Nc3
+Qxd1+ 9. Rxd1 exf3 10. gxf3 Bb4 11. Kf2 Bxc3 12. bxc3 Nc6 13. Bb5 Bd7 14. Nc5
+O-O-O 15. Rd2 a6 16. Bc4 Be8 17. Rhd1 Rxd2+ 18. Rxd2 h6 19. Be3 Rf8 20. a4 Bd7
+21. Bb3 Bf5 22. Ba2 Nd7 23. Nxd7 Bxd7 24. Bd5 f6 25. Bc5 Re8 26. Bf7 Rd8 27.
+Bb6 Rf8 28. Bc4 Re8 29. Be2 Be6 30. Bc5 Rd8 31. Be3 Rxd2 32. Bxd2 Bd7 33. Ke3
+Ne7 34. a5 Nd5+ 35. Kf2 Bc6 36. Bf1 Nc7 37. c4 Ne6 38. Be3 Kd7 39. c3 g5 40.
+Be2 f5 41. Bb6 f4 42. Bf1 Kd6 43. Ke1 Nc5 44. Kf2 e4 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "david_gomez"]
+[Black "Phoenix-20"]
+[Result "0-1"]
+[ECO "A41"]
+[WhiteElo "2461"]
+[BlackElo "2477"]
+[PlyCount "36"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 g6 2. c4 Bg7 3. Nc3 d6 4. e4 Nh6 5. f4 O-O 6. Nf3 f5 7. e5 Nf7 8. Be3 c5
+9. exd6 exd6 10. dxc5 Bxc3+ 11. bxc3 Qe7 12. Kf2 dxc5 13. Qd5 Nd7 14. Ng5 Nf6
+15. Qxc5 Ng4+ 16. Kf3 Nxg5+ 17. fxg5 Qe4+ 18. Ke2 Re8 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "kingcobra23"]
+[Black "alireza3700"]
+[Result "0-1"]
+[ECO "C00"]
+[WhiteElo "2315"]
+[BlackElo "2365"]
+[PlyCount "84"]
+[EventDate "2020.??.??"]
+
+1. e4 e6 2. b3 d5 3. Bb2 dxe4 4. Nc3 Nf6 5. Qe2 Be7 6. Nxe4 Nxe4 7. Qxe4 Bf6 8.
+O-O-O O-O 9. Bd3 g6 10. Nf3 Bxb2+ 11. Kxb2 Qf6+ 12. Kb1 a5 13. Qe5 Qxe5 14.
+Nxe5 Nd7 15. Nxd7 Bxd7 16. h4 a4 17. h5 axb3 18. axb3 Ra7 19. Kb2 Rfa8 20. hxg6
+Ra2+ 21. Kc3 hxg6 22. Bc4 b5 23. Be2 c5 24. d3 Bc6 25. Rhg1 b4+ 26. Kd2 Bd5 27.
+g3 Bxb3 28. Rc1 Bd5 29. Ke3 R8a3 30. Bf3 Bxf3 31. Kxf3 c4 32. Ke3 cxd3 33. cxd3
+b3 34. Rb1 b2 35. Rgd1 Ra1 36. Kd2 R3a2 37. Kc2 Kg7 38. f3 Kf6 39. d4 Ke7 40.
+f4 Kd6 41. Re1 Rxb1 42. Rd1 Rxd1 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "BorisBulto"]
+[Black "fabi_caruano"]
+[Result "0-1"]
+[ECO "C42"]
+[WhiteElo "2384"]
+[BlackElo "2336"]
+[PlyCount "92"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 e5 2. Nf3 Nf6 3. Nxe5 d6 4. Nf3 Nxe4 5. Nc3 Nxc3 6. dxc3 Be7 7. Be3 O-O
+8. Qd2 Nd7 9. O-O-O c5 10. Bf4 Nf6 11. Bd3 Bd7 12. Rhe1 Re8 13. Kb1 b5 14. c4
+b4 15. h3 a5 16. Bf1 a4 17. Bxd6 a3 18. Bxe7 Rxe7 19. Rxe7 Qxe7 20. Qd6 Kf8 21.
+Qxe7+ Kxe7 22. Ne5 axb2 23. Re1 Be6 24. Kxb2 Kd6 25. f4 Ra3 26. Bd3 g6 27. g4
+Nd7 28. Nxd7 Bxd7 29. f5 gxf5 30. gxf5 f6 31. Re2 h5 32. Rg2 Ke5 33. Rg1 Ra6
+34. h4 Kf4 35. Rg2 Rd6 36. Rg1 Bc6 37. Rg7 Bd7 38. Rh7 Kg4 39. Be2+ Kf4 40.
+Rxh5 Bxf5 41. Bd3 Bxd3 42. cxd3 f5 43. Kc2 Ra6 44. Kb2 Rf6 45. a3 bxa3+ 46. Kc2
+Ke3 0-1
+
+[Event "Rated Bullet tournament GAdGz1co"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "OneCoin88"]
+[Black "Zuritadas"]
+[Result "1/2-1/2"]
+[ECO "C46"]
+[WhiteElo "2316"]
+[BlackElo "2399"]
+[PlyCount "104"]
+[EventDate "2020.??.??"]
+
+1. e4 e5 2. Nf3 Nc6 3. Nc3 Nf6 4. Be2 Bc5 5. Nxe5 Nxe5 6. d4 Bd6 7. dxe5 Bxe5
+8. Nb5 c6 9. f4 Bb8 10. Nd6+ Bxd6 11. Qxd6 Nxe4 12. Qe5+ Qe7 13. Qxg7 Qf6 14.
+Qxf6 Nxf6 15. O-O d5 16. Bd2 Ne4 17. Be3 Rg8 18. Bf3 f5 19. Bd4 Be6 20. Be5 Kd7
+21. c3 Rg6 22. Bxe4 dxe4 23. Rad1+ Ke8 24. Rd6 Rd8 25. Rfd1 Rxd6 26. Rxd6 Bd5
+27. Kf2 Rxd6 28. Bxd6 Bxa2 29. Bb8 a6 30. Ke3 Bd5 31. Kd4 Kf7 32. g4 fxg4 33.
+Ke3 h5 34. f5 Kf6 35. Kf4 e3 36. Be5+ Kf7 37. Kxe3 b5 38. Kf4 a5 39. Kg5 Bf3
+40. Kf4 c5 41. h3 b4 42. hxg4 hxg4 43. cxb4 cxb4 44. Bc7 a4 45. Ba5 a3 46. bxa3
+bxa3 47. Bc3 a2 48. Ba1 Bd1 49. Kg5 Ke7 50. Kf4 Kf7 51. Bb2 Kf8 52. Ba1 Kf7
+1/2-1/2
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "BlueGreensun"]
+[Black "Kidefence"]
+[Result "1/2-1/2"]
+[ECO "B02"]
+[WhiteElo "2738"]
+[BlackElo "2728"]
+[PlyCount "158"]
+[EventDate "2020.??.??"]
+
+1. e4 Nf6 2. e5 Nd5 3. Nc3 Nxc3 4. dxc3 d6 5. Nf3 g6 6. Bc4 Nc6 7. exd6 cxd6 8.
+O-O Bg7 9. Bg5 O-O 10. Re1 Bg4 11. Bh4 Bxf3 12. Qxf3 Qc7 13. Bd5 Rae8 14. Rad1
+e6 15. Bxc6 bxc6 16. Bg3 Rd8 17. h4 h5 18. Bf4 Rfe8 19. Bg5 Rb8 20. b3 d5 21.
+Bf6 Bxf6 22. Qxf6 Qe7 23. Qf4 a5 24. Re5 Kg7 25. Rde1 Qf6 26. Qg3 a4 27. Rxh5
+axb3 28. axb3 Rh8 29. Rxh8 Rxh8 30. Qg5 Rxh4 31. Qxf6+ Kxf6 32. g3 Rh8 33. Kg2
+Ra8 34. Kf3 Ra2 35. Re2 e5 36. Ke3 Ke6 37. Kd3 f5 38. Re1 Kd6 39. Rh1 Ra8 40.
+Rh6 Rg8 41. c4 e4+ 42. Ke3 Ke5 43. cxd5 cxd5 44. f4+ exf3 45. Kxf3 g5 46. Ke3
+f4+ 47. gxf4+ gxf4+ 48. Kf2 Rc8 49. c4 dxc4 50. bxc4 Rxc4 51. Rh8 Rc6 52. Kf3
+Re6 53. Rh5+ Kd6 54. Ra5 Re5 55. Ra6+ Ke7 56. Ra8 Re6 57. Kxf4 Rf6+ 58. Ke5 Kf7
+59. Kd5 Kg6 60. Re8 Rf7 61. Re1 Rf6 62. Rg1+ Kf7 63. Ke5 Rg6 64. Rf1+ Kg7 65.
+Rf2 Ra6 66. Rg2+ Kf7 67. Rf2+ Ke7 68. Rb2 Ra5+ 69. Kd4 Ke6 70. Kc4 Kf5 71. Kb4
+Re5 72. Rf2+ Ke6 73. Rf1 Re4+ 74. Kc3 Re5 75. Kd3 Kd7 76. Rf2 Re6 77. Rf4 Rd6+
+78. Rd4 Kc6 79. Rxd6+ Kxd6 1/2-1/2
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "sutcunuri"]
+[Black "ajedrez2021"]
+[Result "0-1"]
+[ECO "A04"]
+[WhiteElo "2538"]
+[BlackElo "2574"]
+[PlyCount "38"]
+[EventDate "2020.??.??"]
+
+1. Nf3 g6 2. d4 Bg7 3. c3 c5 4. dxc5 Nf6 5. e4 O-O 6. e5 Ng4 7. Qd4 d6 8. cxd6
+Nc6 9. dxe7 Qxe7 10. Qe4 Bf5 11. Qe2 Rfe8 12. Bf4 Rad8 13. Nbd2 Ngxe5 14. Nxe5
+Nxe5 15. Bxe5 Bxe5 16. O-O-O Qc5 17. Nb3 Bf4+ 18. Qd2 Rxd2 19. Rxd2 Re1# 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "ROBESPIERR"]
+[Black "imdejong"]
+[Result "1-0"]
+[ECO "A04"]
+[WhiteElo "2533"]
+[BlackElo "2359"]
+[PlyCount "57"]
+[EventDate "2020.??.??"]
+
+1. Nf3 c5 2. g3 Nc6 3. Bg2 e5 4. O-O d5 5. d3 f6 6. e4 d4 7. c3 Nge7 8. cxd4
+cxd4 9. Na3 Be6 10. Nd2 Ng6 11. f4 exf4 12. gxf4 Bf7 13. Nac4 b5 14. Na3 a6 15.
+Nf3 Bxa3 16. bxa3 O-O 17. Bb2 Qd6 18. Rc1 Nxf4 19. Rxc6 Qxc6 20. Nxd4 Qd6 21.
+Nf5 Qc7 22. Qg4 Ng6 23. Nxg7 Kxg7 24. Rxf6 Kg8 25. h4 Qc8 26. Qg5 Qc2 27. Rf2
+Qd1+ 28. Kh2 Qe1 29. Qf6 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "murderoflegends"]
+[Black "Chipodejunin"]
+[Result "0-1"]
+[ECO "A45"]
+[WhiteElo "2425"]
+[BlackElo "2469"]
+[PlyCount "112"]
+[EventDate "2020.??.??"]
+
+1. d4 Nf6 2. c3 e6 3. Nf3 b6 4. Bg5 Bb7 5. e3 Be7 6. Bd3 h6 7. Bh4 O-O 8. Nbd2
+d5 9. Qc1 Nbd7 10. O-O c5 11. Qc2 Rc8 12. Rac1 Re8 13. Qb1 a6 14. a3 b5 15. b4
+cxb4 16. cxb4 Nb6 17. Nb3 Nc4 18. Nc5 Bxc5 19. bxc5 Bc6 20. Qa2 Qc7 21. Bg3 Qe7
+22. Ne5 Nd7 23. Nxd7 Qxd7 24. Bb1 e5 25. dxe5 Nxe5 26. Qc2 Ng6 27. Rcd1 Qe6 28.
+Qc3 Red8 29. Bxg6 Qxg6 30. Rd4 Re8 31. h3 Re4 32. Rfd1 Rce8 33. Qa5 Bb7 34. Qc7
+Qc6 35. Qa5 Qxc5 36. Qd2 Qe7 37. Qb2 Rc8 38. a4 b4 39. Rxe4 dxe4 40. Bd6 Qd7
+41. Rd4 a5 42. Bxb4 Qxa4 43. Bd6 Qc2 44. Qxc2 Rxc2 45. Be5 Rc1+ 46. Kh2 a4 47.
+Rd8+ Kh7 48. Rb8 Bd5 49. Rb6 Be6 50. Ra6 Rc2 51. Ra7 Rxf2 52. Kg3 Rf5 53. Bf4
+Rg5+ 54. Bxg5 hxg5 55. Kf2 a3 56. Rxa3 Kg6 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Evgen_88"]
+[Black "JLeon"]
+[Result "0-1"]
+[ECO "E90"]
+[WhiteElo "2549"]
+[BlackElo "2558"]
+[PlyCount "102"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 Nf6 2. c4 g6 3. Nc3 Bg7 4. e4 d6 5. Nf3 Bg4 6. Be2 O-O 7. Be3 Nc6 8. d5
+Bxf3 9. gxf3 Nb8 10. Qd2 e5 11. dxe6 fxe6 12. h4 Nbd7 13. f4 Nc5 14. Bf3 a5 15.
+h5 Qe8 16. O-O-O Nxh5 17. Bxc5 dxc5 18. Bxh5 gxh5 19. Rdg1 Kh8 20. Qe2 Bxc3 21.
+bxc3 Rxf4 22. Rxh5 Qf7 23. Rgh1 Rf8 24. Rxh7+ Qxh7 25. Rxh7+ Kxh7 26. Qh5+ Kg7
+27. Qxc5 Rxf2 28. Qxc7+ R8f7 29. Qxa5 Rg2 30. Qe5+ Kh7 31. Qh5+ Kg8 32. Qd1 e5
+33. c5 Kg7 34. Kb1 Rff2 35. Qd7+ Kh6 36. Qe6+ Kh5 37. Qxe5+ Kh4 38. Qh8+ Kg3
+39. Qg7+ Kh2 40. Qh8+ Kg1 41. Qd4 Kh1 42. Qd1+ Rg1 43. Qxg1+ Kxg1 44. a4 Re2
+45. a5 Kf2 46. c6 bxc6 47. a6 Rxe4 48. Kb2 Ra4 49. Kb3 Rxa6 50. Kb4 Ra1 51. Kc5
+Rc1 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "vaillant77"]
+[Black "vassiukov"]
+[Result "1-0"]
+[ECO "D00"]
+[WhiteElo "2426"]
+[BlackElo "2366"]
+[PlyCount "105"]
+[EventDate "2020.??.??"]
+
+1. e4 d5 2. d4 dxe4 3. Nc3 Nf6 4. Bg5 Bf5 5. Bc4 e6 6. Nge2 Be7 7. Ng3 Bg4 8.
+Qd2 c6 9. Bxf6 Bxf6 10. Ngxe4 Be7 11. h3 Bf5 12. g4 Bg6 13. O-O-O b5 14. Bd3 a5
+15. f4 O-O 16. Kb1 a4 17. Ne2 Nd7 18. N2g3 Nf6 19. f5 Nxe4 20. Bxe4 Qd6 21.
+fxg6 Qxg3 22. gxh7+ Kh8 23. Qd3 Qd6 24. h4 Rac8 25. h5 Rfd8 26. h6 g6 27. Bxg6
+fxg6 28. Qxg6 Bf8 29. Qf6+ Kxh7 30. Qf7+ Kh8 31. g5 Qe7 32. Rdf1 Rd7 33. g6
+Qxf7 34. gxf7 Rcc7 35. Re1 Rxd4 36. Rxe6 Rxf7 37. Rxc6 Rdf4 38. a3 R4f6 39. Rc8
+Kh7 40. Rd1 Bxh6 41. Ka2 Rf2 42. Rdd8 Bg7 43. Rd5 Rf1 44. Rh5+ Kg6 45. Rxb5 Rg1
+46. Rc6+ Bf6 47. Rbb6 Rg4 48. b3 Rg2 49. bxa4 Rg1 50. a5 Ra1+ 51. Kb3 Rb1+ 52.
+Ka4 Rc1 53. Rxf6+ 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Pharaohs-Curse"]
+[Black "Atomrod"]
+[Result "1/2-1/2"]
+[ECO "E00"]
+[WhiteElo "2352"]
+[BlackElo "2485"]
+[PlyCount "150"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 e6 2. c4 Bb4+ 3. Bd2 Bxd2+ 4. Qxd2 Nf6 5. Nc3 d5 6. Nf3 O-O 7. cxd5 exd5
+8. e3 Bg4 9. Bd3 Nbd7 10. O-O c5 11. dxc5 Nxc5 12. Be2 Nce4 13. Qd4 Nxc3 14.
+Qxc3 Ne4 15. Qd4 Qd6 16. h3 Be6 17. Rac1 a6 18. Rfd1 Rac8 19. Rxc8 Rxc8 20.
+Qxe4 dxe4 21. Rxd6 exf3 22. Bxf3 g6 23. Bxb7 Rc1+ 24. Kh2 a5 25. Ra6 Bxa2 26.
+Rxa5 Be6 27. Rb5 Rc2 28. Kg3 h6 29. Be4 Rc4 30. Bd5 Bxd5 31. Rxd5 Rb4 32. Rd2
+g5 33. f3 f5 34. Kf2 Kf7 35. Re2 Ke6 36. Rc2 Kd5 37. Ke2 Rb3 38. Kd2 h5 39. g3
+h4 40. gxh4 gxh4 41. Ke2 Ke5 42. f4+ Kd5 43. Kf3 Rb8 44. Rd2+ Ke6 45. Rc2 Rg8
+46. Rg2 Rb8 47. Rg6+ Kf7 48. Rh6 Kg7 49. Rxh4 Kg6 50. b4 Rxb4 51. Rh8 Rb1 52.
+Rg8+ Kf7 53. Rg2 Rh1 54. Kg3 Re1 55. Kf2 Rh1 56. Rg3 Kf6 57. Ke2 Ra1 58. Kf3
+Rh1 59. e4 fxe4+ 60. Kxe4 Rh2 61. Kf3 Ra2 62. Kg4 Ra8 63. Rb3 Rg8+ 64. Kf3 Rh8
+65. Rb6+ Kf5 66. Rb5+ Kf6 67. Kg4 Rg8+ 68. Rg5 Ra8 69. Rf5+ Kg6 70. Rg5+ Kh6
+71. h4 Ra1 72. Rh5+ Kg6 73. Rg5+ Kh6 74. Rh5+ Kg6 75. Rg5+ Kh6 1/2-1/2
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "FedaMaster"]
+[Black "gmmitkov"]
+[Result "1-0"]
+[ECO "C56"]
+[WhiteElo "2572"]
+[BlackElo "2504"]
+[PlyCount "41"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 e5 2. Nf3 Nc6 3. d4 exd4 4. Bc4 Nf6 5. O-O Nxe4 6. Re1 d5 7. Bxd5 Qxd5 8.
+Nc3 Qd7 9. Nxe4 Be7 10. Bg5 O-O 11. Bxe7 Qxe7 12. Nxd4 Nxd4 13. Qxd4 b6 14. Ng3
+Qd7 15. Qf4 Re8 16. h3 Bb7 17. Nf5 g6 18. Nh6+ Kg7 19. Ng4 Qc6 20. Qd4+ Kg8 21.
+Nh6+ 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "FerociousLion98999"]
+[Black "Maxterlopez"]
+[Result "0-1"]
+[ECO "C70"]
+[WhiteElo "2583"]
+[BlackElo "2654"]
+[PlyCount "94"]
+[EventDate "2020.??.??"]
+
+1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nge7 5. O-O g6 6. d3 b5 7. Bb3 Bg7 8. c3
+O-O 9. h3 d6 10. Re1 h6 11. Be3 Na5 12. Bc2 c5 13. Nbd2 Kh7 14. Nf1 Nac6 15.
+Ng3 Be6 16. d4 cxd4 17. cxd4 exd4 18. Nxd4 Nxd4 19. Bxd4 Rc8 20. Bxg7 Kxg7 21.
+Bd3 Nc6 22. a4 Qb6 23. Bf1 Ne5 24. axb5 axb5 25. Qd2 Bxh3 26. Rad1 Bg4 27. Be2
+Bxe2 28. Nxe2 Rfd8 29. Nf4 Nc4 30. Qc3+ Ne5 31. Qg3 Rc2 32. Nd5 Qc5 33. Qf4 Nd7
+34. Rd3 Rf8 35. Rh3 g5 36. Qf5 Qd4 37. Ree3 Nf6 38. Rxh6 Rc1+ 39. Kh2 Kxh6 40.
+Rh3+ Nh5 41. Nf6 Qe5+ 42. Qxe5 dxe5 43. Nxh5 Kg6 44. Ng3 Rh8 45. Nf5 Rxh3+ 46.
+Kxh3 g4+ 47. Kg3 Rc3+ 0-1
+
+[Event "Rated Blitz tournament hM7PUvgg"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "espinozasgod"]
+[Black "lgsalazar94"]
+[Result "1-0"]
+[ECO "B35"]
+[WhiteElo "2436"]
+[BlackElo "2343"]
+[PlyCount "79"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 c5 2. Nf3 Nc6 3. d4 cxd4 4. Nxd4 g6 5. Nc3 Bg7 6. Be3 Nf6 7. Bc4 O-O 8.
+Bb3 Qa5 9. O-O d6 10. h3 Bd7 11. Nde2 Rac8 12. f4 Rfd8 13. Qe1 b5 14. a3 b4 15.
+axb4 Qxb4 16. Qh4 Be6 17. Ra4 Qb7 18. Bxe6 fxe6 19. b3 a5 20. f5 exf5 21. exf5
+d5 22. fxg6 hxg6 23. Bh6 d4 24. Bxg7 Kxg7 25. Ne4 Nxe4 26. Qxe4 e5 27. Ng3 Rf8
+28. Raa1 Qd7 29. Rae1 Qd6 30. Qg4 Rxf1+ 31. Rxf1 Ne7 32. Ne4 Qb6 33. Kh2 Rc6
+34. Qg5 Ng8 35. Ng3 Qc7 36. Nf5+ Kh7 37. Qh4+ Nh6 38. Qxh6+ Kg8 39. Ng3 e4 40.
+Rf8# 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Karabakh-Azerbaijan"]
+[Black "Frogkiller"]
+[Result "0-1"]
+[ECO "A01"]
+[WhiteElo "2462"]
+[BlackElo "2361"]
+[PlyCount "136"]
+[EventDate "2020.??.??"]
+
+1. b3 Nf6 2. Bb2 g6 3. Nf3 Bg7 4. e3 O-O 5. d4 d6 6. Be2 Nc6 7. O-O e5 8. dxe5
+Ng4 9. c4 Ngxe5 10. Nxe5 Nxe5 11. Qc1 Bd7 12. Nd2 a5 13. Nf3 b6 14. Nxe5 Bxe5
+15. Bxe5 dxe5 16. Rd1 Qe7 17. Qc3 Rad8 18. Bf3 Bf5 19. h3 Rd6 20. Rxd6 Qxd6 21.
+Rd1 Qe7 22. Qd2 Re8 23. Bc6 Rf8 24. e4 Be6 25. f3 Kg7 26. Kh1 h5 27. Qd3 Qg5
+28. Qd2 Qg3 29. Qe1 Qf4 30. Qd2 Qh4 31. Qe1 Qf6 32. Qd2 Qe7 33. Qe1 Qf6 34. Qd2
+Qh4 35. Bd5 Qe7 36. Bxe6 Qxe6 37. Qd5 Qf6 38. a3 Re8 39. b4 axb4 40. axb4 c6
+41. Qd6 Re6 42. Qd8 Qxd8 43. Rxd8 c5 44. bxc5 bxc5 45. Rc8 Rd6 46. Rxc5 Rd1+
+47. Kh2 f6 48. Rc7+ Kh6 49. c5 Kg5 50. c6 Rc1 51. Rc8 Kh4 52. g3+ Kg5 53. h4+
+Kh6 54. Kg2 Kg7 55. Kf2 Rc2+ 56. Ke3 Rc4 57. Kd3 Rc1 58. Kd2 Rc5 59. Kd3 Rc1
+60. c7 Rxc7 61. Kd2 Rxc8 62. Kd1 Ra8 63. Kd2 Ra3 64. f4 Ra2+ 65. Ke3 Ra3+ 66.
+Kf2 Rb3 67. Kg2 Rb2+ 68. Kh3 exf4 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Northridgehawk"]
+[Black "zenon011"]
+[Result "1-0"]
+[ECO "C25"]
+[WhiteElo "2358"]
+[BlackElo "2336"]
+[PlyCount "97"]
+[EventDate "2020.??.??"]
+
+1. e4 e5 2. Nc3 Nc6 3. Bc4 f5 4. exf5 Nf6 5. Nf3 d5 6. Bb3 e4 7. Nh4 d4 8. Ne2
+d3 9. Ng3 Bc5 10. O-O Nd4 11. cxd3 exd3 12. Re1+ Kf8 13. Be6 Bxe6 14. fxe6 Qe7
+15. b4 Bb6 16. Bb2 Nc2 17. Ngf5 Qxb4 18. Bc3 Qg4 19. Bxf6 Qxd1 20. Bxg7+ Kg8
+21. Raxd1 Nxe1 22. Rxe1 Re8 23. e7 Kf7 24. Bxh8 Rxh8 25. e8=Q+ Rxe8 26. Rxe8
+Kxe8 27. Ne3 c5 28. Nf3 Ba5 29. Kf1 b5 30. Ke1 c4 31. Nd1 b4 32. Ne5 c3 33.
+Nxd3 c2 34. N1b2 Bb6 35. Nc1 Bd4 36. Nbd3 a5 37. Ke2 a4 38. Nxb4 Bb2 39. Ncd3
+a3 40. Nxc2 Kf7 41. Ne3 Kg6 42. Nf4+ Kf7 43. g3 Bd4 44. f3 Be5 45. g4 Bxf4 46.
+Nd5 Be3 47. Nxe3 Kg6 48. Nf5 Kg5 49. f4+ 1-0
+
+[Event "Rated Bullet tournament GAdGz1co"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "ScherlockKA"]
+[Black "JeanGoulifet"]
+[Result "0-1"]
+[ECO "A06"]
+[WhiteElo "2321"]
+[BlackElo "2391"]
+[PlyCount "36"]
+[EventDate "2020.??.??"]
+
+1. d3 d5 2. Nf3 c6 3. g3 Nf6 4. Bg2 Bf5 5. O-O e6 6. Nbd2 h6 7. Re1 Be7 8. h3
+O-O 9. c3 Bh7 10. Qb3 Qb6 11. Ne5 Nfd7 12. Nxd7 Nxd7 13. Nf3 c5 14. Be3 Qc7 15.
+Red1 Rfd8 16. Rac1 a6 17. d4 c4 18. Qa4 b5 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "chipmunknau"]
+[Black "APele"]
+[Result "0-1"]
+[ECO "A46"]
+[WhiteElo "2571"]
+[BlackElo "2467"]
+[PlyCount "54"]
+[EventDate "2020.??.??"]
+
+1. d4 Nf6 2. Nf3 e6 3. Bf4 d5 4. e3 Bd6 5. c4 O-O 6. Bg3 Qe7 7. Nc3 c6 8. Bd3
+Nbd7 9. O-O a6 10. e4 dxe4 11. Nxe4 Bxg3 12. Nxg3 c5 13. d5 exd5 14. cxd5 Qd6
+15. Nf5 Qf4 16. g3 Qb4 17. Ne7+ Kh8 18. Qc2 c4 19. Qxc4 Qxe7 20. Rfe1 Qd6 21.
+Rad1 Qxd5 22. Qh4 Qxf3 23. Be2 Qf5 24. Bd3 Qh5 25. Qb4 Qc5 26. Qh4 Ne5 27. Bb1
+Nf3+ 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "seleneitor13"]
+[Black "tritarov1960"]
+[Result "1/2-1/2"]
+[ECO "A04"]
+[WhiteElo "2310"]
+[BlackElo "2390"]
+[PlyCount "139"]
+[EventDate "2020.??.??"]
+
+1. Nf3 c5 2. g3 d6 3. Bg2 Nd7 4. O-O Ngf6 5. d4 g6 6. b3 Bg7 7. Bb2 O-O 8. Nbd2
+Rb8 9. Re1 b6 10. e4 Bb7 11. e5 Ne8 12. exd6 exd6 13. Qe2 Nc7 14. c4 Re8 15.
+Qd3 Ne6 16. Qc2 cxd4 17. Rad1 d3 18. Qc1 Bxb2 19. Qxb2 Nec5 20. b4 Ne6 21. Ne4
+Bxe4 22. Rxe4 Nf6 23. Ree1 d5 24. Rxd3 d4 25. Red1 Rc8 26. Nxd4 Nxd4 27. Rxd4
+Qe7 28. h4 h5 29. a3 Red8 30. Rxd8+ Rxd8 31. Rxd8+ Qxd8 32. Qe2 Ng4 33. Bf3 Nf6
+34. Qe3 Qd6 35. Kg2 Nd7 36. Be4 Kg7 37. Bd5 Ne5 38. Qd4 f6 39. c5 bxc5 40. bxc5
+Qc7 41. f4 Ng4 42. Bf3 Qa5 43. Bxg4 hxg4 44. Qd7+ Kh6 45. Qxg4 Qxa3 46. Qf3
+Qb2+ 47. Kh3 Qc1 48. f5 Qxc5 49. Qf4+ Kg7 50. fxg6 Qc8+ 51. Qg4 Qxg4+ 52. Kxg4
+Kxg6 53. h5+ Kh6 54. Kf5 a5 55. Kxf6 a4 56. g4 a3 57. g5+ Kxh5 58. g6 a2 59. g7
+a1=Q+ 60. Kf7 Qa7+ 61. Ke8 Qb8+ 62. Kf7 Qc7+ 63. Kf8 Qd8+ 64. Kf7 Qd5+ 65. Kf8
+Qf5+ 66. Ke8 Qg6+ 67. Kd8 Qf6+ 68. Kc8 Qxg7 69. Kb8 Kg6 70. Ka8 1/2-1/2
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "telodijomonstruo"]
+[Black "Olaffo"]
+[Result "1-0"]
+[ECO "B00"]
+[WhiteElo "2508"]
+[BlackElo "2525"]
+[PlyCount "165"]
+[EventDate "2020.??.??"]
+
+1. e4 a6 2. d4 b5 3. Nf3 Bb7 4. Bd3 Nf6 5. Qe2 e6 6. e5 Nd5 7. Nc3 Nb4 8. Be4
+Bxe4 9. Qxe4 c6 10. a3 Nd5 11. O-O h6 12. Ne2 Be7 13. Ng3 d6 14. Nh5 g6 15. Nf4
+Nxf4 16. Bxf4 d5 17. Qe3 g5 18. Bg3 Nd7 19. Nd2 Nb6 20. f4 Nc4 21. Nxc4 bxc4
+22. fxg5 Bxg5 23. Qf3 Ra7 24. Bf4 Bxf4 25. Qxf4 Qg5 26. b4 cxb3 27. cxb3 Qxf4
+28. Rxf4 Rb7 29. b4 Rg8 30. Rc1 Rb6 31. Rh4 Rg6 32. g3 Ke7 33. Kf2 a5 34. bxa5
+Rb2+ 35. Kf3 Rb3+ 36. Ke2 Rxa3 37. Rxc6 Rxa5 38. Rc7+ Kf8 39. Rf4 Rg7 40. Rc8+
+Ke7 41. Rc7+ Kf8 42. Ke3 Ra3+ 43. Kf2 Ra2+ 44. Kg1 Ra8 45. Kg2 Re8 46. Kh3 Re7
+47. Rc8+ Re8 48. Rc7 Kg8 49. Rb7 Rc8 50. Rb3 Rc4 51. Rbf3 Rc3 52. Rxc3 Rg5 53.
+Rcf3 Rg7 54. Rg4 Kh7 55. Rxg7+ Kxg7 56. Kg4 h5+ 57. Kxh5 Kg8 58. Kg5 Kg7 59. h4
+Kg8 60. Kf6 Kh7 61. Rc3 Kh6 62. Rc7 Kh5 63. Rxf7 Kg4 64. Kxe6 Kh3 65. Kxd5 Kg2
+66. Ke6 Kh3 67. d5 Kg4 68. d6 Kh5 69. Ke7 Kg4 70. e6 Kh3 71. d7 Kg2 72. Kf6 Kh3
+73. e7 Kg4 74. h5 Kh3 75. h6 Kg2 76. h7 Kh3 77. h8=Q+ Kg2 78. g4 Kf3 79. g5 Kg3
+80. Ke6 Kg4 81. g6 Kg5 82. g7 Kg4 83. g8=Q# 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "rudolf85"]
+[Black "Paanoos"]
+[Result "1-0"]
+[ECO "D04"]
+[WhiteElo "2411"]
+[BlackElo "2391"]
+[PlyCount "28"]
+[EventDate "2020.??.??"]
+
+1. e3 Nf6 2. d4 d5 3. Nf3 c5 4. Be2 Nc6 5. O-O Bg4 6. Ne5 Bf3 7. Bxf3 e6 8.
+Nxc6 bxc6 9. c4 Bd6 10. cxd5 Qc7 11. h3 cxd5 12. Nc3 O-O 13. dxc5 Qb8 14. cxd6
+Qxd6 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Paanoos"]
+[Black "rudolf85"]
+[Result "0-1"]
+[ECO "A08"]
+[WhiteElo "2385"]
+[BlackElo "2417"]
+[PlyCount "120"]
+[EventDate "2020.??.??"]
+
+1. Nf3 d5 2. g3 Nf6 3. Bg2 c5 4. O-O Nc6 5. e4 dxe4 6. Ng5 Bf5 7. Nc3 e6 8. Re1
+Be7 9. Ngxe4 O-O 10. d3 Bg6 11. Bf4 Rc8 12. Qd2 b6 13. Rad1 Nd4 14. h4 Bxe4 15.
+Nxe4 Nd5 16. Be3 Nxe3 17. Rxe3 Nf5 18. Ree1 Qc7 19. h5 h6 20. g4 Nd4 21. c3 Nc6
+22. Re3 Rcd8 23. Rg3 f6 24. Re1 e5 25. Qc2 Rfe8 26. Rge3 Bf8 27. Ng3 Ne7 28.
+Be4 Rd6 29. a4 Red8 30. Nf5 Nxf5 31. Bxf5 c4 32. dxc4 Qxc4 33. Re4 Qc7 34. Qb3+
+Kh8 35. Rc4 Qb7 36. Be4 Qb8 37. Qb5 Rd2 38. Bb1 Bc5 39. Rxc5 bxc5 40. Qxc5 Rd1
+41. Qe3 Rxe1+ 42. Qxe1 Qd6 43. Qe4 Qd1+ 44. Kg2 Qd5 45. Kf3 Qxe4+ 46. Bxe4 Rd2
+47. b4 Rb2 48. a5 Rb3 49. Bc6 Rxc3+ 50. Ke4 Rb3 51. b5 a6 52. bxa6 Ra3 53. a7
+Rxa5 54. a8=Q+ Rxa8 55. Bxa8 Kg8 56. Bd5+ Kf8 57. Kf5 Ke7 58. Kg6 e4 59. Kxg7
+e3 60. fxe3 f5 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "FinalCut"]
+[Black "RigelStar"]
+[Result "1/2-1/2"]
+[ECO "A01"]
+[WhiteElo "2452"]
+[BlackElo "2406"]
+[PlyCount "137"]
+[EventDate "2020.??.??"]
+
+1. b3 c5 2. Bb2 Nc6 3. e3 Nf6 4. Nf3 g6 5. Bb5 Bg7 6. c4 O-O 7. O-O d6 8. d4
+cxd4 9. Bxc6 bxc6 10. Nxd4 c5 11. Nf3 Bb7 12. Nbd2 a5 13. a4 Qb6 14. Qc2 Rfd8
+15. Rad1 e6 16. Rfe1 d5 17. h3 Rac8 18. Nb1 Ne4 19. Bxg7 Kxg7 20. Na3 Qb4 21.
+Nb5 Bc6 22. Ne5 Bxb5 23. axb5 f6 24. Nc6 Rxc6 25. bxc6 Qb6 26. f3 Ng5 27. e4 d4
+28. Ra1 Ra8 29. Ra3 Qxc6 30. Rea1 Qd6 31. Rxa5 Rf8 32. Qf2 Qf4 33. Ra7+ Nf7 34.
+Kh1 h5 35. R1a5 Qc1+ 36. Kh2 d3 37. Rd7 Rd8 38. Raa7 Rxd7 39. Rxd7 Qc3 40. Qxc5
+Qe5+ 41. Qxe5 fxe5 42. Rxd3 Kf6 43. c5 Nh6 44. c6 Nf7 45. Rd7 Nd6 46. Rxd6 Ke7
+47. Rd7+ Kf6 48. b4 g5 49. b5 g4 50. c7 g3+ 51. Kxg3 Kg5 52. c8=Q h4+ 53. Kh2
+Kf4 54. Qf8+ Ke3 55. Re7 Ke2 56. Rxe6 Ke3 57. Rxe5 Kd3 58. Rh5 Kd4 59. Rxh4 Ke3
+60. b6 Kd4 61. b7 Ke5 62. b8=Q+ Kd4 63. Qbd6+ Ke3 64. Qfe7 Ke2 65. Qee6 Kf2 66.
+Qed5 Ke1 67. e5 Ke2 68. Qd4 Kf1 69. Qe3 1/2-1/2
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "ajedrez2021"]
+[Black "sutcunuri"]
+[Result "1-0"]
+[ECO "A04"]
+[WhiteElo "2579"]
+[BlackElo "2533"]
+[PlyCount "95"]
+[EventDate "2020.??.??"]
+
+1. Nf3 g6 2. c4 Bg7 3. g3 e5 4. Bg2 Nc6 5. O-O d6 6. Nc3 f5 7. d3 Nf6 8. Rb1
+O-O 9. b4 a6 10. a4 h6 11. b5 axb5 12. axb5 Ne7 13. Bb2 Be6 14. Ra1 Rc8 15. Ra7
+b6 16. Nd2 g5 17. Qb3 Kh7 18. Nd5 Ng6 19. Nxf6+ Qxf6 20. Bb7 Rcd8 21. Bc6 Rc8
+22. Bb7 Rcd8 23. Bc3 h5 24. Bc6 Rc8 25. Bb7 Rce8 26. Rfa1 h4 27. Bd5 Rf7 28.
+Nf1 Bxd5 29. cxd5 f4 30. Be1 f3 31. exf3 Qxf3 32. Qd1 Qxd5 33. Qh5+ Bh6 34. Qg4
+Ref8 35. Qe4 Qe6 36. Rc1 h3 37. Rcxc7 Rxc7 38. Rxc7+ Rf7 39. Rc6 g4 40. Qe2 Qd5
+41. Qe4 Qe6 42. Ne3 Kg7 43. Qxg4 Qd5 44. Nxd5 Rf5 45. Rc7+ Kf8 46. Rc6 Ke8 47.
+Qxg6+ Kd8 48. Rc7 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Akali666"]
+[Black "vava05"]
+[Result "0-1"]
+[ECO "A46"]
+[WhiteElo "2529"]
+[BlackElo "2396"]
+[PlyCount "118"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 Nf6 2. Nf3 e6 3. Bf4 d5 4. e3 Bd6 5. Bg3 O-O 6. Nbd2 c5 7. c3 Nc6 8. Bd3
+b6 9. Qe2 Bb7 10. Rd1 Qc7 11. e4 cxd4 12. e5 dxc3 13. bxc3 Nxe5 14. Bxe5 Nd7
+15. Bxd6 Qxd6 16. c4 Nc5 17. O-O d4 18. Ne4 Qf4 19. Rfe1 h6 20. g3 Qg4 21. Kg2
+Nxd3 22. Rxd3 f5 23. Nd6 Bc6 24. Qxe6+ Kh7 25. h3 Qh5 26. Re5 Rae8 27. Nxe8
+Rxe8 28. Qxf5+ Qxf5 29. Rxf5 Be4 30. Rxd4 Bxf5 31. g4 Be6 32. Kg3 Rc8 33. Ne5
+b5 34. cxb5 Bxa2 35. f4 Rb8 36. Rb4 Bd5 37. Nc6 Bxc6 38. Ra4 Rxb5 39. Rxa7 Rb3+
+40. Kh4 Rb7 41. Ra6 Bb5 42. Rd6 Be8 43. g5 hxg5+ 44. Kxg5 g6 45. f5 gxf5 46.
+Kxf5 Bd7+ 47. Kg5 Bxh3 48. Rh6+ Kg7 49. Rxh3 Rb5+ 50. Kf4 Kf6 51. Kg3 Rb4 52.
+Kh2 Rb2+ 53. Kg1 Rb1+ 54. Kh2 Rb4 55. Kg1 Kg5 56. Kh2 Kf4 57. Rg3 Rb1 58. Rg2
+Rb2 59. Kh3 Rxg2 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Obito2016"]
+[Black "zaqvili"]
+[Result "1-0"]
+[ECO "A56"]
+[WhiteElo "2327"]
+[BlackElo "2321"]
+[PlyCount "117"]
+[EventDate "2020.??.??"]
+
+1. d4 Nf6 2. c4 c5 3. Nc3 cxd4 4. Qxd4 Nc6 5. Qd1 g6 6. e3 Bg7 7. Be2 Qa5 8.
+Nf3 Ne4 9. Bd2 Nxd2 10. Qxd2 Bxc3 11. bxc3 d6 12. h4 Bg4 13. Nd4 Bxe2 14. Nxe2
+Rc8 15. h5 Ne5 16. hxg6 fxg6 17. Qd5 Qxd5 18. cxd5 O-O 19. f3 Nc4 20. Kf2 b5
+21. a4 a6 22. axb5 axb5 23. Rab1 Rb8 24. e4 Nd2 25. Rb2 Nxe4+ 26. Ke3 Nc5 27.
+Nd4 Na4 28. Rxb5 Nxc3 29. Rxb8 Nxd5+ 30. Ke4 Nf6+ 31. Ke3 Rxb8 32. Ne6 Rb3+ 33.
+Kf2 Kf7 34. Nd4 Rb2+ 35. Ne2 e5 36. Ke3 Ke6 37. g4 d5 38. Ra1 d4+ 39. Kf2 d3
+40. Ra6+ Ke7 41. Ke3 dxe2 42. Ra1 Nd5+ 43. Kf2 Nf4 44. Ke3 h5 45. Kf2 e1=Q+ 46.
+Kxe1 h4 47. Kf1 Kf6 48. Kg1 Kg5 49. Kh1 h3 50. Re1 Kh4 51. Rxe5 Kg3 52. Re1 Rb1
+53. Rxb1 Nd3 54. Rg1+ Kxf3 55. g5 Nf2+ 56. Kh2 Ng4+ 57. Kxh3 Ne3 58. Rg3+ Kf4
+59. Rxe3 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "profaVa"]
+[Black "JiangoFett"]
+[Result "0-1"]
+[ECO "B22"]
+[WhiteElo "2381"]
+[BlackElo "2383"]
+[PlyCount "46"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 c5 2. c3 Nf6 3. e5 Nd5 4. d4 cxd4 5. Nf3 Nc6 6. Bc4 Nb6 7. Bb3 d6 8. exd6
+Qxd6 9. Na3 dxc3 10. Qe2 cxb2 11. Bxb2 Qb4+ 12. Kf1 Bg4 13. Nc2 Qf4 14. Ne3
+Bxf3 15. gxf3 e6 16. Rg1 Qxh2 17. Rd1 Qh3+ 18. Rg2 Qh1+ 19. Rg1 Qh3+ 20. Rg2
+Be7 21. Bxg7 Rg8 22. f4 Rxg7 23. f5 Qh1+ 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "starkspieler"]
+[Black "pmlmail"]
+[Result "1-0"]
+[ECO "C45"]
+[WhiteElo "2416"]
+[BlackElo "2483"]
+[PlyCount "111"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 e5 2. Nf3 Nf6 3. Bc4 Nc6 4. d4 exd4 5. e5 d5 6. Bb5 Ne4 7. Nxd4 Bd7 8.
+Bxc6 bxc6 9. O-O c5 10. Nb3 c4 11. Qxd5 cxb3 12. Qxe4 bxc2 13. Qxc2 Be7 14. Nc3
+c6 15. Be3 Qc7 16. f4 g6 17. Rac1 Bf5 18. Qa4 O-O 19. Nd5 Qd7 20. Qxc6 Bd8 21.
+Qxd7 Bxd7 22. Bc5 Re8 23. Rfd1 Be6 24. b4 a6 25. a4 Bd7 26. Nc3 Bg4 27. Rd2 h5
+28. h3 Bf5 29. Nd5 Be6 30. Nb6 Bxb6 31. Bxb6 Bb3 32. a5 Ba4 33. Rc7 Rac8 34.
+Rxc8 Rxc8 35. Rd8+ Rxd8 36. Bxd8 Kf8 37. Kf2 Ke8 38. Bb6 Kd7 39. g4 hxg4 40.
+hxg4 Bd1 41. Kg3 Ke6 42. Kh4 Be2 43. Kg5 Bd3 44. Be3 Bc2 45. Bd4 Be4 46. Bc3
+Bd3 47. Bb2 Be4 48. b5 axb5 49. a6 b4 50. a7 b3 51. f5+ gxf5 52. gxf5+ Ke7 53.
+Ba3+ Ke8 54. Kf6 Ba8 55. e6 fxe6 56. Kxe6 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "chesslismab"]
+[Black "hungzhao"]
+[Result "1-0"]
+[ECO "B20"]
+[WhiteElo "2446"]
+[BlackElo "2627"]
+[PlyCount "103"]
+[EventDate "2020.??.??"]
+
+1. e4 c5 2. d3 Nc6 3. f4 g6 4. g3 Bg7 5. Bg2 h5 6. Nf3 d6 7. h3 b5 8. O-O Rb8
+9. c3 b4 10. c4 Nf6 11. Nbd2 Nd7 12. a4 bxa3 13. Rxa3 O-O 14. b3 Nb4 15. Qe2 a6
+16. g4 hxg4 17. hxg4 Nf6 18. g5 Nh5 19. f5 Ng3 20. Qf2 Nxf1 21. Bxf1 gxf5 22.
+Nh4 fxe4 23. Nxe4 d5 24. cxd5 Bd4 25. Be3 Bxe3 26. Qxe3 Nc2 27. Qg3 Nxa3 28.
+Nf6+ Kh8 29. Ng6+ Kg7 30. Nxf8 exf6 31. Qxb8 Kxf8 32. gxf6 Qxf6 33. Qxc8+ Kg7
+34. Qxc5 Qg5+ 35. Bg2 Nb5 36. Qf2 Qe5 37. Be4 Nd6 38. Qg2+ Kf8 39. Qf3 f5 40.
+Qf2 Ke7 41. Qh4+ Kd7 42. Qh7+ Kc8 43. Qg8+ Kb7 44. Qe6 Qxe6 45. dxe6+ fxe4 46.
+dxe4 Nxe4 47. e7 Nf6 48. Kf2 Ne8 49. Ke3 Kc7 50. Kd4 Kd7 51. Kc5 Kxe7 52. Kb6
+1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "alireza3700"]
+[Black "kingcobra23"]
+[Result "0-1"]
+[ECO "D00"]
+[WhiteElo "2370"]
+[BlackElo "2310"]
+[PlyCount "86"]
+[EventDate "2020.??.??"]
+
+1. d4 d5 2. Nc3 c6 3. Bg5 Nf6 4. Bxf6 exf6 5. e3 Bb4 6. Qf3 Bxc3+ 7. bxc3 Qa5
+8. Ne2 O-O 9. g4 Re8 10. h4 Na6 11. g5 Nc7 12. Bh3 fxg5 13. hxg5 Ne6 14. Qh5
+Nf8 15. Bxc8 Raxc8 16. Kd2 c5 17. Rag1 g6 18. Qh4 cxd4 19. Qxd4 Ne6 20. Qh4 Nc5
+21. Qxh7+ Kf8 22. Qh8+ Ke7 23. Qf6+ Kd7 24. Qxf7+ Kc6 25. Qxg6+ Kb5 26. Rb1+
+Ka4 27. Rh4+ Ne4+ 28. Ke1 b5 29. Rb4+ Ka3 30. Rhxe4 Rxe4 31. Qd6 Rxb4 32. cxb4
+Qxb4+ 33. Qxb4+ Kxb4 34. f4 Kc4 35. Kf2 Re8 36. Kg3 Rxe3+ 37. Kf2 Re4 38. Kf3
+Re7 39. Ng3 d4 40. Nf5 Kd5 41. Nxe7+ Ke6 42. Nf5 Kxf5 43. Kg3 d3 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "WildBreath"]
+[Black "LordBendtner99"]
+[Result "1-0"]
+[ECO "B06"]
+[WhiteElo "2425"]
+[BlackElo "2483"]
+[PlyCount "135"]
+[EventDate "2020.??.??"]
+
+1. e4 g6 2. d4 f6 3. Bc4 Nh6 4. Bxh6 Bxh6 5. h4 e6 6. h5 g5 7. Ne2 O-O 8. c3 d5
+9. exd5 exd5 10. Bd3 c6 11. Bc2 Qe7 12. Qd3 f5 13. Nd2 Nd7 14. O-O-O Nf6 15. f3
+Be6 16. Rde1 Qf7 17. Ng3 Nd7 18. Re2 Rae8 19. Rhe1 f4 20. Nh1 Bf5 21. Rxe8 Bxd3
+22. Rxf8+ Nxf8 23. Bxd3 Bg7 24. Nf2 h6 25. Ng4 Nd7 26. Bg6 Qf8 27. Re8 Qxe8 28.
+Bxe8 Nb6 29. Bg6 Kf8 30. a4 Ke7 31. a5 Nc8 32. Bd3 Nd6 33. Nb3 b6 34. axb6 axb6
+35. Nd2 Bf8 36. b3 Ke6 37. Kc2 Nf5 38. Bxf5+ Kxf5 39. Nf1 Bg7 40. Kd3 Ke6 41.
+Nd2 Kf5 42. c4 Ke6 43. c5 bxc5 44. dxc5 Bf8 45. b4 Kf5 46. Nb3 Ke6 47. Nd4+ Kd7
+48. Ne5+ Kc7 49. Ndxc6 Bg7 50. Kd4 Bf6 51. Kxd5 Bg7 52. Ng4 Kb7 53. b5 Bh8 54.
+Nce5 Kb8 55. Nf7 Bg7 56. Nfxh6 Bf8 57. Nf7 Bg7 58. Nxg5 Bc3 59. Ne6 Bh8 60. h6
+Ka8 61. h7 Kb8 62. c6 Kc8 63. b6 Kb8 64. Nxf4 Kc8 65. Ng6 Kb8 66. Nxh8 Ka8 67.
+Ng6 Kb8 68. h8=Q# 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "DoctorFromGallifrey"]
+[Black "estocastico"]
+[Result "1/2-1/2"]
+[ECO "B20"]
+[WhiteElo "2550"]
+[BlackElo "2591"]
+[PlyCount "112"]
+[EventDate "2020.??.??"]
+
+1. e4 c5 2. b3 e6 3. Bb2 a6 4. d3 Nc6 5. Nd2 d5 6. Ngf3 d4 7. a4 g6 8. Nc4 Bg7
+9. e5 Nge7 10. Nd6+ Kf8 11. Nc4 Qc7 12. Qe2 Rb8 13. a5 Nd5 14. g3 h6 15. h4 Kg8
+16. Bg2 Kh7 17. h5 g5 18. Nxg5+ hxg5 19. h6 Bxh6 20. Be4+ Kg7 21. Bc1 Qe7 22.
+Qg4 f5 23. exf6+ Nxf6 24. Qf3 Nxe4 25. Qxe4 e5 26. Bd2 Be6 27. O-O-O Bxc4 28.
+dxc4 Rbf8 29. f4 exf4 30. Qd5 Qf7 31. gxf4 Qxd5 32. cxd5 Ne7 33. fxg5 Nxd5 34.
+gxh6+ Kh7 35. Rhg1 Rhg8 36. Rde1 Rxg1 37. Rxg1 Rf7 38. Re1 Nf4 39. Rf1 Nd3+ 40.
+cxd3 Rxf1+ 41. Kc2 Rf2 42. b4 Kg6 43. bxc5 Rf5 44. Bb4 Kxh6 45. Kb3 Rf3 46. Kc4
+Kg6 47. Kxd4 Kf5 48. Kc4 Ke6 49. d4 Rf4 50. Bc3 Rg4 51. Bb4 Kd7 52. Bc3 Kc6 53.
+Bb4 Rf4 54. Bc3 Rg4 55. Bb4 Rf4 56. Bc3 Rg4 1/2-1/2
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "AlexMitAlex"]
+[Black "Mondesespoir2700"]
+[Result "0-1"]
+[ECO "D02"]
+[WhiteElo "2306"]
+[BlackElo "2428"]
+[PlyCount "80"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 d5 2. Nf3 c6 3. Bf4 e6 4. Nbd2 Nf6 5. e3 Bd6 6. Bd3 Bxf4 7. exf4 Nbd7 8.
+O-O O-O 9. Ne5 c5 10. c3 cxd4 11. cxd4 Qb6 12. Nb3 a5 13. Qc2 a4 14. Nc5 h6 15.
+Rac1 Nxc5 16. dxc5 Qc7 17. b4 axb3 18. axb3 b6 19. b4 bxc5 20. bxc5 Nd7 21. Qc3
+Nxe5 22. fxe5 Bb7 23. c6 Ba6 24. Rfd1 Rfc8 25. Qd4 Qa7 26. Qg4 Qb6 27. Bxa6
+Rxa6 28. h4 Rxc6 29. Rb1 Qc7 30. h5 Rab6 31. f4 Rxb1 32. Rxb1 Rc1+ 33. Rxc1
+Qxc1+ 34. Kh2 Qc2 35. Qh4 Qf5 36. Kg3 d4 37. Qg4 Qe4 38. Qf3 Qc2 39. Qa8+ Kh7
+40. Qb7 Qf5 0-1
+
+[Event "Rated Blitz tournament hM7PUvgg"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Club-Jaque-al-Rey"]
+[Black "vangulio"]
+[Result "1/2-1/2"]
+[ECO "B54"]
+[WhiteElo "2533"]
+[BlackElo "2433"]
+[PlyCount "39"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. f3 g6 6. c4 Bg7 7. Nc3 O-O 8. Be3
+Nc6 9. Qd2 Bd7 10. Rc1 Nxd4 11. Bxd4 Bc6 12. Be2 a5 13. O-O Nd7 14. Be3 Nc5 15.
+Rfd1 Qb6 16. Nd5 Bxd5 17. cxd5 Rfc8 18. b3 Qb4 19. Kf2 Qxd2 20. Bxd2 1/2-1/2
+
+[Event "Rated Bullet tournament Ty5yUoqy"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Superman89"]
+[Black "RyanX4FleteChavale"]
+[Result "0-1"]
+[ECO "A43"]
+[WhiteElo "2338"]
+[BlackElo "2358"]
+[PlyCount "102"]
+[EventDate "2020.??.??"]
+
+1. d4 c5 2. dxc5 Nf6 3. Nf3 e5 4. g3 e4 5. Nd4 e3 6. Bxe3 Nc6 7. Nxc6 bxc6 8.
+Nc3 d5 9. cxd6 Bxd6 10. Bg2 Bb7 11. O-O O-O 12. Na4 Rc8 13. Bc5 Bxc5 14. Nxc5
+Qb6 15. Nb3 c5 16. Bxb7 Qxb7 17. c4 Rfd8 18. Qc2 Nd7 19. Rad1 Ne5 20. Rxd8+
+Rxd8 21. Rd1 Re8 22. e3 Nc6 23. Nxc5 Qe7 24. Nd3 h6 25. Nf4 Nb4 26. Nd5 Nxc2
+27. Nxe7+ Rxe7 28. a3 Nxe3 29. fxe3 Rxe3 30. Rd2 Re8 31. Rc2 Rc8 32. c5 Kf8 33.
+c6 Ke8 34. b4 Ke7 35. b5 Kd6 36. a4 Kd5 37. Kf2 Kd6 38. Kf3 f6 39. Kf4 Ke6 40.
+Re2+ Kf7 41. Rd2 g6 42. Rd7+ Ke6 43. Rxa7 g5+ 44. Ke4 Re8 45. Kd3 Kd6 46. Kc4
+Re4+ 47. Kb3 Re2 48. Kb4 Ke5 49. Ka5 Ra2 50. Kb6 Rxa4 51. c7 Rb4 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Elhlwagy11"]
+[Black "Johnnyballgame"]
+[Result "0-1"]
+[ECO "D01"]
+[WhiteElo "2306"]
+[BlackElo "2300"]
+[PlyCount "44"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 Nf6 2. Nc3 d5 3. Bg5 Nbd7 4. f3 c6 5. e4 dxe4 6. fxe4 e5 7. Bxf6 Qxf6 8.
+Nf3 Bb4 9. Bd3 O-O 10. dxe5 Nxe5 11. Nxe5 Qxe5 12. O-O Bxc3 13. bxc3 Qxc3 14.
+Rb1 b6 15. Qh5 Be6 16. e5 g6 17. Qg5 Rad8 18. Rf3 Qd4+ 19. Kh1 Rd5 20. Re1 c5
+21. Rf4 Qc3 22. Re3 Rxd3 0-1
+
+[Event "Rated Bullet tournament GAdGz1co"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Zuritadas"]
+[Black "RaylessStarfish"]
+[Result "0-1"]
+[ECO "A10"]
+[WhiteElo "2397"]
+[BlackElo "2380"]
+[PlyCount "124"]
+[EventDate "2020.??.??"]
+
+1. c4 b6 2. e4 Bb7 3. Nc3 e6 4. Nf3 Bb4 5. Bd3 c5 6. O-O Nc6 7. a3 Bxc3 8. dxc3
+Nge7 9. Bf4 d6 10. e5 Ng6 11. Bxg6 hxg6 12. Qxd6 Qxd6 13. exd6 f6 14. Rfe1 Kd7
+15. Rad1 e5 16. Bg3 Rae8 17. Nd2 f5 18. Nf1 Re6 19. f4 e4 20. Ne3 Rxd6 21.
+Rxd6+ Kxd6 22. Rd1+ Ke6 23. Kf2 Rd8 24. Rxd8 Nxd8 25. b3 Nf7 26. Ke2 Nd6 27.
+Kd2 Nc8 28. a4 a5 29. Bf2 Ne7 30. g3 Kd6 31. h3 Ke6 32. g4 Kd6 33. h4 Ke6 34.
+h5 fxg4 35. hxg6 Kf6 36. Bh4+ Ke6 37. Bxe7 Kxe7 38. Nxg4 Bc8 39. Ne5 Kf6 40.
+Ke3 Bf5 41. b4 Ke6 42. bxa5 bxa5 43. Kd2 Kf6 44. Ke3 Be6 45. Kd2 Bf5 46. Ke3
+Ke6 47. Nc6 Kf6 48. Nd8 Kxg6 49. Nb7 Kf6 50. Nxc5 Be6 51. Nxe4+ Ke7 52. Nc5
+Bxc4 53. Nb7 Bb5 54. Nxa5 Bxa4 55. Nc6+ Bxc6 56. Kd4 Bb7 57. Ke5 Kd8 58. f5 Kc8
+59. f6 Bd5 60. fxg7 Bg8 61. Kf6 Bf7 62. Ke7 Bg8 0-1
+
+[Event "Rated Rapid game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Mukha73"]
+[Black "Tallnicke"]
+[Result "0-1"]
+[ECO "D85"]
+[WhiteElo "2392"]
+[BlackElo "2400"]
+[PlyCount "124"]
+[EventDate "2020.??.??"]
+[EventType "rapid"]
+
+1. d4 Nf6 2. c4 g6 3. Nc3 d5 4. cxd5 Nxd5 5. e4 Nxc3 6. bxc3 Bg7 7. Nf3 O-O 8.
+Rb1 Nd7 9. Be2 c5 10. O-O Nf6 11. e5 Nd5 12. Bd2 cxd4 13. cxd4 b6 14. Rc1 Bb7
+15. Qa4 a6 16. Qa3 Qd7 17. Bg5 f6 18. Bd2 Kh8 19. Bc4 g5 20. exf6 exf6 21. Rfe1
+Rfe8 22. Qd3 b5 23. Bb3 Bf8 24. h3 Bd6 25. Bc2 Nf4 26. Bxf4 Bxf4 27. Rxe8+ Rxe8
+28. Re1 Rxe1+ 29. Nxe1 Bd5 30. Bb3 Qe6 31. Bxd5 Qxd5 32. g3 Bd6 33. Nf3 h6 34.
+Qe2 Kg7 35. Kh2 a5 36. h4 b4 37. h5 a4 38. Qd3 f5 39. Nd2 Qf7 40. Qf3 g4 41.
+Qc6 Qxa2 42. Qd7+ Kg8 43. Qxd6 Qxd2 44. Qg6+ Kf8 45. Qxf5+ Ke7 46. Qc5+ Kd7 47.
+Qb5+ Kc7 48. Qc5+ Kd7 49. d5 Qc3 50. Qb5+ Kd6 51. Qxa4 Kxd5 52. Qd7+ Kc4 53.
+Qxg4+ Kd3 54. Qg6+ Kd2 55. Qxh6+ Ke1 56. Qe3+ Qxe3 57. fxe3 b3 58. h6 b2 59. h7
+b1=Q 60. h8=Q Qf5 61. Qh6 Ke2 62. Qf4 Qh7+ 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "imdejong"]
+[Black "BerserkAdopter"]
+[Result "0-1"]
+[ECO "B01"]
+[WhiteElo "2356"]
+[BlackElo "2433"]
+[PlyCount "90"]
+[EventDate "2020.??.??"]
+
+1. e4 d5 2. exd5 Qxd5 3. Nc3 Qd8 4. d4 Bf5 5. Nf3 e6 6. Bd3 Bg6 7. Bxg6 hxg6 8.
+O-O c6 9. Re1 Nf6 10. Qe2 Bd6 11. Bg5 O-O 12. Ne5 Be7 13. Rad1 Nbd7 14. Rd3 Nd5
+15. Bxe7 Qxe7 16. Rh3 Nxe5 17. dxe5 Nxc3 18. Rxc3 Rfd8 19. Rh3 Rd4 20. c3 Rd5
+21. Rd1 Rad8 22. Rhd3 R8d7 23. Rxd5 Rxd5 24. Rxd5 exd5 25. f4 f6 26. Qe3 fxe5
+27. fxe5 b6 28. h4 Qe6 29. g3 Kf7 30. Kg2 Ke7 31. Kf3 Kd7 32. Qf4 c5 33. Ke3
+Kc6 34. g4 Kb5 35. g5 Kc6 36. a4 Kd7 37. b4 Kc6 38. b5+ Kd7 39. Kd3 Ke7 40. Ke3
+Qh3+ 41. Qf3 Qe6 42. Qf4 Qd7 43. h5 Qe6 44. h6 gxh6 45. gxh6 Qh3+ 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "mixo23"]
+[Black "Dimitriy1975"]
+[Result "0-1"]
+[ECO "B50"]
+[WhiteElo "2422"]
+[BlackElo "2383"]
+[PlyCount "62"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. Nf3 c5 2. e4 d6 3. Nc3 g6 4. Bc4 Bg7 5. d3 Nc6 6. O-O e6 7. a3 Nge7 8. Bg5
+O-O 9. Qd2 Rb8 10. Bh6 a6 11. Bxg7 Kxg7 12. h3 b5 13. Ba2 e5 14. Nd5 Be6 15.
+Nh2 Qd7 16. f4 f5 17. Rae1 exf4 18. Qxf4 Bxd5 19. exd5 Ne5 20. Rxe5 dxe5 21.
+Qxe5+ Kh6 22. d6 Nc6 23. Qxc5 Rbc8 24. Bd5 Rfd8 25. Re1 Qxd6 26. Qe3+ f4 27.
+Ng4+ Kg7 28. Qb6 Qxd5 29. Kh1 h5 30. Nf2 Qd4 31. Ne4 Qxb6 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "pro100still"]
+[Black "Filemon64"]
+[Result "1-0"]
+[ECO "B07"]
+[WhiteElo "2356"]
+[BlackElo "2321"]
+[PlyCount "49"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 d6 2. d4 Nf6 3. Nc3 c6 4. a4 Qa5 5. Bd3 e5 6. Nge2 Nbd7 7. O-O g6 8. f4
+exd4 9. Nxd4 Bg7 10. e5 dxe5 11. fxe5 Nxe5 12. Bg5 Nfd7 13. Kh1 O-O 14. Be7 Re8
+15. b4 Qc7 16. Bh4 Nxd3 17. Qxd3 Ne5 18. Qg3 Qb6 19. Rad1 Qxb4 20. Ne4 Bg4 21.
+Nf6+ Bxf6 22. Bxf6 Bxd1 23. Bxe5 Bh5 24. Qf4 Rad8 25. Qxf7# 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Kidefence"]
+[Black "BlueGreensun"]
+[Result "0-1"]
+[ECO "B07"]
+[WhiteElo "2728"]
+[BlackElo "2738"]
+[PlyCount "62"]
+[EventDate "2020.??.??"]
+
+1. e4 d6 2. d4 Nf6 3. Nc3 e5 4. Nf3 Bd7 5. Bg5 exd4 6. Nxd4 Be7 7. Qd2 Nc6 8.
+O-O-O O-O 9. f3 a6 10. Kb1 Nxd4 11. Qxd4 c5 12. Qd2 b5 13. Bxf6 Bxf6 14. Qxd6
+Qa5 15. Nd5 Be6 16. Nxf6+ gxf6 17. a3 Rfd8 18. Qg3+ Kh8 19. Be2 b4 20. Qf4 Kg7
+21. Qg3+ Kf8 22. Rxd8+ Rxd8 23. Rd1 Rxd1+ 24. Bxd1 bxa3 25. Qd6+ Kg7 26. Qg3+
+Kf8 27. Qb8+ Ke7 28. Qb7+ Bd7 29. bxa3 Qxa3 30. Be2 a5 31. Bb5 Qb4+ 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "vassiukov"]
+[Black "vaillant77"]
+[Result "0-1"]
+[ECO "A43"]
+[WhiteElo "2361"]
+[BlackElo "2430"]
+[PlyCount "134"]
+[EventDate "2020.??.??"]
+
+1. d4 c5 2. Nf3 cxd4 3. c3 e5 4. cxd4 e4 5. Nfd2 d5 6. e3 Nf6 7. Nc3 a6 8. a4
+Nc6 9. Qb3 Bd6 10. g3 O-O 11. Bg2 Nb4 12. O-O Be6 13. h3 Qd7 14. Kh2 h5 15. Ne2
+h4 16. Nf4 Bxf4 17. gxf4 Nd3 18. Qd1 Rac8 19. b3 g6 20. Ba3 Rfe8 21. Qe2 Rc2
+22. Qd1 Rec8 23. Nc4 Rxf2 24. Ne5 Qc7 25. Nxd3 Rxf1 26. Qxf1 exd3 27. Qxd3 Qc2
+28. Qf1 Ne4 29. Rc1 Qa2 30. Rxc8+ Bxc8 31. Be7 f6 32. Qe1 Kf7 33. Bb4 Bf5 34.
+Kg1 Ng3 35. Bxd5+ Kg7 36. Bd2 Qc2 37. Bc4 Be4 38. d5 Nf5 39. Bf1 b5 40. axb5
+axb5 41. Bc3 Bxd5 42. e4 Bxe4 43. Qf2 Ng3 44. Qxc2 Bxc2 45. f5 Nxf1 46. Bxf6+
+Kxf6 47. Kf2 Bxb3 48. Kxf1 gxf5 49. Kf2 Kg5 50. Ke3 f4+ 51. Kd4 Bd5 52. Ke5 f3
+53. Kxd5 f2 54. Kc5 f1=Q 55. Kd6 Qxh3 56. Ke7 Qe3+ 57. Kd6 h3 58. Kc7 h2 59.
+Kc6 h1=Q+ 60. Kc7 Qd1 61. Kc6 b4 62. Kb5 b3 63. Ka4 b2+ 64. Kb5 Qdb3+ 65. Ka6
+Qc4+ 66. Kb7 Qe7+ 67. Kb8 Qc8+ 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Bighamian"]
+[Black "fusionpro"]
+[Result "1-0"]
+[ECO "E67"]
+[WhiteElo "2344"]
+[BlackElo "2441"]
+[PlyCount "73"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. Nf3 Nf6 2. g3 g6 3. Bg2 Bg7 4. O-O O-O 5. c4 d6 6. d4 e5 7. Nc3 Nbd7 8. h3
+Re8 9. e4 exd4 10. Nxd4 Nc5 11. Re1 Bd7 12. Bf4 h6 13. g4 a6 14. Qd2 Kh7 15.
+Rad1 Ne6 16. Be3 b5 17. cxb5 axb5 18. a3 Rb8 19. f4 Nc5 20. Qc2 b4 21. axb4
+Rxb4 22. g5 hxg5 23. fxg5 Nh5 24. Nd5 Rb8 25. b4 Ne6 26. Nc6 Bxc6 27. Qxc6 Nhf4
+28. Nxf4 Nxf4 29. Bxf4 Rxb4 30. h4 Qb8 31. Bh2 Rb2 32. Rc1 Bd4+ 33. Kh1 Qb4 34.
+Qxe8 Qd2 35. Qxf7+ Kh8 36. Qf8+ Kh7 37. Rxc7+ 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Vladimir_Putilov"]
+[Black "Kabila"]
+[Result "1-0"]
+[ECO "A00"]
+[WhiteElo "2303"]
+[BlackElo "2320"]
+[PlyCount "77"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d3 d5 2. c3 e5 3. Nd2 Nc6 4. h3 Nf6 5. g4 Bc5 6. Bg2 Be6 7. Nf1 Qd6 8. Ne3
+O-O-O 9. Qc2 d4 10. Nf5 Bxf5 11. gxf5 Rhe8 12. Bd2 e4 13. dxe4 dxc3 14. bxc3
+Bxf2+ 15. Kxf2 Qxd2 16. Qxd2 Rxd2 17. Ke3 Rb2 18. h4 Ne5 19. Nh3 Nfg4+ 20. Kf4
+Rxe2 21. Bf3 Nxf3 22. Kxg4 Ne5+ 23. Kf4 Nd3+ 24. Kf3 R8xe4 25. Rad1 R4e3+ 26.
+Kg4 Ne5+ 27. Kh5 Rg2 28. Nf4 Rf3 29. Rhf1 Rgf2 30. Rxf2 Rxf2 31. Rd4 Nf3 32.
+Re4 Nd2 33. Rd4 Nf3 34. Re4 Nh2 35. f6 g6+ 36. Kg5 h6+ 37. Kxh6 Ng4+ 38. Kg7
+Kd7 39. Kxf7 1-0
+
+[Event "Rated Blitz tournament hM7PUvgg"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "vangulio"]
+[Black "Janemba"]
+[Result "1-0"]
+[ECO "B21"]
+[WhiteElo "2435"]
+[BlackElo "2315"]
+[PlyCount "65"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 c5 2. Nf3 Nc6 3. d4 cxd4 4. c3 dxc3 5. Nxc3 e6 6. Bc4 a6 7. O-O b5 8. Bb3
+Bb4 9. Qe2 Bxc3 10. bxc3 Bb7 11. Ba3 Nge7 12. Rfd1 O-O 13. e5 Na5 14. Bc2 Nc4
+15. Bxh7+ Kxh7 16. Ng5+ Kg8 17. Qh5 Be4 18. Nxe4 Nf5 19. Bxf8 Kxf8 20. Rxd7
+Qxd7 21. Qh8+ Ke7 22. Qxa8 Nxe5 23. Qxa6 Qd3 24. Ng3 Nxg3 25. Qa3+ Kf6 26. hxg3
+Nc4 27. Qb3 Nd2 28. Rd1 Qe2 29. Rxd2 Qxd2 30. Qxb5 Qxc3 31. a4 Qe1+ 32. Qf1
+Qxf2+ 33. Qxf2+ 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Maxterlopez"]
+[Black "FerociousLion98999"]
+[Result "1-0"]
+[ECO "C58"]
+[WhiteElo "2659"]
+[BlackElo "2578"]
+[PlyCount "65"]
+[EventDate "2020.??.??"]
+
+1. e4 e5 2. Nf3 Nc6 3. Bc4 Nf6 4. Ng5 d5 5. exd5 Na5 6. Bb5+ c6 7. dxc6 bxc6 8.
+Bd3 Be7 9. O-O h6 10. Ne4 Nd5 11. Qf3 O-O 12. Ng3 Nf4 13. Bf5 Bb7 14. d3 c5 15.
+Be4 Bxe4 16. Qxe4 Ne6 17. Qxe5 Nc6 18. Qe4 Ncd4 19. Na3 f5 20. Qe1 f4 21. Ne4
+f3 22. Ng3 fxg2 23. Kxg2 Bg5 24. c3 Bxc1 25. cxd4 Nf4+ 26. Kh1 Bxb2 27. Nc4
+Bxa1 28. Qxa1 Qd5+ 29. f3 Nxd3 30. Qc3 Rxf3 31. Kg1 cxd4 32. Qa5 Raf8 33. Qxd5+
+1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "allan-cantonjos"]
+[Black "self_service"]
+[Result "0-1"]
+[ECO "D01"]
+[WhiteElo "2416"]
+[BlackElo "2418"]
+[PlyCount "68"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 Nf6 2. Nc3 d5 3. Bg5 h6 4. Bxf6 exf6 5. e4 dxe4 6. Nxe4 f5 7. Ng3 Qe7+ 8.
+Be2 f4 9. Nh5 Qb4+ 10. Kf1 Qxb2 11. Nxf4 Bd6 12. Nd5 O-O 13. Nf3 Nc6 14. Ne3
+Re8 15. h3 Nb4 16. Rb1 Qxa2 17. Bc4 Qa4 18. Bb3 Qb5+ 19. c4 Qh5 20. c5 Bf4 21.
+Ba4 Nc6 22. d5 Rd8 23. Qe1 Ne7 24. g4 Qg6 25. Bc2 Qa6+ 26. Kg2 Bxe3 27. Qxe3
+Nxd5 28. Qe4 Be6 29. Qh7+ Kf8 30. Nd4 Nf4+ 31. Kg3 Rxd4 32. Be4 Qa3+ 33. f3
+Rxe4 34. Qxe4 Nd5 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Lil_D"]
+[Black "murderoflegends"]
+[Result "0-1"]
+[ECO "A00"]
+[WhiteElo "2305"]
+[BlackElo "2420"]
+[PlyCount "102"]
+[EventDate "2020.??.??"]
+
+1. g3 d5 2. Bg2 c6 3. d3 Nf6 4. Nd2 Bg4 5. h3 Bh5 6. g4 Bg6 7. f4 e6 8. e3 Bc5
+9. Ndf3 Nbd7 10. Ne2 O-O 11. O-O Qb6 12. Qd2 Rfe8 13. Ng3 h6 14. Kh2 Rad8 15.
+Nh4 Bh7 16. g5 Bd6 17. gxf6 Nxf6 18. Qe2 Qc7 19. Nf3 b6 20. a3 c5 21. b3 e5 22.
+Nxe5 Bxe5 23. fxe5 Qxe5 24. Bd2 d4 25. e4 Bg6 26. Bf4 Qe7 27. Qf2 Nd7 28. Nf5
+Qe6 29. Qg3 Kh7 30. Nd6 Rf8 31. Rae1 Nf6 32. Nf5 Nh5 33. Qg4 Nf6 34. Qh4 Rde8
+35. Bxh6 Bxf5 36. Bg5+ Kg8 37. exf5 Qd6+ 38. Bf4 Qd7 39. Be5 Rxe5 40. Rxe5 Qd6
+41. Rfe1 Re8 42. Qg3 Rf8 43. Re8 Qxg3+ 44. Kxg3 Nxe8 45. Rxe8 Rxe8 46. Kf4 Re3
+47. Be4 f6 48. h4 Kf8 49. h5 Ke7 50. c3 Rh3 51. cxd4 cxd4 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "zenon011"]
+[Black "Northridgehawk"]
+[Result "0-1"]
+[ECO "C50"]
+[WhiteElo "2331"]
+[BlackElo "2363"]
+[PlyCount "30"]
+[EventDate "2020.??.??"]
+
+1. e4 e5 2. Nf3 Nc6 3. Bc4 Nf6 4. d3 Bc5 5. Nc3 d6 6. Bb3 Bb6 7. Be3 Ne7 8. Ne2
+Ng6 9. Ng3 c6 10. Qd2 Qe7 11. O-O-O Be6 12. Nh4 Nxh4 13. f4 Bxe3 14. Qxe3 Nxg2
+15. Qf2 Nxf4 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "irakliberadze"]
+[Black "FishyMcPatzer"]
+[Result "0-1"]
+[ECO "B28"]
+[WhiteElo "2662"]
+[BlackElo "2567"]
+[PlyCount "72"]
+[EventDate "2020.??.??"]
+
+1. e4 c5 2. Nf3 a6 3. c3 Nf6 4. e5 Nd5 5. d4 cxd4 6. cxd4 d6 7. Nc3 dxe5 8.
+Nxe5 Nxc3 9. bxc3 Nd7 10. Nxf7 Kxf7 11. Qf3+ Ke8 12. Bc4 Nf6 13. O-O e6 14. Re1
+Be7 15. Bxe6 Bxe6 16. Rxe6 Qd7 17. Re2 Kf7 18. Bf4 Rae8 19. Rae1 Bd8 20. Be5
+Re6 21. h3 Rhe8 22. c4 Kg8 23. d5 Rb6 24. Bxf6 Rxe2 25. Qxe2 Rxf6 26. Qe5 Bb6
+27. Re2 h6 28. a3 Bc5 29. a4 b6 30. Kh1 a5 31. Re4 Qxa4 32. Rg4 Kh8 33. Qc7
+Qd1+ 34. Kh2 Bd6+ 35. Qxd6 Rxd6 36. c5 bxc5 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "rudolf85"]
+[Black "Paanoos"]
+[Result "1-0"]
+[ECO "A00"]
+[WhiteElo "2422"]
+[BlackElo "2380"]
+[PlyCount "41"]
+[EventDate "2020.??.??"]
+
+1. e3 g6 2. d4 Bg7 3. Nf3 c5 4. Be2 Nf6 5. O-O O-O 6. c4 b6 7. Nc3 d5 8. cxd5
+Nxd5 9. Nxd5 Qxd5 10. Ne5 Bxe5 11. Bf3 Qd6 12. dxe5 Qxe5 13. Bxa8 Nd7 14. Bf3
+Nf6 15. Qc2 Ba6 16. Rd1 h5 17. Bd2 h4 18. h3 g5 19. Bc3 Qe6 20. Bxf6 exf6 21.
+Qe4 1-0
+
+[Event "Rated Blitz tournament hM7PUvgg"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Fasmc17"]
+[Black "RCSA007"]
+[Result "0-1"]
+[ECO "D14"]
+[WhiteElo "2342"]
+[BlackElo "2428"]
+[PlyCount "32"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 d5 2. c4 c6 3. Nc3 Nf6 4. cxd5 cxd5 5. Nf3 Nc6 6. Bf4 Bf5 7. e3 e6 8. Qb3
+Bb4 9. a3 Bxc3+ 10. bxc3 O-O 11. Qxb7 Qa5 12. Qxc6 Rac8 13. Qxc8 Rxc8 14. Rc1
+Rxc3 15. Rxc3 Qxc3+ 16. Nd2 Ne4 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "david_gomez"]
+[Black "zpxocivubyntmraeswdq"]
+[Result "0-1"]
+[ECO "A80"]
+[WhiteElo "2456"]
+[BlackElo "2682"]
+[PlyCount "64"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 f5 2. Bg5 g6 3. Nd2 Bg7 4. e4 fxe4 5. Nxe4 d5 6. Nc5 b6 7. Nb3 Nh6 8. Nf3
+Nf7 9. h4 c5 10. dxc5 Bxb2 11. Bb5+ Bd7 12. Bd3 Nc6 13. O-O O-O 14. Rb1 Bg7 15.
+Bb5 Nce5 16. Nxe5 Bxb5 17. Nxf7 Rxf7 18. Re1 h6 19. Be3 e5 20. Na5 bxa5 21.
+Rxb5 d4 22. Bc1 Qd5 23. Qd3 Raf8 24. f3 Rf5 25. Qb3 Qxb3 26. axb3 Rc8 27. Rxa5
+e4 28. Rxe4 Rfxc5 29. Rxc5 Rxc5 30. Re8+ Kf7 31. Re7+ Kxe7 32. Ba3 Kd6 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Midnight_Mushroom"]
+[Black "yaguigor"]
+[Result "0-1"]
+[ECO "A11"]
+[WhiteElo "2436"]
+[BlackElo "2435"]
+[PlyCount "76"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. c4 c6 2. Nf3 d5 3. e3 Nf6 4. b3 Bg4 5. Be2 e6 6. Bb2 Nbd7 7. O-O Be7 8. d3
+O-O 9. Nbd2 Re8 10. h3 Bh5 11. Qc2 h6 12. Rac1 Bd6 13. Qb1 e5 14. cxd5 cxd5 15.
+Qa1 Qb6 16. Rfe1 Rad8 17. d4 e4 18. Ne5 Bxe2 19. Rxe2 Rc8 20. Ree1 Rc7 21. Rxc7
+Qxc7 22. Rc1 Qb8 23. Rc2 Nxe5 24. dxe5 Bxe5 25. Bxe5 Rxe5 26. b4 Re8 27. Qc3
+Qd6 28. Nb3 Qb6 29. Nd4 Qa6 30. b5 Qa4 31. Qc7 b6 32. Qc3 Nd7 33. Qc6 Nf6 34.
+Nf5 Kh7 35. Nd6 Re6 36. Rc1 Qa3 37. Nxe4 Rxc6 38. bxc6 Nxe4 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "aminmohamad64"]
+[Black "EventHorizonNeptune"]
+[Result "1-0"]
+[ECO "A00"]
+[WhiteElo "2373"]
+[BlackElo "2343"]
+[PlyCount "65"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. g3 d5 2. Bg2 Bg4 3. c4 c6 4. Qb3 Qb6 5. cxd5 Qxb3 6. axb3 Nf6 7. Nc3 e5 8.
+h3 Bd7 9. g4 Bb4 10. dxc6 Nxc6 11. Nf3 O-O 12. O-O Rad8 13. d3 Bxc3 14. bxc3
+Nd5 15. c4 Nf4 16. Bxf4 exf4 17. d4 Rfe8 18. d5 Nb4 19. Rxa7 Rxe2 20. Rxb7 h5
+21. Rxb4 hxg4 22. hxg4 Bxg4 23. Nd4 Rd2 24. Nc6 Ra8 25. Ne5 Be2 26. Re1 f6 27.
+Nf3 Rb2 28. d6 g5 29. d7 g4 30. Nd4 f3 31. Nxe2 fxe2 32. Bxa8 Rd2 33. Rb8+ 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "davidcm92"]
+[Black "mohsen448"]
+[Result "0-1"]
+[ECO "C18"]
+[WhiteElo "2323"]
+[BlackElo "2356"]
+[PlyCount "174"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 e6 2. d4 d5 3. Nc3 Bb4 4. e5 Ne7 5. a3 Bxc3+ 6. bxc3 c5 7. Qg4 O-O 8. Nf3
+Nbc6 9. h4 Qa5 10. Bd2 Qa4 11. Ra2 cxd4 12. cxd4 Nf5 13. c3 Qb3 14. Ra1 Qb2 15.
+Rd1 Qxa3 16. Bd3 a5 17. Rh3 a4 18. h5 Qe7 19. Bg5 Qe8 20. Nh4 a3 21. Nxf5 exf5
+22. Bxf5 Bxf5 23. Qxf5 a2 24. Ra1 Qe6 25. Qc2 Qg4 26. Rg3 Qe4+ 27. Qxe4 dxe4
+28. Re3 f5 29. Re2 Ra3 30. d5 Nxe5 31. Be7 Nd3+ 32. Kd2 Rfa8 33. Bxa3 Rxa3 34.
+Ke3 Rxc3 35. Rexa2 Nb4+ 36. Kf4 Nxa2 37. Rxa2 Rc5 38. Kxf5 Rxd5+ 39. Kxe4 Rxh5
+40. Rb2 b5 41. g4 Rc5 42. Kd4 Rc4+ 43. Ke3 Rxg4 44. Rxb5 h5 45. Kf3 g6 46. Rb7
+Ra4 47. Rc7 Ra8 48. Kg2 Rf8 49. Rb7 Rf7 50. Rb6 Kg7 51. Ra6 Rf6 52. Ra7+ Kh6
+53. Ra5 Rf5 54. Ra8 Kg5 55. f3 h4 56. Rg8 Rb5 57. Rg7 Rb2+ 58. Kg1 Re2 59. Rg8
+Rb2 60. Rg7 h3 61. Rh7 h2+ 62. Rxh2 Rb1+ 63. Kg2 Kf4 64. Rh4+ Kg5 65. Rg4+ Kf5
+66. Kg3 g5 67. Re4 Rg1+ 68. Kf2 Ra1 69. Rb4 Ra2+ 70. Kg3 Ra3 71. Rb5+ Kg6 72.
+Rb4 Kh5 73. Rg4 Ra5 74. f4 Ra3+ 75. Kf2 Kxg4 76. fxg5 Kxg5 77. Ke2 Kf4 78. Kd2
+Re3 79. Kc2 Ke4 80. Kd2 Kd4 81. Kc2 Rd3 82. Kc1 Kc3 83. Kb1 Kb3 84. Kc1 Rd4 85.
+Kb1 Rd2 86. Kc1 Rd4 87. Kb1 Rd1# 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Xychael27"]
+[Black "seleneitor13"]
+[Result "1-0"]
+[ECO "D01"]
+[WhiteElo "2309"]
+[BlackElo "2311"]
+[PlyCount "63"]
+[EventDate "2020.??.??"]
+
+1. d4 Nf6 2. Nc3 d5 3. Bf4 c6 4. e3 e6 5. Bd3 Bd6 6. Nf3 Bxf4 7. exf4 Nbd7 8.
+O-O O-O 9. Ne5 c5 10. Qf3 c4 11. Be2 a6 12. Qh3 Ne4 13. Nxe4 dxe4 14. Bxc4 b5
+15. Be2 Bb7 16. Rfd1 f5 17. c4 bxc4 18. Bxc4 Bd5 19. Bxd5 exd5 20. Rdc1 Rb8 21.
+b3 Nxe5 22. fxe5 f4 23. Rc5 Qg5 24. Rxd5 f3 25. Qg3 Qd2 26. Rd7 g6 27. Qh3 h6
+28. Qe6+ Kh8 29. Qxg6 Qxf2+ 30. Kxf2 fxg2+ 31. Kxg2 Rg8 32. Rh7# 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "camilomunoz0107"]
+[Black "alirezafirulais"]
+[Result "1-0"]
+[ECO "E06"]
+[WhiteElo "2343"]
+[BlackElo "2361"]
+[PlyCount "117"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 Nf6 2. Nf3 e6 3. c4 d5 4. g3 Be7 5. Bg2 O-O 6. O-O c6 7. b3 b6 8. Bb2 Bb7
+9. Nbd2 Nbd7 10. Qc2 Rc8 11. e4 dxe4 12. Nxe4 Nxe4 13. Qxe4 Nf6 14. Qe2 c5 15.
+dxc5 Bxc5 16. Rad1 Qe7 17. Rfe1 Bb4 18. Rf1 Rfd8 19. Ne5 Bxg2 20. Kxg2 h6 21.
+Qf3 Qc7 22. a3 Bd6 23. Ng4 Nxg4 24. Qxg4 Bf8 25. Qe4 a5 26. a4 Rxd1 27. Rxd1
+Rd8 28. Rxd8 Qxd8 29. Qd4 Qc7 30. f3 f6 31. h4 Bd6 32. f4 Qc6+ 33. Kh2 Bc5 34.
+Qd8+ Kh7 35. Qd3+ Kg8 36. Qd8+ Kf7 37. Qd3 h5 38. Qe2 Kg6 39. Qd3+ Kf7 40. Qe2
+Kg6 41. Bc3 Qd7 42. Qc2+ Kf7 43. Qe2 Qd6 44. Qxh5+ Kg8 45. Qe8+ Kh7 46. Qh5+
+Kg8 47. Qe2 Qd7 48. h5 Qf7 49. Kg2 Kh7 50. g4 Qb7+ 51. Qf3 Qd7 52. g5 fxg5 53.
+fxg5 e5 54. Bxe5 Qd2+ 55. Kh3 Qxg5 56. Bg3 Be7 57. Qe4+ Kg8 58. Qg6 Qe3 59.
+Qe8+ 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Al_Shima"]
+[Black "Glig"]
+[Result "1-0"]
+[ECO "A01"]
+[WhiteElo "2496"]
+[BlackElo "2459"]
+[PlyCount "113"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. b3 d5 2. Bb2 Bg4 3. h3 Bh5 4. g4 Bg6 5. Bg2 e6 6. c4 c6 7. d3 Nd7 8. Nd2 h5
+9. Ngf3 a5 10. g5 Ne7 11. h4 Nf5 12. e4 Nd6 13. cxd5 cxd5 14. Qe2 Nc5 15. Ne5
+Bh7 16. exd5 Nf5 17. g6 Bxg6 18. Nxg6 fxg6 19. d4 Nxh4 20. Rxh4 Qxh4 21. dxc5
+Bxc5 22. dxe6 Bb4 23. a3 Bxd2+ 24. Qxd2 O-O 25. Qd4 Qe7 26. Bd5 Rfd8 27. O-O-O
+Ra6 28. Qe5 Rad6 29. Bf3 Kh7 30. Rxd6 Rxd6 31. Bd5 Rd8 32. Bc4 b6 33. Kb1 Rf8
+34. Ka2 Rf5 35. Qe2 a4 36. bxa4 Rf4 37. Bd3 Rg4 38. f3 Rxa4 39. Bc2 Rh4 40. Bb3
+Rh1 41. Qd2 Rh4 42. Qe1 Rf4 43. Qe3 Rf5 44. Qxb6 Rxf3 45. Qb4 Qe8 46. e7 Re3
+47. Qd4 Rxe7 48. Bc2 Qf7+ 49. Bb3 Qe8 50. Qc3 Rd7 51. Qb4 Qe7 52. Qxe7 Rxe7 53.
+Bc3 h4 54. Bb2 h3 55. Bd5 Re2 56. Bc6 Rxb2+ 57. Kxb2 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Odirovski"]
+[Black "Brocha"]
+[Result "1-0"]
+[ECO "D02"]
+[WhiteElo "2448"]
+[BlackElo "2456"]
+[PlyCount "123"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. Nf3 Nf6 2. d4 d5 3. Bf4 e6 4. e3 Bd6 5. Bg3 O-O 6. Nbd2 Ne4 7. Nxe4 dxe4 8.
+Nd2 f5 9. Nc4 Nc6 10. c3 Kh8 11. a4 b6 12. d5 Bxg3 13. dxc6 Bd6 14. a5 bxa5 15.
+g3 Ba6 16. Rxa5 Bxc4 17. Bxc4 Qe7 18. Qb3 e5 19. Bd5 f4 20. Bxe4 fxe3 21. fxe3
+Qg5 22. Ke2 Qg4+ 23. Kd3 Rf2 24. Qd1 Qxd1+ 25. Rxd1 Rxb2 26. h4 g6 27. Rda1 Kg7
+28. Rxa7 Rxa7 29. Rxa7 Rb1 30. Ra8 Rg1 31. Rd8 Kf6 32. g4 Ke6 33. g5 Rg4 34.
+Re8+ Kf7 35. Rd8 Ke6 36. Re8+ Kf7 37. Rh8 Rxh4 38. Bd5+ Ke7 39. Rg8 Rh5 40.
+Rg7+ Kf8 41. Rd7 Ke8 42. Bf7+ Kf8 43. Rxd6 Kxf7 44. Rd7+ Ke6 45. Rxc7 Kd6 46.
+Rg7 Kxc6 47. Ke4 Rxg5 48. Rxh7 Kd6 49. Rh4 Rf5 50. c4 Rg5 51. Rg4 Kc5 52. Rxg5
+Kxc4 53. Rxe5 Kc3 54. Rg5 Kd2 55. Rxg6 Kc3 56. Rg3 Kb3 57. Kf4 Kb4 58. e4 Kc4
+59. e5 Kc5 60. Kf5 Kc6 61. Re3 Kd7 62. e6+ 1-0
+
+[Event "Rated Blitz tournament hM7PUvgg"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "CarlsenCamacho"]
+[Black "Pomberito"]
+[Result "0-1"]
+[ECO "C57"]
+[WhiteElo "2311"]
+[BlackElo "2332"]
+[PlyCount "62"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 e5 2. Nf3 Nc6 3. Bc4 Nf6 4. Ng5 d5 5. exd5 Nd4 6. c3 b5 7. Bf1 Nxd5 8.
+cxd4 Qxg5 9. Bxb5+ Kd8 10. O-O Bb7 11. Qf3 Rb8 12. d3 Nf4 13. Bxf4 exf4 14. d5
+Bxd5 15. Qh3 Rxb5 16. Nc3 Be6 17. Qf3 Rb8 18. d4 Bd6 19. h3 Re8 20. Rac1 Ke7
+21. d5 Bf5 22. Ne4 Bxe4 23. Qxe4+ Kf8 24. Qxh7 f3 25. g3 Bxg3 26. Qh8+ Ke7 27.
+Rfe1+ Kd7 28. Rxe8 Bd6+ 29. Kf1 Qxc1+ 30. Re1 Qc4+ 31. Kg1 Rxh8 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "PimponNicois"]
+[Black "fedateam"]
+[Result "1-0"]
+[ECO "B21"]
+[WhiteElo "2330"]
+[BlackElo "2351"]
+[PlyCount "81"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 c5 2. Nf3 a6 3. d4 cxd4 4. c3 dxc3 5. Nxc3 Nc6 6. Bc4 e6 7. O-O b5 8. Bb3
+d6 9. Qe2 Qc7 10. Bf4 Nf6 11. Rac1 Bd7 12. Nd5 Qb8 13. Nxf6+ gxf6 14. Rfd1 h5
+15. Qd2 e5 16. Be3 Nd8 17. Bd5 Rg8 18. Nh4 Be6 19. Bxa8 Qxa8 20. f3 Be7 21. a4
+Qb7 22. axb5 axb5 23. Qa5 Nc6 24. Qc3 Nd4 25. Bxd4 exd4 26. Qxd4 Rg5 27. Re1
+Kf8 28. Kh1 Rc5 29. Nf5 Qc6 30. Rcd1 Bxf5 31. exf5 Rxf5 32. Qe3 Re5 33. Qh6+
+Kg8 34. Rxe5 dxe5 35. Qxh5 Qc2 36. Qg4+ Kf8 37. Qd7 Qxb2 38. h4 Qe2 39. Qd2 Qc4
+40. g3 Qe6 41. Kg2 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "BlueGreensun"]
+[Black "Kidefence"]
+[Result "0-1"]
+[ECO "B02"]
+[WhiteElo "2744"]
+[BlackElo "2722"]
+[PlyCount "152"]
+[EventDate "2020.??.??"]
+
+1. e4 Nf6 2. e5 Nd5 3. Nc3 Nxc3 4. dxc3 d6 5. Nf3 Nc6 6. Bb5 g6 7. exd6 cxd6 8.
+Nd4 Bd7 9. Qf3 Bg7 10. Nxc6 bxc6 11. Bxc6 Rb8 12. Bxd7+ Qxd7 13. O-O O-O 14.
+Re1 e6 15. b3 Rfc8 16. Bd2 Qc6 17. Qxc6 Rxc6 18. Rad1 Bxc3 19. Bxc3 Rxc3 20.
+Rxd6 Rxc2 21. Ra6 Rb7 22. h4 Rd7 23. Re3 Rdd2 24. Rf3 Rxa2 25. Rc6 Rd7 26. b4
+h5 27. b5 Ra5 28. Rb3 Rb7 29. Rc5 Kg7 30. Kh2 Rb6 31. Rb4 a6 32. bxa6 Rbxa6 33.
+Rc7 Rf5 34. Rb2 Ra4 35. g3 g5 36. Kg2 gxh4 37. gxh4 Rxh4 38. Rb3 Rg4+ 39. Kf1
+Rgf4 40. Rg3+ Kf6 41. Rc2 h4 42. Rgc3 Rf3 43. Rc4 h3 44. Rh4 Kg5 45. Rh8 Kf6
+46. Rh6+ Kg7 47. Rh4 e5 48. Rg4+ Kf6 49. Rh4 R5f4 50. Rh6+ Kf5 51. Kg1 f6 52.
+Rh5+ Kg6 53. Rh8 Rg4+ 54. Kf1 Rg2 55. Rxh3 Rgxf2+ 56. Rxf2 Rxh3 57. Rg2+ Kf5
+58. Rg8 Rh4 59. Ra8 Rf4+ 60. Ke2 Rd4 61. Ke3 Rh4 62. Kf3 Rh3+ 63. Ke2 Rb3 64.
+Kf2 Kf4 65. Ra4+ e4 66. Rb4 Rxb4 67. Ke2 Rb3 68. Kd2 Rd3+ 69. Kc2 Ke5 70. Kc1
+f5 71. Kc2 f4 72. Kb2 f3 73. Kc2 f2 74. Kc1 f1=Q+ 75. Kc2 Qe2+ 76. Kc1 Rd1# 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "InsaneTryhard"]
+[Black "Analitik33"]
+[Result "0-1"]
+[ECO "B21"]
+[WhiteElo "2378"]
+[BlackElo "2386"]
+[PlyCount "88"]
+[EventDate "2020.??.??"]
+
+1. e4 c5 2. d4 d6 3. c3 Nf6 4. Bd3 e5 5. d5 Nbd7 6. c4 g6 7. Nc3 Bg7 8. Nge2
+O-O 9. O-O Nh5 10. h3 f5 11. exf5 gxf5 12. Ng3 Nxg3 13. fxg3 e4 14. Bc2 Ne5 15.
+Qe2 Bd7 16. Bf4 Qe7 17. Rae1 Rae8 18. Kh1 a6 19. a3 Ng6 20. Be3 b5 21. cxb5
+axb5 22. b4 Bxc3 23. Rb1 c4 24. a4 Bg7 25. a5 Ne5 26. a6 Ra8 27. a7 Ng6 28. Ra1
+Bxa1 29. Rxa1 Qe5 30. Ra6 Qxg3 31. Bd4 Nf4 32. Qf1 Nd3 33. Bxd3 cxd3 34. Qd1 f4
+35. Rxd6 f3 36. gxf3 Qxh3+ 37. Kg1 Qg3+ 38. Kh1 Qxd6 39. Qg1+ Qg6 40. Qxg6+
+hxg6 41. f4 Rxf4 42. Kg2 Rf3 43. Kh2 Rf5 44. d6 Rd5 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Northridgehawk"]
+[Black "zenon011"]
+[Result "1-0"]
+[ECO "C25"]
+[WhiteElo "2368"]
+[BlackElo "2326"]
+[PlyCount "33"]
+[EventDate "2020.??.??"]
+
+1. e4 e5 2. Nc3 Nc6 3. Bc4 d6 4. d3 Nf6 5. f4 exf4 6. Nf3 Be7 7. Bxf4 O-O 8.
+Bb3 Be6 9. O-O Bxb3 10. axb3 Nd7 11. d4 Bf6 12. Nd5 Kh8 13. c3 Re8 14. Qd3 Be7
+15. Be3 Bf8 16. Ng5 f6 17. Nf7+ 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "sutcunuri"]
+[Black "ajedrez2021"]
+[Result "0-1"]
+[ECO "B06"]
+[WhiteElo "2528"]
+[BlackElo "2584"]
+[PlyCount "96"]
+[EventDate "2020.??.??"]
+
+1. e4 g6 2. d4 Bg7 3. h4 c5 4. c3 cxd4 5. cxd4 d5 6. e5 Nc6 7. h5 Qb6 8. Nc3
+Qxd4 9. Qxd4 Nxd4 10. Nxd5 Nc2+ 11. Kd1 Nxa1 12. Nc7+ Kd8 13. Nxa8 Bxe5 14. Nf3
+Bg4 15. hxg6 hxg6 16. Rxh8 Bxh8 17. b3 Kc8 18. Bc4 e6 19. Bf4 e5 20. Be3 e4 21.
+Bxa7 exf3 22. gxf3 Be6 23. Nb6+ Kc7 24. Nd5+ Kc6 25. Ne3 Ne7 26. Bb8 Nf5 27.
+Bxe6 fxe6 28. Nc4 b5 29. Bf4 bxc4 30. bxc4 Kc5 31. Kc1 Kxc4 32. Kb1 Nd4 33. Bc1
+Ne2 34. Bb2 Nc3+ 35. Kxa1 Kd3 36. Bxc3 Bxc3+ 37. Kb1 e5 38. a4 Ke2 39. a5 Kxf3
+40. a6 Bd4 41. Kc2 Ba7 42. Kd3 e4+ 43. Kc4 e3 44. Kd5 exf2 45. Kc6 f1=Q 46. Kb7
+Qd3 47. Kxa7 Qd6 48. Ka8 Qc6+ 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "emiliofelixramirez"]
+[Black "MonsieurPatate"]
+[Result "1-0"]
+[ECO "C50"]
+[WhiteElo "2396"]
+[BlackElo "2390"]
+[PlyCount "47"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 e5 2. Nf3 Nc6 3. Bc4 Bc5 4. d3 Nf6 5. Nc3 d6 6. a3 a6 7. Be3 Bxe3 8. fxe3
+O-O 9. O-O d5 10. exd5 Nxd5 11. Qe1 Nxc3 12. Qxc3 Qe7 13. d4 exd4 14. exd4 Qd6
+15. Rad1 Bg4 16. h3 Bh5 17. d5 Rad8 18. dxc6 Qxd1 19. Rxd1 Rxd1+ 20. Kh2 bxc6
+21. Ne5 Rfd8 22. Bd3 Bg6 23. Nxg6 hxg6 24. Qxc6 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "FedaMaster"]
+[Black "Heisenberg01"]
+[Result "0-1"]
+[ECO "B06"]
+[WhiteElo "2577"]
+[BlackElo "2677"]
+[PlyCount "28"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 g6 2. d4 Bg7 3. Nc3 c6 4. Nf3 d5 5. h3 dxe4 6. Nxe4 Nf6 7. Nxf6+ exf6 8.
+Qe2+ Be6 9. Be3 O-O 10. O-O-O Bxa2 11. b3 a5 12. Kb2 a4 13. Kxa2 axb3+ 14. Kxb3
+Qb6+ 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "gmmitkov"]
+[Black "Abouyahya1983"]
+[Result "0-1"]
+[ECO "B25"]
+[WhiteElo "2500"]
+[BlackElo "2558"]
+[PlyCount "90"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 c5 2. Nc3 Nc6 3. Bb5 Nd4 4. Nf3 e6 5. O-O a6 6. Bd3 Ne7 7. Nxd4 cxd4 8.
+Ne2 Nc6 9. c3 Bc5 10. b4 Ba7 11. cxd4 Nxb4 12. Bc4 b5 13. Bb3 a5 14. a4 Ba6 15.
+Ba3 O-O 16. Bxb4 axb4 17. a5 Bb7 18. a6 Bxe4 19. d3 Bc6 20. d5 exd5 21. d4 Qf6
+22. Qd2 Rfe8 23. Rfe1 Re4 24. Rad1 Bb6 25. f3 Ree8 26. Ra1 h5 27. Kf1 h4 28. h3
+Qd6 29. Qg5 Bd8 30. Qd2 Qh2 31. Kf2 Bc7 32. Qg5 Re6 33. Qxh4 Rae8 34. Ra2 Rg6
+35. Rg1 Bb6 36. a7 Ba8 37. Bc2 Rge6 38. Bd3 g6 39. Qh6 Rxe2+ 40. Rxe2 Bxd4+ 41.
+Ke1 Qxg1+ 42. Kd2 Bc3+ 43. Kc2 Re7 44. Bxg6 Rxe2+ 45. Kd3 Rd2+ 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "RigelStar"]
+[Black "FinalCut"]
+[Result "1-0"]
+[ECO "A01"]
+[WhiteElo "2407"]
+[BlackElo "2451"]
+[PlyCount "89"]
+[EventDate "2020.??.??"]
+
+1. b3 c5 2. Bb2 b6 3. f3 Bb7 4. g3 Nf6 5. Bg2 d5 6. d3 d4 7. e3 dxe3 8. Qe2 Nc6
+9. Qxe3 Nd4 10. Na3 e6 11. O-O-O Rc8 12. Ne2 Nf5 13. Qf2 Be7 14. h3 a6 15. f4
+Bxg2 16. Qxg2 b5 17. g4 Nd4 18. Nb1 O-O 19. Nd2 Nxe2+ 20. Qxe2 Qa5 21. Kb1 Rfd8
+22. Ne4 Nxe4 23. Qxe4 Rd5 24. f5 Qb6 25. Rhe1 Rc6 26. Qf4 Bf8 27. f6 g6 28. Qh2
+h5 29. gxh5 Rxh5 30. Qg2 c4 31. dxc4 bxc4 32. Qf3 Qc5 33. Re3 Rf5 34. Qe2 Bh6
+35. Rc3 Bg5 36. Rxc4 Qb6 37. Rxc6 Qxc6 38. Rd8+ Kh7 39. Qd1 Bxf6 40. Bxf6 Rxf6
+41. Rb8 Qc5 42. Qd8 Rf1+ 43. Kb2 Qe5+ 44. Ka3 Qc5+ 45. b4 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "hungzhao"]
+[Black "chesslismab"]
+[Result "1-0"]
+[ECO "C45"]
+[WhiteElo "2619"]
+[BlackElo "2455"]
+[PlyCount "91"]
+[EventDate "2020.??.??"]
+
+1. e4 e5 2. Nf3 Nc6 3. d4 exd4 4. Nxd4 Bc5 5. Nb3 Bb6 6. Qe2 Nge7 7. Be3 d6 8.
+Nc3 O-O 9. O-O-O Be6 10. f3 Bxb3 11. cxb3 Kh8 12. g4 f6 13. h4 a5 14. Kb1 Bxe3
+15. Qxe3 Ne5 16. Be2 c6 17. f4 Nf7 18. g5 f5 19. h5 fxe4 20. Nxe4 Nd5 21. Qg3
+a4 22. g6 Nh6 23. Bc4 axb3 24. Bxb3 Nxf4 25. Ng5 d5 26. Nxh7 Rf5 27. Rhf1 Qd6
+28. Qc3 Ne2 29. Qd2 Re5 30. Ng5 Rae8 31. Nf7+ Nxf7 32. gxf7 Rf8 33. Rde1 Qh6
+34. Rxe2 Qxd2 35. Rxd2 Rxh5 36. Rdf2 Rh6 37. Bc2 g6 38. Rf6 Kg7 39. b4 Rh4 40.
+Rxg6+ Kh8 41. a3 Rh7 42. Rgf6 Rg7 43. R6f2 Rh7 44. Bxh7 Kxh7 45. Rg2 Rxf7 46.
+Rh1# 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Paanoos"]
+[Black "rudolf85"]
+[Result "0-1"]
+[ECO "B01"]
+[WhiteElo "2375"]
+[BlackElo "2427"]
+[PlyCount "130"]
+[EventDate "2020.??.??"]
+
+1. e4 d5 2. Nc3 dxe4 3. Nxe4 Nf6 4. Qe2 e6 5. Nxf6+ Qxf6 6. Nf3 Qd8 7. d4 Nd7
+8. c3 Nf6 9. g3 Be7 10. Bg2 c5 11. O-O cxd4 12. Nxd4 Qb6 13. Rd1 O-O 14. Be3
+Qa5 15. Nb3 Qc7 16. Bf4 Qb6 17. Rd2 a5 18. Rad1 a4 19. Nd4 a3 20. b3 Qc5 21. c4
+Qb6 22. Nb5 Bb4 23. Be3 Qa5 24. Rd4 Ra6 25. Rh4 Bd7 26. Rxd7 Nxd7 27. Qd3 Nf6
+28. Bd4 Rd8 29. Qe3 Rxd4 30. Qxd4 Ra8 31. Bxb7 Rd8 32. Qe5 Qb6 33. Be4 Bc5 34.
+Qf4 Nxe4 35. Qxe4 Bxf2+ 36. Kg2 Bc5 37. Qxh7+ Kf8 38. Qh8+ Ke7 39. Qxg7 Bd4 40.
+Qg5+ Bf6 41. Qf4 Qc6+ 42. Kh3 Rh8 43. Rxh8 Bxh8 44. Qe4 Qxe4 45. Nd4 Qh7+ 46.
+Kg2 Bxd4 47. Kf3 Qc2 48. h4 Qxa2 49. Kg4 Qxb3 50. Kh3 a2 51. h5 a1=Q 52. Kh4
+Qxg3+ 53. Kxg3 Bh8 54. Kg4 Qc3 55. h6 Qxc4+ 56. Kh5 Qd5+ 57. Kh4 Qe5 58. Kh3
+Qf6 59. h7 Qg6 60. Kh2 Qxh7+ 61. Kg1 Qg7+ 62. Kf1 Qg6 63. Ke1 Qf6 64. Kd1 Qf5
+65. Kc1 Qe5 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "alireza3700"]
+[Black "Aisen_Mestnikov"]
+[Result "0-1"]
+[ECO "D00"]
+[WhiteElo "2364"]
+[BlackElo "2366"]
+[PlyCount "72"]
+[EventDate "2020.??.??"]
+
+1. d4 d5 2. Nc3 c6 3. Bg5 f6 4. f3 fxg5 5. e4 dxe4 6. fxe4 e5 7. Nf3 exd4 8.
+Nxd4 Nf6 9. Bc4 Bc5 10. Nf5 Qxd1+ 11. Rxd1 Bxf5 12. exf5 Nbd7 13. Be6 O-O-O 14.
+Ke2 Rhe8 15. Rhe1 Kc7 16. Kf1 Nf8 17. Rxd8 Kxd8 18. a3 Nxe6 19. fxe6 Ng4 20.
+Ne4 Bb6 21. Rd1+ Kc7 22. Rd7+ Kb8 23. Rxg7 Nxh2+ 24. Ke2 Rxe6 25. Kd3 Ng4 26.
+Rg8+ Kc7 27. Rxg5 Ne5+ 28. Kc3 Nf7 29. Rg7 Rxe4 30. Rxf7+ Kd6 31. Rxh7 Rg4 32.
+Rxb7 Rxg2 33. b3 Rg3+ 34. Kb2 Bd4+ 35. Ka2 Rg1 36. a4 Ra1# 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "HustlersCorner"]
+[Black "kingcobra23"]
+[Result "0-1"]
+[ECO "A02"]
+[WhiteElo "2342"]
+[BlackElo "2317"]
+[PlyCount "74"]
+[EventDate "2020.??.??"]
+
+1. f4 e5 2. fxe5 d6 3. Nf3 dxe5 4. e4 Bd6 5. Bc4 Nc6 6. O-O Nf6 7. d3 O-O 8.
+Nc3 h6 9. Qe1 Na5 10. Qh4 Nxc4 11. dxc4 Bc5+ 12. Kh1 Ng4 13. Qg3 Be6 14. h3 Ne3
+15. Bxe3 Bxe3 16. Nxe5 Qg5 17. Qxg5 Bxg5 18. Nd5 Rac8 19. Nf3 c6 20. Nxg5 hxg5
+21. Ne3 Rfd8 22. Rad1 Kf8 23. b3 Ke7 24. g4 f6 25. Kg2 Bf7 26. Kf3 g6 27. Rxd8
+Rxd8 28. Rd1 Rc8 29. c5 a5 30. a4 Rb8 31. Rd6 Rh8 32. Kg3 Re8 33. Kf3 Be6 34.
+Nc4 Kf7 35. e5 Bc8 36. Rxf6+ Kg7 37. Ke4 Rf8 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Sherlock90"]
+[Black "lucrecio777"]
+[Result "0-1"]
+[ECO "C53"]
+[WhiteElo "2302"]
+[BlackElo "2404"]
+[PlyCount "96"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 e5 2. Nf3 Nc6 3. Bc4 Bc5 4. c3 Nf6 5. d3 d6 6. Bb3 O-O 7. Qe2 a5 8. h3 h6
+9. Nbd2 Re8 10. Nf1 d5 11. g4 d4 12. Ng3 b5 13. Nf5 dxc3 14. bxc3 b4 15. g5
+hxg5 16. Nxg5 Rf8 17. O-O Bxf5 18. exf5 bxc3 19. Be3 Nd4 20. Bxd4 Qxd4 21. Ne4
+Be7 22. Kh1 Rad8 23. Bc4 Nxe4 24. dxe4 Qd2 25. Qg4 Bf6 26. Rg1 Qf4 27. f3 Qxg4
+28. Rxg4 c2 29. Rgg1 Rd2 30. Rac1 a4 31. Rg2 Rd1+ 32. Rg1 Rd2 33. Bd5 Rb8 34.
+Rge1 Rb2 35. Kg1 Kf8 36. Kf1 Ke7 37. Re2 Rxe2 38. Kxe2 Bg5 39. Rxc2 Rxc2+ 40.
+Kf1 Rb2 41. Kg1 a3 42. Kf1 Bf4 43. Ke1 c5 44. Kd1 c4 45. Ke1 c3 46. Kf1 c2 47.
+Bb3 c1=Q+ 48. Bd1 Qxd1# 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "awisepawn"]
+[Black "Zobbie"]
+[Result "1-0"]
+[ECO "B13"]
+[WhiteElo "2391"]
+[BlackElo "2358"]
+[PlyCount "99"]
+[EventDate "2020.??.??"]
+
+1. e4 c6 2. d4 d5 3. exd5 cxd5 4. Bd3 Nf6 5. c3 a6 6. Nf3 Nc6 7. Bf4 Bg4 8. O-O
+Bh5 9. h3 e6 10. Nbd2 Bg6 11. Qe2 Be7 12. Ne5 Nxe5 13. Bxe5 O-O 14. Bxg6 hxg6
+15. a4 Rc8 16. a5 Nd7 17. Nb3 Nxe5 18. Qxe5 Qc7 19. Qxc7 Rxc7 20. Rfc1 Rfc8 21.
+Kf1 Bd6 22. Ke2 Kf8 23. Kd3 Ke7 24. Nd2 Kd7 25. b3 Bf4 26. Rc2 Rc6 27. g3 Bg5
+28. h4 Bf6 29. c4 e5 30. dxe5 Bxe5 31. Rac1 dxc4+ 32. Rxc4 Rxc4 33. Rxc4 Rxc4
+34. Nxc4 Bc7 35. Ke4 Kc6 36. Kd4 Kb5 37. Kd5 Bxa5 38. Nd6+ Kb4 39. Nxb7 Bb6 40.
+Nc5 Bxc5 41. f4 Be3 42. g4 Bxf4 43. h5 gxh5 44. gxh5 Bh6 45. Kc6 a5 46. Kb6 Bd2
+47. Ka6 Kxb3 48. Kb5 a4 49. Kc5 a3 50. Kd6 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "ROBESPIERR"]
+[Black "LordBendtner99"]
+[Result "1-0"]
+[ECO "A04"]
+[WhiteElo "2536"]
+[BlackElo "2476"]
+[PlyCount "118"]
+[EventDate "2020.??.??"]
+
+1. Nf3 g6 2. g3 f6 3. Bg2 Nh6 4. O-O Nf7 5. d4 Bg7 6. c4 O-O 7. Nc3 d6 8. e4 e5
+9. d5 Nd7 10. Ne1 a5 11. Nd3 Nc5 12. Nxc5 dxc5 13. f4 exf4 14. Bxf4 f5 15. Qc2
+Bd4+ 16. Kh1 a4 17. Rae1 fxe4 18. Nxe4 Nd6 19. Nxd6 cxd6 20. Bh6 Bf5 21. Be4
+Bxe4+ 22. Qxe4 Rxf1+ 23. Rxf1 Qe8 24. Rf8+ Qxf8 25. Bxf8 Rxf8 26. Qe6+ Kg7 27.
+Qxd6 Rf1+ 28. Kg2 Rf2+ 29. Kh3 Rxb2 30. Qd7+ Kh6 31. Qxa4 Bg1 32. Kg4 Bxh2 33.
+Qd1 Rb4 34. Qc1+ Kg7 35. a3 Rb6 36. Qh1 Bxg3 37. Kxg3 Rb3+ 38. Kf4 Rxa3 39. Ke5
+Re3+ 40. Kd6 Rf3 41. Qa1+ Kf7 42. Kxc5 Rf6 43. d6 h5 44. d7 Ke7 45. Qxf6+ Kxf6
+46. d8=Q+ Kf5 47. Qb6 Kg4 48. Qxb7 g5 49. Qe4+ Kh3 50. Kd4 g4 51. Qe3+ g3 52.
+Qg5 Kh2 53. Qxh5+ Kg1 54. c5 g2 55. Qe2 Kh1 56. Qxg2+ Kxg2 57. c6 Kf3 58. c7
+Ke2 59. c8=Q Kd1 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "estocastico"]
+[Black "WildBreath"]
+[Result "1-0"]
+[ECO "C72"]
+[WhiteElo "2590"]
+[BlackElo "2432"]
+[PlyCount "81"]
+[EventDate "2020.??.??"]
+
+1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 d6 5. O-O Nge7 6. c4 g6 7. d4 Bg7 8. d5 b5
+9. cxb5 Nd4 10. bxa6+ Bd7 11. Nxd4 exd4 12. Bxd7+ Qxd7 13. Nd2 O-O 14. Nf3 c5
+15. dxc6 Nxc6 16. b3 Rxa6 17. Bb2 Rfa8 18. Nxd4 Nxd4 19. Bxd4 Bxd4 20. Qxd4
+Rxa2 21. Rxa2 Rxa2 22. Ra1 Rxa1+ 23. Qxa1 Qb7 24. Qb1 Qb4 25. g3 h5 26. h4 Kg7
+27. Kg2 Kg8 28. Qd3 Kg7 29. Qc4 Qd2 30. b4 Kf6 31. b5 Qb2 32. Qd5 Ke7 33. Qc6
+f5 34. exf5 gxf5 35. b6 Kf6 36. b7 Ke5 37. Qc7 Qb1 38. b8=Q Qe4+ 39. Kh2 Qf3
+40. Qxd6+ Ke4 41. Qbb4# 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "zaqvili"]
+[Black "Obito2016"]
+[Result "1-0"]
+[ECO "A69"]
+[WhiteElo "2315"]
+[BlackElo "2332"]
+[PlyCount "47"]
+[EventDate "2020.??.??"]
+
+1. d4 Nf6 2. c4 g6 3. Nc3 Bg7 4. e4 d6 5. f4 O-O 6. Nf3 c5 7. d5 e6 8. Be2 exd5
+9. cxd5 Re8 10. e5 dxe5 11. fxe5 Ng4 12. Bg5 f6 13. exf6 Bxf6 14. Qd2 Na6 15.
+O-O Bxg5 16. Nxg5 Nb4 17. Ne6 Bxe6 18. Qf4 Bf5 19. Bxg4 Bxg4 20. Qxg4 Nxd5 21.
+Qc4 Qg5 22. Qxd5+ Qxd5 23. Nxd5 Re7 24. Nxe7+ 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Antropterix"]
+[Black "Realblindmuddy"]
+[Result "0-1"]
+[ECO "B22"]
+[WhiteElo "2313"]
+[BlackElo "2396"]
+[PlyCount "58"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. c3 c5 2. e4 Nf6 3. d3 d5 4. Nd2 Nc6 5. Ngf3 e5 6. g3 d4 7. Nc4 Qc7 8. cxd4
+cxd4 9. Bg5 Bb4+ 10. Bd2 Bxd2+ 11. Qxd2 b5 12. Na3 a6 13. Rc1 Bd7 14. Qg5 O-O
+15. h4 h6 16. Qd2 Qd6 17. Bh3 Bxh3 18. Rxh3 Nb4 19. Nxe5 Nxa2 20. Ra1 Nc3 21.
+bxc3 Qxe5 22. c4 Rfb8 23. Rb1 bxc4 24. Rxb8+ Rxb8 25. Nxc4 Qe6 26. Rh2 Rb1+ 27.
+Ke2 Qg4+ 28. f3 Qxg3 29. Rf2 Nh5 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "APele"]
+[Black "BerserkAdopter"]
+[Result "1-0"]
+[ECO "B01"]
+[WhiteElo "2475"]
+[BlackElo "2438"]
+[PlyCount "91"]
+[EventDate "2020.??.??"]
+
+1. e4 d5 2. exd5 Qxd5 3. d4 Qd8 4. c4 Bf5 5. Nc3 e6 6. Qb3 Qc8 7. Nf3 Nf6 8.
+Bf4 c5 9. d5 Be7 10. Nb5 O-O 11. Nc7 exd5 12. cxd5 Nbd7 13. Nxa8 Qxa8 14. Bd3
+Bg4 15. O-O b6 16. d6 Bd8 17. Ne5 Nxe5 18. Bxe5 Nd7 19. Bg3 Bf6 20. Rfe1 Be6
+21. Bc4 Bf5 22. Bd5 Qc8 23. Rad1 h6 24. h3 a5 25. Qb5 Rd8 26. Bc6 Nf8 27. Qxb6
+a4 28. Qxc5 Bd7 29. Rc1 Bxc6 30. Qxc6 Qd7 31. Qxd7 Nxd7 32. b3 Kh7 33. bxa4 Ra8
+34. Rc7 Rd8 35. a5 Kg6 36. a6 Nb6 37. a7 Bd4 38. Rb7 Na8 39. Rb8 Rd7 40. Rxa8
+Bxa7 41. Rxa7 Rxa7 42. Be5 Ra8 43. Bf4 Rd8 44. Be3 Rd7 45. Rd1 Rd8 46. Re1 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Atom5"]
+[Black "barnaul_chess"]
+[Result "0-1"]
+[ECO "D00"]
+[WhiteElo "2305"]
+[BlackElo "2327"]
+[PlyCount "64"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 d5 2. Bf4 c6 3. e3 Nf6 4. Bd3 Bg4 5. Nf3 e6 6. Nbd2 Bd6 7. h3 Bxf3 8.
+Qxf3 Bxf4 9. exf4 O-O 10. g4 Re8 11. g5 Nfd7 12. Rg1 c5 13. c3 cxd4 14. cxd4
+Nc6 15. Nb3 Qb6 16. O-O-O Na5 17. Nxa5 Qxa5 18. Kb1 Rab8 19. Rg4 Rbc8 20. Rh4
+g6 21. Rg4 Rc7 22. h4 Rec8 23. h5 Qb4 24. hxg6 fxg6 25. Rh4 Nf8 26. Qe2 Qd6 27.
+Rdh1 Rf7 28. a3 Rxf4 29. Rxf4 Qxf4 30. Rxh7 Kxh7 31. Qh5+ Kg7 32. Qh6+ Kf7 0-1
+
+[Event "Rated Blitz tournament hM7PUvgg"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "hectordetroya"]
+[Black "Fasmc17"]
+[Result "1-0"]
+[ECO "C00"]
+[WhiteElo "2398"]
+[BlackElo "2338"]
+[PlyCount "25"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 e6 2. Nf3 d5 3. exd5 e5 4. d4 e4 5. Qe2 Qxd5 6. Nc3 Bb4 7. Bd2 Bxc3 8.
+Bxc3 Ne7 9. Nd2 f5 10. f3 O-O 11. fxe4 fxe4 12. Qxe4 Qf7 13. Bc4 1-0
+
+[Event "Rated Blitz tournament hM7PUvgg"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "RCSA007"]
+[Black "lama17"]
+[Result "0-1"]
+[ECO "A41"]
+[WhiteElo "2432"]
+[BlackElo "2324"]
+[PlyCount "150"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. c4 g6 2. Nc3 Bg7 3. d4 d6 4. e4 Nd7 5. f4 e5 6. fxe5 dxe5 7. d5 Ne7 8. Nf3
+O-O 9. Be3 f5 10. Ng5 Nf6 11. Be2 h6 12. Nf3 Ng4 13. Bd2 fxe4 14. Nxe4 Nf5 15.
+Qc1 Nd6 16. Nxd6 cxd6 17. h3 Nf6 18. Bxh6 Ne4 19. Bxg7 Kxg7 20. O-O Qb6+ 21.
+Kh2 Bf5 22. Bd3 Rh8 23. Bxe4 Bxe4 24. Ng5 Bf5 25. Ne6+ Bxe6 26. dxe6 Rhf8 27.
+Qg5 Rae8 28. e7 Rf4 29. Rxf4 exf4 30. Rf1 Qe3 31. Rxf4 Qxe7 32. Qxe7+ Rxe7 33.
+Rd4 Re6 34. b4 Kf6 35. Rd5 Ke7 36. Rd4 Re2 37. a4 Rb2 38. c5 dxc5 39. bxc5 a5
+40. Rd6 Rb4 41. Rxg6 Rxa4 42. Rb6 Rb4 43. Rh6 a4 44. c6 a3 45. cxb7 a2 46. Ra6
+Rxb7 47. Rxa2 Kf6 48. Ra5 Kg6 49. h4 Re7 50. Kh3 Re4 51. g3 Kf6 52. h5 Kg7 53.
+g4 Kh6 54. Kh4 Re1 55. Ra6+ Kg7 56. h6+ Kh7 57. Kh5 Rh1+ 58. Kg5 Rc1 59. Ra7+
+Kg8 60. Kh5 Rc5+ 61. g5 Rc1 62. g6 Rh1+ 63. Kg5 Rg1+ 64. Kf5 Rf1+ 65. Ke4 Re1+
+66. Kf3 Rf1+ 67. Ke2 Rf8 68. Re7 Ra8 69. Ke3 Ra3+ 70. Kf4 Ra4+ 71. Kf5 Ra5+ 72.
+Kf6 Ra6+ 73. Re6 Ra8 74. h7+ Kh8 75. g7+ Kxh7 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "zenon011"]
+[Black "Northridgehawk"]
+[Result "0-1"]
+[ECO "C50"]
+[WhiteElo "2321"]
+[BlackElo "2373"]
+[PlyCount "65"]
+[EventDate "2020.??.??"]
+
+1. e4 e5 2. Nf3 Nc6 3. Bc4 Nf6 4. d3 Bc5 5. Nc3 d6 6. Bb3 Be6 7. Be3 Bb6 8. Ne2
+Ne7 9. Ng3 Ng6 10. O-O Qd7 11. Bxb6 axb6 12. Ng5 O-O 13. Nxe6 fxe6 14. Ne2 c6
+15. f4 exf4 16. Nxf4 Nxf4 17. Rxf4 d5 18. e5 Ne8 19. Rh4 Nc7 20. Qh5 g6 21. Rg4
+Qg7 22. Qg5 Rf5 23. Qh4 Qxe5 24. h3 Raf8 25. d4 Qe3+ 26. Kh2 R8f7 27. c3 Kg7
+28. Re1 Qf2 29. Qxf2 Rxf2 30. Ba4 Rxb2 31. Bb3 Rff2 32. c4 h5 33. Rg5 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "strangerous"]
+[Black "Rooko64"]
+[Result "0-1"]
+[ECO "C31"]
+[WhiteElo "2332"]
+[BlackElo "2360"]
+[PlyCount "44"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 e5 2. f4 d5 3. exd5 c6 4. dxc6 Nxc6 5. Bb5 exf4 6. d4 Nf6 7. Bxf4 Bd6 8.
+Bxd6 Qxd6 9. Qe2+ Be6 10. Nf3 O-O 11. Bxc6 bxc6 12. O-O Bd5 13. c3 Rae8 14. Qd3
+Ng4 15. h3 Bxf3 16. hxg4 Be2 17. Qf5 Bxf1 18. Kxf1 Re6 19. g5 Qh2 20. Qh3 Qf4+
+21. Qf3 Qc1+ 22. Kf2 Qe1# 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "FishyMcPatzer"]
+[Black "irakliberadze"]
+[Result "0-1"]
+[ECO "A40"]
+[WhiteElo "2575"]
+[BlackElo "2654"]
+[PlyCount "46"]
+[EventDate "2020.??.??"]
+
+1. d4 e5 2. Nc3 exd4 3. Qxd4 Nc6 4. Qd2 d5 5. e3 Nf6 6. Bb5 Bd6 7. Nge2 O-O 8.
+a3 Re8 9. Ng3 h5 10. Bxc6 bxc6 11. Nge2 c5 12. b3 d4 13. exd4 Ba6 14. Bb2 cxd4
+15. Qxd4 Be5 16. Qxd8 Bxc3+ 17. Bxc3 Raxd8 18. O-O Rxe2 19. Rfd1 Rxd1+ 20. Rxd1
+Rxc2 21. Bxf6 gxf6 22. Rd8+ Kg7 23. Ra8 Rc1# 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "LordGrim2500"]
+[Black "Phutressniak"]
+[Result "1-0"]
+[ECO "C45"]
+[WhiteElo "2473"]
+[BlackElo "2426"]
+[PlyCount "111"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 e5 2. Nf3 Nc6 3. d4 exd4 4. Nxd4 Qf6 5. Nxc6 Bc5 6. Qf3 dxc6 7. Qxf6 Nxf6
+8. f3 Be6 9. Nc3 O-O-O 10. Bd2 Bf2+ 11. Kd1 Be3 12. Bd3 Bxd2 13. Kxd2 h5 14.
+Rhd1 h4 15. Ke3 Nh5 16. Be2 g5 17. Rxd8+ Rxd8 18. Rd1 Nf4 19. Rxd8+ Kxd8 20. g3
+Ng6 21. f4 hxg3 22. hxg3 gxf4+ 23. gxf4 f5 24. Bd3 Ne7 25. exf5 Bxf5 26. Be4
+Kd7 27. Bxf5+ Nxf5+ 28. Ke4 Ke6 29. Ne2 Nd6+ 30. Kf3 c5 31. Ng3 b5 32. Ne4 Nb7
+33. Kg4 c4 34. f5+ Ke5 35. f6 Nd8 36. Kf3 a5 37. Ke3 b4 38. Nd2 c3 39. bxc3
+bxc3 40. Nc4+ Kxf6 41. Nxa5 Ke5 42. Kd3 Kd5 43. Kxc3 Kc5 44. a4 Ne6 45. Nb3+
+Kb6 46. Kb4 Nd8 47. a5+ Kc6 48. Nc5 Kd5 49. Kb5 Nc6 50. c4+ Kd6 51. Ne4+ Kd7
+52. Nf6+ Kd6 53. Ne8+ Kd7 54. Nf6+ Kd6 55. c5+ Ke6 56. Kxc6 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Kralj56"]
+[Black "Tigerscot"]
+[Result "0-1"]
+[ECO "A41"]
+[WhiteElo "2457"]
+[BlackElo "2458"]
+[PlyCount "56"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 d6 2. c4 e5 3. Nf3 e4 4. Ng5 f5 5. h4 Nf6 6. Nc3 Be7 7. f3 O-O 8. fxe4
+fxe4 9. Ncxe4 Nxe4 10. Nxe4 Bxh4+ 11. g3 Be7 12. Bg2 Bf5 13. Qb3 Nc6 14. Be3 a5
+15. O-O-O Nb4 16. a3 d5 17. axb4 dxe4 18. c5+ Kh8 19. Bh3 a4 20. Qc4 Bg5 21.
+Bxg5 Qxg5+ 22. Kb1 a3 23. Bxf5 Qxf5 24. d5 axb2 25. Qd4 e3+ 26. Kxb2 Ra2+ 27.
+Kxa2 Qc2+ 28. Ka3 Ra8# 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Routmund1976"]
+[Black "Adrian_DelaCruz"]
+[Result "0-1"]
+[ECO "A48"]
+[WhiteElo "2363"]
+[BlackElo "2349"]
+[PlyCount "95"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 Nf6 2. Nf3 g6 3. Bf4 Bg7 4. e3 O-O 5. h3 d6 6. Be2 Nbd7 7. c3 a6 8. a4 b6
+9. Nbd2 Bb7 10. O-O Re8 11. Bh2 e5 12. dxe5 Nxe5 13. Nxe5 dxe5 14. Nc4 Ne4 15.
+Qxd8 Raxd8 16. Rfd1 f6 17. Bf3 Nc5 18. Bxb7 Nxb7 19. Kf1 Kf7 20. Ke2 Ke6 21. f3
+Nc5 22. a5 b5 23. Nd2 Rd7 24. b4 Na4 25. Nb1 Rxd1 26. Kxd1 Nb2+ 27. Ke2 Rd8 28.
+Nd2 Na4 29. Rc1 f5 30. c4 e4 31. Bxc7 Rd7 32. cxb5 Nc3+ 33. Rxc3 Bxc3 34. Nb1
+Bxb4 35. Bb6 Kd5 36. bxa6 Kc6 37. a7 Kb7 38. a6+ Ka8 39. fxe4 fxe4 40. Bd4 Rd6
+41. Bc3 Bxc3 42. Nxc3 Re6 43. Kf2 Kxa7 44. Kg3 g5 45. Nb5+ Kb6 46. a7 Re8 47.
+Nc7 Kxc7 48. Kg4 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Betovsky"]
+[Black "taras05"]
+[Result "1-0"]
+[ECO "A80"]
+[WhiteElo "2637"]
+[BlackElo "2476"]
+[PlyCount "17"]
+[EventDate "2020.??.??"]
+
+1. d4 f5 2. Bg5 g6 3. e4 Bg7 4. exf5 gxf5 5. Bd3 d6 6. Qh5+ Kf8 7. Nc3 Qe8 8.
+Qh4 Bxd4 9. Qxd4 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Dashibalov"]
+[Black "Elhlwagy11"]
+[Result "1-0"]
+[ECO "B40"]
+[WhiteElo "2377"]
+[BlackElo "2300"]
+[PlyCount "69"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 c5 2. Nf3 e6 3. c3 a6 4. d4 cxd4 5. cxd4 d5 6. e5 Ne7 7. Bd3 Nbc6 8. a3
+Nf5 9. Be3 Be7 10. O-O h5 11. Nc3 g5 12. Bc2 g4 13. Ne1 Bg5 14. Qd2 Bxe3 15.
+fxe3 Qg5 16. Bxf5 exf5 17. Nxd5 Qd8 18. Nf6+ Kf8 19. Nd3 Be6 20. Nf4 Nxe5 21.
+Qb4+ Kg7 22. dxe5 h4 23. Qxb7 Rb8 24. Nxe6+ Kg6 25. Nxd8 Rxb7 26. Nxb7 Rb8 27.
+Nc5 Rxb2 28. e4 fxe4 29. Nfxe4 h3 30. Rf6+ Kh5 31. gxh3 gxh3 32. Kh1 Kh4 33.
+Rg1 Kh5 34. Rg5+ Kh4 35. Rh6# 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "vaillant77"]
+[Black "vassiukov"]
+[Result "1-0"]
+[ECO "B01"]
+[WhiteElo "2435"]
+[BlackElo "2356"]
+[PlyCount "149"]
+[EventDate "2020.??.??"]
+
+1. e4 d5 2. exd5 Qxd5 3. Nc3 Qa5 4. d4 c6 5. Nf3 Nf6 6. Bc4 Bg4 7. O-O e6 8.
+Bf4 Nbd7 9. h3 Bh5 10. Qd3 Bg6 11. Qe2 Bb4 12. Bd2 Qc7 13. Ne5 Nxe5 14. dxe5
+Nd7 15. a3 Be7 16. Bf4 b5 17. Bd3 Nc5 18. Bxg6 hxg6 19. Ne4 Nxe4 20. Qxe4 O-O
+21. Rad1 Rfd8 22. c4 bxc4 23. Qxc4 Rd5 24. Rxd5 exd5 25. Qd4 a5 26. Rc1 Rd8 27.
+e6 Bd6 28. exf7+ Kxf7 29. Bxd6 Qxd6 30. Qb6 Rc8 31. Qxa5 d4 32. Qd2 c5 33. Rc4
+Qd5 34. Qd3 Rb8 35. Qf3+ Qxf3 36. gxf3 Rb5 37. b4 cxb4 38. axb4 Rd5 39. Kf1 d3
+40. Ke1 d2+ 41. Kd1 Ke7 42. Rc2 Rb5 43. Kxd2 Rxb4 44. Ke3 Rh4 45. Rc5 Rxh3 46.
+Rg5 Kf6 47. Rg4 g5 48. Ra4 Kg6 49. Ra6+ Kh5 50. Ke4 Rh4+ 51. Ke3 Rf4 52. Ra8
+Kg6 53. Ra6+ Rf6 54. Ra5 Re6+ 55. Kd2 Rf6 56. Ke2 Re6+ 57. Kf1 Rf6 58. Kg2 Rd6
+59. Kg3 Rd2 60. Ra6+ Kf7 61. Kg4 Rd4+ 62. Kxg5 Rd2 63. Kg4 Rxf2 64. Ra7+ Kf6
+65. f4 Rg2+ 66. Kf3 Rg6 67. Ra6+ Kf7 68. Ra7+ Kf6 69. Ke4 Rg1 70. Ra6+ Kf7 71.
+Kf5 Kg8 72. Ra8+ Kh7 73. Ra2 Rf1 74. Rh2+ Kg8 75. Rh8+ 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Lil_D"]
+[Black "Bulingot"]
+[Result "0-1"]
+[ECO "A00"]
+[WhiteElo "2301"]
+[BlackElo "2358"]
+[PlyCount "66"]
+[EventDate "2020.??.??"]
+
+1. g3 c5 2. Bg2 g6 3. d3 Bg7 4. e4 Nf6 5. f4 O-O 6. Nf3 Nc6 7. O-O d6 8. h3 Rb8
+9. g4 b5 10. Nc3 b4 11. Ne2 a5 12. Ng3 Ba6 13. g5 Nd7 14. f5 Nde5 15. Nh2 c4
+16. dxc4 Bxc4 17. Re1 Qc7 18. Ng4 Nxg4 19. hxg4 Ne5 20. Bf4 Rfd8 21. a3 bxa3
+22. bxa3 a4 23. Ne2 Qc5+ 24. Kh1 Nxg4 25. Rf1 Bxa1 26. Qxa1 Bxe2 27. Re1 Bc4
+28. fxg6 hxg6 29. Bd2 Be6 30. Bc3 Ne5 31. Rf1 Rdc8 32. Rf3 Rb6 33. Rh3 Rcb8 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Steed28"]
+[Black "Allshad"]
+[Result "1-0"]
+[ECO "A81"]
+[WhiteElo "2391"]
+[BlackElo "2323"]
+[PlyCount "47"]
+[EventDate "2020.??.??"]
+
+1. d4 f5 2. g3 Nf6 3. Bg2 g6 4. c3 Bg7 5. Nh3 O-O 6. Qb3+ Kh8 7. Bxb7 Bxb7 8.
+Qxb7 Nc6 9. Nf4 e5 10. dxe5 Nxe5 11. O-O c6 12. Nd2 Qe8 13. Nf3 Nxf3+ 14. exf3
+g5 15. Nd3 Qh5 16. Kg2 f4 17. Ne5 Nd5 18. g4 Qh4 19. Nxd7 h5 20. Nxf8 Rxf8 21.
+h3 Ne3+ 22. Bxe3 fxe3 23. Qc7 Re8 24. Qg3 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "MrMania"]
+[Black "lord_barre"]
+[Result "1-0"]
+[ECO "A14"]
+[WhiteElo "2379"]
+[BlackElo "2415"]
+[PlyCount "45"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. g3 Nf6 2. Bg2 d5 3. Nf3 e6 4. O-O Be7 5. c4 O-O 6. cxd5 exd5 7. d4 Bd6 8.
+Nc3 c6 9. Ne5 Bxe5 10. dxe5 Nfd7 11. f4 Re8 12. e4 Qb6+ 13. Kh1 d4 14. Na4 Qb5
+15. Qxd4 c5 16. Qd1 Nc6 17. Nc3 Qa6 18. Nd5 Nd4 19. Nc7 Qc6 20. Nxe8 b5 21. Nd6
+Ba6 22. Be3 Nb6 23. Bxd4 1-0
+
+[Event "Rated Bullet tournament Ty5yUoqy"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "vervitu"]
+[Black "RyanX4FleteChavale"]
+[Result "0-1"]
+[ECO "C21"]
+[WhiteElo "2329"]
+[BlackElo "2367"]
+[PlyCount "66"]
+[EventDate "2020.??.??"]
+
+1. e4 e5 2. d4 d5 3. dxe5 d4 4. c3 c5 5. cxd4 cxd4 6. Nf3 Nc6 7. Bd3 Be6 8. O-O
+Be7 9. Nbd2 h5 10. Bc4 Nh6 11. Bxe6 fxe6 12. Nb3 Ng4 13. h3 a5 14. Nbxd4 Qb6
+15. Nxe6 Ncxe5 16. Nxg7+ Kf7 17. Nxe5+ Nxe5 18. Nf5 Bc5 19. Qd5+ Kf6 20. Kh2
+Rad8 21. f4 Rxd5 22. exd5 Ng4+ 23. hxg4 hxg4+ 24. Kg3 Kxf5 25. Bd2 Qb5 26. Rae1
+Qd3+ 27. Be3 Bxe3 28. d6 Bd2+ 29. Rf3 gxf3 30. gxf3 Bxe1+ 31. Kg2 Qxd6 32. Kf1
+Qd2 33. Kg1 Qf2# 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "JiangoFett"]
+[Black "profaVa"]
+[Result "1-0"]
+[ECO "D07"]
+[WhiteElo "2389"]
+[BlackElo "2375"]
+[PlyCount "93"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 d5 2. c4 Nc6 3. Nf3 Bg4 4. cxd5 Bxf3 5. gxf3 Qxd5 6. e3 e5 7. Nc3 Bb4 8.
+Bd2 Bxc3 9. bxc3 exd4 10. cxd4 Nge7 11. Bg2 O-O 12. O-O Rad8 13. f4 Qd6 14. Rb1
+b6 15. Qc2 Qg6 16. Qxg6 hxg6 17. Rfc1 Rd6 18. Rc2 a5 19. a3 Rfd8 20. Rbc1 Na7
+21. Rxc7 Nb5 22. Rxe7 Nxa3 23. Rcc7 Rf6 24. d5 b5 25. Bxa5 Nc4 26. Bc3 Ra8 27.
+Bxf6 gxf6 28. Rxf7 Ra1+ 29. Bf1 Nd2 30. Rfd7 Nf3+ 31. Kg2 Nh4+ 32. Kh3 Ra8 33.
+Kxh4 b4 34. Rb7 b3 35. Rxb3 g5+ 36. Kg3 gxf4+ 37. Kxf4 f5 38. Rbb7 Kh8 39. Rh7+
+Kg8 40. d6 Ra4+ 41. Kxf5 Ra5+ 42. Bb5 Rxb5+ 43. Rxb5 Kxh7 44. d7 Kh6 45. d8=Q
+Kh7 46. Rb7+ Kh6 47. Qh8# 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "taras05"]
+[Black "Betovsky"]
+[Result "0-1"]
+[ECO "B01"]
+[WhiteElo "2472"]
+[BlackElo "2640"]
+[PlyCount "106"]
+[EventDate "2020.??.??"]
+
+1. e4 d5 2. exd5 Nf6 3. Bb5+ Bd7 4. Bc4 Bg4 5. f3 Bh5 6. Nc3 c6 7. dxc6 Nxc6 8.
+Nge2 e5 9. O-O Bc5+ 10. Kh1 O-O 11. d3 Bg6 12. Ng3 a6 13. a3 Be7 14. Nce4 Kh8
+15. Be3 Rc8 16. Qe2 b5 17. Bb3 Nd5 18. Bf2 f5 19. Nc3 Nf4 20. Qd2 Bg5 21. Be3
+Nd4 22. Ba2 a5 23. Rac1 b4 24. axb4 axb4 25. Nd1 b3 26. cxb3 Rxc1 27. Qxc1 Nfe2
+28. Nxe2 Nxe2 29. Qd2 Bxe3 30. Nxe3 Nd4 31. b4 Qb6 32. Nd5 Qb7 33. Bc4 Rd8 34.
+Nc3 Qxb4 35. f4 Nb3 36. Qe2 e4 37. dxe4 Nd4 38. Qd3 Nc6 39. Nd5 fxe4 40. Nxb4
+exd3 41. Nxc6 Rc8 42. Bd5 d2 43. Rd1 Ra8 44. Bf3 Bc2 45. Rxd2 Ra1+ 46. Bd1
+Rxd1+ 47. Rxd1 Bxd1 48. Ne5 Bf3 49. Kg1 Bd5 50. Kf2 Be6 51. Ke3 Bf5 52. Nd3 g5
+53. Ne5 gxf4+ 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Jaggust01"]
+[Black "FedaMaster"]
+[Result "1-0"]
+[ECO "A45"]
+[WhiteElo "2579"]
+[BlackElo "2573"]
+[PlyCount "37"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 Nf6 2. Bf4 c5 3. c3 cxd4 4. cxd4 Qb6 5. Nc3 e6 6. Nf3 Bb4 7. e3 Nd5 8.
+Rc1 Nxf4 9. exf4 Nc6 10. Be2 Bd6 11. g3 Qxb2 12. O-O a6 13. d5 exd5 14. Qxd5
+Be7 15. Ng5 O-O 16. Nxh7 Kxh7 17. Qh5+ Kg8 18. Bd3 f5 19. Bc4+ 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Kidefence"]
+[Black "BlueGreensun"]
+[Result "0-1"]
+[ECO "C41"]
+[WhiteElo "2728"]
+[BlackElo "2738"]
+[PlyCount "100"]
+[EventDate "2020.??.??"]
+
+1. e4 d6 2. d4 e5 3. Nf3 Nf6 4. Nc3 Nbd7 5. Be3 Be7 6. Qd2 O-O 7. O-O-O c6 8.
+Kb1 b5 9. Bd3 b4 10. Ne2 Qa5 11. Nc1 Nb6 12. Nb3 Qa4 13. dxe5 dxe5 14. Nxe5 Be6
+15. g4 c5 16. Qe2 a6 17. g5 Nfd7 18. Nxd7 Bxd7 19. Bxc5 Bxc5 20. Nxc5 Qc6 21.
+Nxd7 Nxd7 22. e5 Nc5 23. h4 Nxd3 24. Qxd3 a5 25. h5 a4 26. Qd5 Qc7 27. g6 b3
+28. cxb3 axb3 29. gxf7+ Kh8 30. axb3 Qa7 31. Rh3 Qa2+ 32. Kc2 Qa7 33. Qd4 Qa6
+34. Rc3 Qe2+ 35. Rd2 Qxh5 36. e6 Qg6+ 37. Qd3 Qxe6 38. Re2 Qxf7 39. Rc4 Qf6 40.
+Rce4 Rac8+ 41. Kb1 Rcd8 42. Qe3 Rd1+ 43. Ka2 Rdd8 44. Ra4 Qa6 45. Rxa6 Rc8 46.
+Ra4 Rb8 47. Qe5 Rbc8 48. Qxg7+ Kxg7 49. Re7+ Kh8 50. Raa7 Rf7 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Yoseqpuedo"]
+[Black "Frogkiller"]
+[Result "1-0"]
+[ECO "A00"]
+[WhiteElo "2415"]
+[BlackElo "2371"]
+[PlyCount "93"]
+[EventDate "2020.??.??"]
+
+1. e3 e5 2. f4 exf4 3. exf4 d5 4. d4 Nf6 5. Nf3 c5 6. Be2 cxd4 7. Nxd4 Nc6 8.
+c3 Bc5 9. O-O O-O 10. Kh1 Qb6 11. Nb3 Bd6 12. N1d2 Qc7 13. Nf3 Bxf4 14. Nfd4
+Bxc1 15. Qxc1 Nxd4 16. Nxd4 Ne4 17. Qe3 Be6 18. Nf5 Qe5 19. Nd4 f5 20. Rae1 f4
+21. Qg1 Bd7 22. Bf3 Rae8 23. Re2 Qg5 24. Rfe1 Bf5 25. Nxf5 Qxf5 26. Qd4 Kh8 27.
+Bxe4 dxe4 28. Rxe4 Rxe4 29. Qxe4 Qf7 30. h3 Qxa2 31. Re2 Qf7 32. Rf2 h6 33. Rf3
+b6 34. Qe5 Qf6 35. Qe4 a5 36. g3 Qd6 37. Kg2 Qd2+ 38. Rf2 f3+ 39. Kg1 Qd1+ 40.
+Rf1 Qe2 41. Rf2 Qxe4 42. h4 Qe3 43. Kf1 Qxf2+ 44. Kxf2 h5 45. c4 g5 46. c5 gxh4
+47. c6 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "chesslismab"]
+[Black "hungzhao"]
+[Result "0-1"]
+[ECO "A40"]
+[WhiteElo "2451"]
+[BlackElo "2622"]
+[PlyCount "80"]
+[EventDate "2020.??.??"]
+
+1. d4 e6 2. Nf3 Nf6 3. b3 a5 4. Bb2 a4 5. c4 a3 6. Bc3 Ne4 7. Qc2 d5 8. e3 Nxc3
+9. Nxc3 Na6 10. c5 Nb4 11. Qd2 b6 12. cxb6 cxb6 13. Bb5+ Bd7 14. Bxd7+ Qxd7 15.
+Ne5 Qa7 16. O-O Be7 17. Rfc1 O-O 18. Nb5 Qa5 19. Nc7 Rac8 20. Qe2 Bd6 21. Nb5
+Bxe5 22. dxe5 Rxc1+ 23. Rxc1 Nxa2 24. Qxa2 Qxb5 25. Qxa3 Qe2 26. h3 h5 27. Qe7
+Qb2 28. Qc7 Qxb3 29. Rc6 b5 30. Rb6 b4 31. Rb8 Rxb8 32. Qxb8+ Kh7 33. Qf8 Kg6
+34. g4 hxg4 35. hxg4 Qd1+ 36. Kh2 Qxg4 37. Qe7 Qf5 38. Qh4 Qh5 39. Qxh5+ Kxh5
+40. Kg3 b3 0-1
+
+[Event "Rated Blitz tournament hM7PUvgg"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Lidiodelgado"]
+[Black "hectordetroya"]
+[Result "1-0"]
+[ECO "A40"]
+[WhiteElo "2366"]
+[BlackElo "2403"]
+[PlyCount "81"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 e6 2. Nf3 Nf6 3. c3 d5 4. Nbd2 Be7 5. e3 Ne4 6. Nxe4 dxe4 7. Nd2 f5 8.
+Bc4 O-O 9. O-O Kh8 10. f3 exf3 11. Qxf3 c5 12. b3 Nc6 13. Bb2 Bf6 14. Rad1 Qb6
+15. Kh1 a5 16. e4 cxd4 17. exf5 Ne5 18. Qg3 exf5 19. cxd4 Ng6 20. Nf3 f4 21.
+Qe1 Bg4 22. Qd2 Rad8 23. h3 Bxf3 24. Rxf3 Rfe8 25. d5 Bxb2 26. Qxb2 Ne5 27.
+Rxf4 Nxc4 28. Rxc4 Qg6 29. Rg4 Qh6 30. Qd4 Rd7 31. Qd2 Qa6 32. Rd4 Red8 33. d6
+h6 34. Qf4 Qc6 35. Rd5 b6 36. Qf3 Rxd6 37. Rxd6 Rxd6 38. Qf8+ Kh7 39. Qxd6 Qc2
+40. Qd3+ Qxd3 41. Rxd3 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Maxterlopez"]
+[Black "DoctorFromGallifrey"]
+[Result "1-0"]
+[ECO "B10"]
+[WhiteElo "2663"]
+[BlackElo "2551"]
+[PlyCount "93"]
+[EventDate "2020.??.??"]
+
+1. e4 c6 2. Nf3 d5 3. exd5 cxd5 4. d4 Nc6 5. h3 g6 6. Bd3 Nh6 7. c3 Bg7 8. Bxh6
+Bxh6 9. O-O O-O 10. Re1 e6 11. Nbd2 Rb8 12. Ne5 Nxe5 13. dxe5 b5 14. b4 a5 15.
+Nb3 axb4 16. cxb4 d4 17. Be4 Bb7 18. Qxd4 Qxd4 19. Nxd4 Bxe4 20. Rxe4 Rfc8 21.
+Nb3 Rc4 22. Rae1 Bf8 23. a3 Ra8 24. Na5 Rc3 25. R4e3 Rac8 26. g3 h5 27. h4 Bh6
+28. f4 Bf8 29. Kf2 Rc2+ 30. R1e2 Rc1 31. Rd3 Rh1 32. Kg2 Rcc1 33. Red2 Rcg1+
+34. Kf3 Rf1+ 35. Rf2 Ra1 36. Nb7 Kg7 37. Nd6 Be7 38. Nxb5 f6 39. Rd7 Kf8 40.
+Rc2 Rhf1+ 41. Ke3 Rae1+ 42. Re2 fxe5 43. Rxe1 Rxe1+ 44. Kf2 Re4 45. Kf3 Re1 46.
+Kf2 Re4 47. Nc7 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Aisen_Mestnikov"]
+[Black "alireza3700"]
+[Result "1/2-1/2"]
+[ECO "D21"]
+[WhiteElo "2372"]
+[BlackElo "2358"]
+[PlyCount "122"]
+[EventDate "2020.??.??"]
+
+1. d4 d5 2. c4 dxc4 3. Nf3 e5 4. Nxe5 Nc6 5. Nxc4 Qxd4 6. Qxd4 Nxd4 7. Nba3 Be6
+8. e3 Bxc4 9. Bxc4 Bxa3 10. exd4 Bb4+ 11. Bd2 Bxd2+ 12. Kxd2 O-O-O 13. Kc3 Nf6
+14. Bxf7 Ne4+ 15. Kc2 Rxd4 16. Rad1 Rhd8 17. Rxd4 Rxd4 18. f3 Nd6 19. Be6+ Kd8
+20. Rd1 Rxd1 21. Kxd1 Ke7 22. Bd5 c6 23. Bb3 a5 24. Bc2 h6 25. Ke2 Nc4 26. b3
+Na3 27. Bd3 Kd6 28. Ke3 Ke5 29. f4+ Kf6 30. g4 Ke6 31. h4 Kf6 32. g5+ hxg5 33.
+hxg5+ Kf7 34. f5 b5 35. Kf4 c5 36. Ke5 c4 37. bxc4 bxc4 38. Be4 c3 39. g6+ Kf8
+40. f6 c2 41. Bxc2 Nxc2 42. fxg7+ Kxg7 43. Kd5 Nb4+ 44. Kc4 Nxa2 45. Kb5 Nc3+
+46. Kxa5 Ne4 47. Kb4 Nf6 48. Kb5 Ng4 49. Kc5 Nh6 50. Kd6 Nf5+ 51. Ke5 Ne7 52.
+Kf4 Nc8 53. Kg5 Nb6 54. Kh5 Nc4 55. Kg5 Nd6 56. Kh5 Ne4 57. Kg4 Nf6+ 58. Kf5
+Ne8 59. Kg4 Nc7 60. Kg5 Ne6+ 61. Kg4 Kxg6 1/2-1/2
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Atomrod"]
+[Black "Tematico"]
+[Result "1-0"]
+[ECO "E60"]
+[WhiteElo "2483"]
+[BlackElo "2399"]
+[PlyCount "107"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 Nf6 2. Nf3 g6 3. c4 c5 4. d5 d6 5. g3 Bg7 6. Nc3 O-O 7. Bg2 e6 8. O-O
+exd5 9. cxd5 Na6 10. Nd2 Nc7 11. Nc4 b5 12. Nxd6 Qxd6 13. Bf4 Qb6 14. d6 Ne6
+15. Bxa8 Nxf4 16. gxf4 Bg4 17. Bg2 Rd8 18. Qb3 b4 19. Nd5 Nxd5 20. Bxd5 Rxd6
+21. Bxf7+ Kh8 22. Bd5 Qd8 23. Bf3 Bh3 24. Rfd1 Bd4 25. e3 Bf6 26. Rxd6 Qxd6 27.
+Rd1 Qe7 28. Qd5 Bxb2 29. Qd8+ Qxd8 30. Rxd8+ Kg7 31. Ra8 c4 32. Rxa7+ Kf6 33.
+Ra6+ Ke7 34. Rc6 c3 35. Be4 Be6 36. Bb1 Bd5 37. Rc8 Kd6 38. Kf1 Bc6 39. Ke2 Kc5
+40. Kd3 Kb6 41. Kc4 Bb5+ 42. Kxb4 Bd7 43. Rxc3 Bxc3+ 44. Kxc3 Be6 45. Kd4 Bf7
+46. Ke5 Kc5 47. h4 Bc4 48. a4 Kb4 49. Bc2 Kc3 50. Be4 Kd2 51. h5 Ke1 52. h6
+Kxf2 53. Bxg6 hxg6 54. h7 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Analitik33"]
+[Black "InsaneTryhard"]
+[Result "0-1"]
+[ECO "B90"]
+[WhiteElo "2391"]
+[BlackElo "2372"]
+[PlyCount "124"]
+[EventDate "2020.??.??"]
+
+1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Nb3 e6 7. g4 Be7 8. g5
+Nfd7 9. h4 b5 10. a3 Bb7 11. Bh3 Nc5 12. Nxc5 dxc5 13. Qxd8+ Bxd8 14. Be3 Nd7
+15. O-O-O Be7 16. f4 h6 17. f5 hxg5 18. fxe6 fxe6 19. Bxe6 Nf8 20. Bd5 Bxd5 21.
+Nxd5 Bd6 22. Bxg5 Ne6 23. Be3 O-O-O 24. Rdf1 Kb7 25. Rf7+ Kc6 26. c4 bxc4 27.
+h5 Nd4 28. Rxg7 Rdf8 29. Ra7 Rf3 30. Rxa6+ Kd7 31. h6 Nb3+ 32. Kb1 Be5 33. h7
+Rb8 34. Rb6 Rxb6 35. Nxb6+ Kc6 36. Nxc4 Bg7 37. h8=Q Bxh8 38. Rxh8 Rf1+ 39. Kc2
+Nd4+ 40. Bxd4 cxd4 41. Rh5 Rf2+ 42. Kb3 Rg2 43. Rd5 Kb7 44. Rxd4 Rg3+ 45. Kb4
+Rg1 46. Nd6+ Ka7 47. Nb5+ Kb6 48. Rd2 Rg3 49. Nc3 Rg5 50. Nd5+ Kc6 51. Kc4 Kd7
+52. Kd4 Ke8 53. Rf2 Rg4 54. Rf5 Rg3 55. Re5+ Kd7 56. Nf6+ Kc8 57. Nd5 Rg1 58.
+Re8+ Kb7 59. Ke5 Ka6 60. Re7 Rd1 61. Re6+ Ka5 62. Rc6 Ka4 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "ajedrez2021"]
+[Black "sutcunuri"]
+[Result "1-0"]
+[ECO "A04"]
+[WhiteElo "2589"]
+[BlackElo "2523"]
+[PlyCount "115"]
+[EventDate "2020.??.??"]
+
+1. Nf3 d6 2. c4 Bd7 3. g3 Qc8 4. Bg2 Bh3 5. O-O Bxg2 6. Kxg2 c6 7. d4 Nf6 8.
+Nc3 Nbd7 9. e4 e5 10. Re1 Be7 11. d5 O-O 12. Be3 Re8 13. h3 a6 14. b4 b5 15.
+Qb3 bxc4 16. Qxc4 cxd5 17. Qxc8 Rexc8 18. Nxd5 Nxd5 19. exd5 Rc4 20. a3 Rac8
+21. Rec1 Rxc1 22. Bxc1 Nb6 23. Bg5 f6 24. Bd2 Nxd5 25. a4 Nb6 26. Be3 Nc4 27.
+b5 axb5 28. axb5 Rb8 29. Rb1 Na3 30. Rb3 Nxb5 31. Nd2 d5 32. Nb1 Rb7 33. Nc3 d4
+34. Nxb5 dxe3 35. fxe3 Kf7 36. Kf3 Kg6 37. g4 h5 38. Ke4 hxg4 39. hxg4 Kg5 40.
+Kd5 Rb6 41. e4 g6 42. Kc4 Kxg4 43. Rb1 Rc6+ 44. Kd3 Rc5 45. Rg1+ Kh5 46. Rf1
+Kg5 47. Nc3 Kh6 48. Nd5 Kg7 49. Nxe7 Rc7 50. Nd5 Rf7 51. Ke3 f5 52. exf5 gxf5
+53. Rg1+ Kf8 54. Rc1 Ke8 55. Rc6 Kd7 56. Rh6 Rf6 57. Nxf6+ Ke6 58. Nd5+ 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "JLeon"]
+[Black "Evgen_88"]
+[Result "1-0"]
+[ECO "C00"]
+[WhiteElo "2563"]
+[BlackElo "2543"]
+[PlyCount "73"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 e6 2. Nf3 d5 3. Nc3 Nf6 4. Bd3 c5 5. exd5 exd5 6. O-O Be7 7. Bb5+ Nc6 8.
+d4 O-O 9. dxc5 Bxc5 10. Bg5 Be6 11. h3 h6 12. Bh4 g5 13. Bg3 Ne4 14. Bxc6 Nxg3
+15. Bxd5 Bxd5 16. Nxd5 Nxf1 17. Kxf1 Qd6 18. c4 Rfd8 19. Qc2 b5 20. b3 bxc4 21.
+bxc4 Qg6 22. Qc3 Qg7 23. Ne5 Re8 24. Re1 Bd6 25. Ng4 Qxc3 26. Nxc3 Rxe1+ 27.
+Kxe1 Bb4 28. Kd2 Kg7 29. Kd3 Bxc3 30. Kxc3 Re8 31. Ne3 Kf6 32. c5 Ke5 33. Kc4
+f5 34. c6 f4 35. Nd5 Kd6 36. c7 Re1 37. c8=Q 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "khabar5555"]
+[Black "Kanon1"]
+[Result "1/2-1/2"]
+[ECO "B13"]
+[WhiteElo "2345"]
+[BlackElo "2322"]
+[PlyCount "145"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 c6 2. d4 d5 3. exd5 cxd5 4. Bd3 Nf6 5. c3 Bg4 6. Qb3 Qc8 7. Bf4 Nbd7 8.
+Nd2 Nb6 9. Ngf3 Bf5 10. Bb5+ Bd7 11. Bd3 Ba4 12. Bb5+ Bxb5 13. Qxb5+ Qd7 14.
+Qxd7+ Nfxd7 15. a4 a5 16. O-O e6 17. Rfe1 Rc8 18. Nb3 Nc4 19. Re2 b6 20. Nc1
+Bd6 21. Bxd6 Nxd6 22. Nd3 Ne4 23. Nfe5 Nxe5 24. Nxe5 f6 25. Nd3 Kd7 26. f3 Nd6
+27. Rae1 Rhe8 28. Nf4 Rc4 29. Nxe6 Rxa4 30. Nxg7 Rxe2 31. Rxe2 Ra2 32. Nh5 Nc4
+33. Nxf6+ Kd6 34. Nxh7 Nxb2 35. h4 a4 36. h5 a3 37. h6 Ra1+ 38. Kh2 a2 39. Rxb2
+Rh1+ 40. Kxh1 a1=Q+ 41. Kh2 Qxb2 42. Ng5 Qd2 43. h7 Qf4+ 44. g3 Qxg5 45. h8=Q
+Qd2+ 46. Kh3 Qxc3 47. Qe5+ Kc6 48. Qe6+ Kc7 49. Qxd5 Qd3 50. g4 b5 51. Qc5+ Kb7
+52. Kg3 Ka6 53. d5 Ka5 54. d6 Ka4 55. Qa7+ Kb3 56. Qf7+ Kb2 57. d7 Qd6+ 58. f4
+b4 59. Qe8 Qd3+ 60. Kh4 Qh7+ 61. Kg5 Qg7+ 62. Kf5 Qh7+ 63. Ke5 Qg7+ 64. Kd5
+Qxg4 65. Qe5+ Ka2 66. d8=Q Qd1+ 67. Qd4 Qb3+ 68. Qc4 Ka1 69. Qa8+ Qa3 70. Qxa3+
+Kb1 71. Qcxb4+ Kc2 72. Qac3+ Kd1 73. Qbb2 1/2-1/2
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "rudolf85"]
+[Black "Paanoos"]
+[Result "0-1"]
+[ECO "A00"]
+[WhiteElo "2432"]
+[BlackElo "2370"]
+[PlyCount "42"]
+[EventDate "2020.??.??"]
+
+1. e3 c5 2. d4 cxd4 3. exd4 Nf6 4. Nf3 g6 5. Be2 Bg7 6. O-O O-O 7. c3 d6 8. b3
+Nc6 9. Bb2 e5 10. Nbd2 Re8 11. dxe5 dxe5 12. Re1 Bf5 13. Nc4 Qe7 14. Ne3 Be4
+15. Nd2 Rad8 16. Qc1 Bh6 17. Nxe4 Nxe4 18. Qc2 Nxf2 19. Kxf2 Bxe3+ 20. Kxe3 Qh4
+21. h3 Qf4# 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "sleepylock"]
+[Black "ROBESPIERR"]
+[Result "0-1"]
+[ECO "B13"]
+[WhiteElo "2494"]
+[BlackElo "2541"]
+[PlyCount "74"]
+[EventDate "2020.??.??"]
+
+1. e4 c6 2. d4 d5 3. exd5 cxd5 4. Bd3 Nc6 5. c3 Nf6 6. Bf4 Bg4 7. Qb3 e5 8.
+dxe5 Nh5 9. Be3 Nxe5 10. Bb5+ Nc6 11. Nd2 Bd6 12. Ngf3 Nf6 13. O-O O-O 14. h3
+Bh5 15. Rfe1 h6 16. Nd4 Ne5 17. Bf1 Bg6 18. N2f3 Nc4 19. Bxc4 dxc4 20. Qxc4 Re8
+21. Qb3 Qd7 22. Rad1 a6 23. a4 Rad8 24. Ne2 Qc6 25. Nf4 Be4 26. Nd4 Qc8 27. f3
+Bh7 28. Bc1 Bb8 29. Rxe8+ Rxe8 30. Nde2 Qc7 31. Qb4 g5 32. Nd3 Rxe2 33. Kf1 Re8
+34. Qc5 Bxd3+ 35. Rxd3 Qxc5 36. Bd2 Qc4 37. Be1 Qxd3+ 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "irakliberadze"]
+[Black "FishyMcPatzer"]
+[Result "1-0"]
+[ECO "C00"]
+[WhiteElo "2659"]
+[BlackElo "2570"]
+[PlyCount "97"]
+[EventDate "2020.??.??"]
+
+1. e4 a6 2. d4 e6 3. a4 Ne7 4. Bd3 Nbc6 5. Nf3 d5 6. O-O dxe4 7. Bxe4 Ng6 8. c4
+Bd6 9. d5 exd5 10. cxd5 Nce7 11. Nc3 O-O 12. Be3 f5 13. Bc2 f4 14. Bd4 Bg4 15.
+h3 Bh5 16. Qd3 Qd7 17. Rfe1 Nf5 18. Re6 Bxf3 19. gxf3 Nxd4 20. Qxd4 Rae8 21.
+Rae1 Nh4 22. Bd1 Qf7 23. Kh1 Qh5 24. Qe4 Rxe6 25. Qxe6+ Kh8 26. Qg4 Qh6 27. Bc2
+Ng6 28. Re6 a5 29. Ne4 Bb4 30. Ng5 Qh4 31. Bxg6 Qxg4 32. hxg4 hxg6 33. Rxg6 Rd8
+34. Nf7+ Kh7 35. Nxd8 Kxg6 36. Nxb7 Kf6 37. Nd8 g6 38. Nc6 Kg5 39. Kg2 Kh4 40.
+Nxb4 axb4 41. a5 g5 42. a6 c6 43. a7 cxd5 44. a8=Q b3 45. Qc6 d4 46. Qg6 d3 47.
+Qg7 d2 48. Qg6 d1=Q 49. Qh5# 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "murderoflegends"]
+[Black "awisepawn"]
+[Result "1-0"]
+[ECO "A45"]
+[WhiteElo "2424"]
+[BlackElo "2396"]
+[PlyCount "57"]
+[EventDate "2020.??.??"]
+
+1. d4 Nf6 2. c3 e6 3. Nf3 d5 4. Bg5 Bd6 5. Nbd2 h6 6. Bxf6 Qxf6 7. e4 dxe4 8.
+Nxe4 Qe7 9. Bd3 O-O 10. Qc2 Nd7 11. O-O-O Nf6 12. h3 Nxe4 13. Bxe4 a5 14. g4 a4
+15. a3 Rb8 16. h4 b5 17. g5 h5 18. g6 f5 19. Bd3 c5 20. Ng5 cxd4 21. Qe2 Bf4+
+22. Kb1 Bxg5 23. hxg5 Qxg5 24. Rdg1 Qg4 25. Rxg4 fxg4 26. Rxh5 Rf4 27. cxd4 Bb7
+28. Qxe6+ Kf8 29. Rh8# 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "kingcobra23"]
+[Black "Bigbier"]
+[Result "0-1"]
+[ECO "C00"]
+[WhiteElo "2323"]
+[BlackElo "2365"]
+[PlyCount "60"]
+[EventDate "2020.??.??"]
+
+1. e4 c5 2. d4 e6 3. c3 d5 4. dxc5 Bxc5 5. exd5 exd5 6. Nf3 Nc6 7. Bd3 Nge7 8.
+O-O O-O 9. h3 h6 10. Nbd2 Bf5 11. Nb3 Bb6 12. Bxf5 Nxf5 13. Qd3 Qd7 14. Nbd4
+Ncxd4 15. Nxd4 Nxd4 16. cxd4 Rfe8 17. Be3 Rac8 18. Rac1 Qa4 19. Rcd1 Qxa2 20.
+Rd2 Qc4 21. Qxc4 Rxc4 22. b3 Rc3 23. b4 Rc4 24. Rb1 Rec8 25. b5 Rc1+ 26. Rxc1
+Rxc1+ 27. Kh2 Rb1 28. Rc2 Rxb5 29. Rc8+ Kh7 30. Rb8 Bc7+ 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "BoJet"]
+[Black "RigelStar"]
+[Result "1-0"]
+[ECO "B12"]
+[WhiteElo "2599"]
+[BlackElo "2413"]
+[PlyCount "51"]
+[EventDate "2020.??.??"]
+
+1. e4 c6 2. d4 d5 3. e5 Bf5 4. h4 h6 5. g4 Bd7 6. h5 e6 7. c4 Bb4+ 8. Nc3 Ne7
+9. f4 c5 10. cxd5 Nxd5 11. Nge2 cxd4 12. Qxd4 Nc6 13. Qe4 Qa5 14. Bd2 f5 15.
+exf6 Nxf6 16. Qg6+ Kf8 17. Bg2 Be8 18. Qc2 Rd8 19. a3 Nd4 20. Nxd4 Rxd4 21. O-O
+Bd6 22. Bf3 Qb6 23. Kg2 Bxf4 24. Bxf4 Rxf4 25. Rae1 Nxg4 26. Bxg4 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "LaBandaDelHacha"]
+[Black "pmlmail"]
+[Result "1-0"]
+[ECO "C29"]
+[WhiteElo "2312"]
+[BlackElo "2477"]
+[PlyCount "43"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 e5 2. Nc3 Nf6 3. f4 d5 4. fxe5 Nxe4 5. Qf3 Nxc3 6. bxc3 Be6 7. d4 c6 8.
+Bd3 h5 9. Nh3 Qh4+ 10. Nf2 Nd7 11. Rb1 b5 12. O-O a6 13. Nh3 Qe7 14. Ng5 Rh6
+15. Nxe6 Rxe6 16. Bf5 O-O-O 17. Bxe6 fxe6 18. a4 Kc7 19. axb5 axb5 20. Qxh5 g6
+21. Qxg6 Qa3 22. Bxa3 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "alwaysplanahead"]
+[Black "WildBreath"]
+[Result "1-0"]
+[ECO "C54"]
+[WhiteElo "2319"]
+[BlackElo "2428"]
+[PlyCount "37"]
+[EventDate "2020.??.??"]
+
+1. e4 e5 2. Nf3 Nc6 3. Bc4 Bc5 4. c3 Nf6 5. d4 exd4 6. cxd4 Bb4+ 7. Bd2 Bxd2+
+8. Nbxd2 d5 9. O-O dxc4 10. Nxc4 Bg4 11. d5 Ne7 12. d6 cxd6 13. Nxd6+ Kf8 14.
+e5 Nfd5 15. h3 Bxf3 16. Qxf3 f6 17. Rad1 Kg8 18. Rxd5 Nxd5 19. Qxd5+ 1-0
+
+[Event "Rated Bullet tournament GAdGz1co"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Zuritadas"]
+[Black "RaylessStarfish"]
+[Result "0-1"]
+[ECO "A19"]
+[WhiteElo "2395"]
+[BlackElo "2386"]
+[PlyCount "110"]
+[EventDate "2020.??.??"]
+
+1. c4 Nf6 2. Nc3 e6 3. e4 c5 4. Nf3 Nc6 5. e5 Ng4 6. d4 cxd4 7. Nb5 Ngxe5 8.
+Bf4 Nxf3+ 9. Qxf3 Bb4+ 10. Kd1 O-O 11. a3 Be7 12. Bc7 Qe8 13. Nd6 Bxd6 14. Bxd6
+Ne7 15. Bd3 f5 16. h4 Rf7 17. h5 Nc6 18. g4 fxg4 19. Qxg4 Qd8 20. f4 Qf6 21.
+Kc2 b6 22. Rag1 h6 23. Bg6 Re7 24. Bxe7 Nxe7 25. f5 exf5 26. Qf3 Rb8 27. Qf4 d6
+28. Re1 Bb7 29. Rhf1 Be4+ 30. Kd2 d5 31. Qxb8+ Qf8 32. Bh7+ Kf7 33. Qxf8+ Kxf8
+34. Rxe4 dxe4 35. Bxf5 e3+ 36. Kd3 Kf7 37. Bg6+ Ke6 38. Kxd4 e2 39. Re1 Nc6+
+40. Kc3 Kf6 41. Rxe2 Na5 42. b4 Nb7 43. Re8 Nd6 44. Ra8 Nf5 45. Rxa7 Ne3 46.
+Ra6 Kg5 47. Rxb6 Nd1+ 48. Kd4 Nf2 49. a4 Kh4 50. a5 Ng4 51. a6 Nf6 52. a7 Nd7
+53. a8=Q Nxb6 54. Qh1+ Kg5 55. Qg1+ Kf6 0-1
+
+[Event "Rated Bullet tournament GAdGz1co"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "RhenzRheann_Auza98"]
+[Black "ScherlockKA"]
+[Result "0-1"]
+[ECO "A39"]
+[WhiteElo "2390"]
+[BlackElo "2321"]
+[PlyCount "76"]
+[EventDate "2020.??.??"]
+
+1. Nf3 c5 2. g3 g6 3. Bg2 Bg7 4. O-O Nc6 5. c4 Nf6 6. Nc3 O-O 7. d4 cxd4 8.
+Nxd4 Rb8 9. b3 a6 10. Bb2 Nxd4 11. Qxd4 d6 12. Nd5 Be6 13. Rfd1 b5 14. cxb5
+axb5 15. Rac1 Nh5 16. Qd2 Bxb2 17. Qxb2 Bxd5 18. Rxd5 Qa5 19. a4 Nf6 20. Rxb5
+Rxb5 21. axb5 Qxb5 22. Rc7 e6 23. Qd2 d5 24. Qc3 Ne4 25. Bxe4 dxe4 26. Qe3 Rd8
+27. Kg2 Qe5 28. Qa7 Qf5 29. Qb7 Rd2 30. Rc8+ Kg7 31. Qb8 Rxe2 32. Rg8+ Kh6 33.
+Qf8+ Kh5 34. Qc5 Qxc5 35. g4+ Kg5 36. h4+ Kh6 37. Re8 Qxf2+ 38. Kh3 Qh2# 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "two64brocc"]
+[Black "estocastico"]
+[Result "1/2-1/2"]
+[ECO "A00"]
+[WhiteElo "2639"]
+[BlackElo "2593"]
+[PlyCount "91"]
+[EventDate "2020.??.??"]
+
+1. d3 c5 2. c4 g6 3. Nc3 Bg7 4. g3 Nf6 5. Bg2 Nc6 6. Nf3 O-O 7. a3 d6 8. O-O a5
+9. Rb1 e5 10. Bg5 h6 11. Bxf6 Bxf6 12. Nd2 Bg7 13. Nde4 Rb8 14. Nd5 Be6 15.
+Nec3 f5 16. Nb5 Kh7 17. b4 axb4 18. axb4 Bxd5 19. Bxd5 Nxb4 20. Bg2 Qe7 21. e3
+e4 22. d4 b6 23. Qd2 Nd3 24. f3 cxd4 25. exd4 Rbc8 26. Rb3 Rxc4 27. fxe4 fxe4
+28. Rxf8 Bxf8 29. Bxe4 Qxe4 30. Rxd3 Rc1+ 31. Qxc1 Qxd3 32. Qc7+ Bg7 33. Nxd6
+Qxd4+ 34. Kg2 Qc5 35. Qxc5 bxc5 36. Kf3 Kg8 37. Ke4 Bf8 38. Nb7 Kf7 39. Kd5 Kf6
+40. Nxc5 Bxc5 41. Kxc5 Kf5 42. Kd5 Kg4 43. Ke5 Kh3 44. Kf6 Kxh2 45. Kxg6 Kxg3
+46. Kxh6 1/2-1/2
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "BerserkAdopter"]
+[Black "imdejong"]
+[Result "1-0"]
+[ECO "C00"]
+[WhiteElo "2433"]
+[BlackElo "2356"]
+[PlyCount "61"]
+[EventDate "2020.??.??"]
+
+1. e4 e6 2. d3 d5 3. Nd2 Nf6 4. Ngf3 b6 5. Qe2 Be7 6. g3 O-O 7. Bg2 c5 8. O-O
+Ba6 9. e5 Nfd7 10. Re1 Nc6 11. Nf1 b5 12. h4 b4 13. h5 h6 14. N1h2 Nd4 15. Qd1
+Nxf3+ 16. Qxf3 Qc7 17. Ng4 c4 18. d4 c3 19. b3 Kh7 20. Bf4 Rg8 21. Qe3 Bf8 22.
+a3 Qc6 23. axb4 Bxb4 24. Bxh6 Bf8 25. Bf4 Bb5 26. h6 g6 27. Bg5 a5 28. Bf1 Nb6
+29. Bxb5 Kh8 30. Bxc6 Nc4 31. bxc4 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "MonsieurPatate"]
+[Black "Rusticous"]
+[Result "0-1"]
+[ECO "B03"]
+[WhiteElo "2385"]
+[BlackElo "2334"]
+[PlyCount "68"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 Nf6 2. e5 Nd5 3. d4 d6 4. c4 Nb6 5. exd6 exd6 6. Nc3 Be7 7. Bd3 O-O 8.
+Nge2 Bg4 9. f3 Bh5 10. O-O Nc6 11. b3 Bg6 12. Bxg6 hxg6 13. Be3 Bg5 14. Bf2 Re8
+15. Qd3 Nb4 16. Qd1 Be3 17. a3 Bxf2+ 18. Rxf2 Nc6 19. Qd3 Qf6 20. Ne4 Qf4 21.
+N2g3 d5 22. cxd5 Nxd5 23. Re2 Qh4 24. Rae1 Nf4 25. Nf6+ gxf6 26. Rxe8+ Rxe8 27.
+Rxe8+ Kg7 28. Qe4 f5 29. Qe1 Qf6 30. d5 Qd4+ 31. Kh1 Qxd5 32. b4 Nd3 33. Qc3+
+f6 34. Qc5 Nxc5 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "AlexMitAlex"]
+[Black "emiliofelixramirez"]
+[Result "1-0"]
+[ECO "D02"]
+[WhiteElo "2302"]
+[BlackElo "2401"]
+[PlyCount "67"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 d5 2. Nf3 e6 3. Bf4 c5 4. e3 Nc6 5. c3 Qb6 6. Qb3 Bd7 7. Nbd2 Nf6 8. Be2
+Be7 9. O-O O-O 10. Ne5 Rfc8 11. Bg5 Be8 12. f4 cxd4 13. Qxb6 axb6 14. exd4 Na5
+15. f5 exf5 16. Rxf5 h6 17. Bh4 b5 18. a3 Nc4 19. Ndxc4 bxc4 20. Raf1 Ra6 21.
+Bxf6 Bxf6 22. Bf3 Rd8 23. Ng4 Bg5 24. Rxd5 Rc8 25. Re5 Rb6 26. Re2 Bd7 27. Ne5
+Be6 28. g3 Rd8 29. h4 Be7 30. Kg2 Bd6 31. Rfe1 Kf8 32. d5 Bf5 33. Nxc4 Rb5 34.
+Nxd6 1-0
+
+[Event "Rated Bullet tournament Ty5yUoqy"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "John-Wick"]
+[Black "vervitu"]
+[Result "1-0"]
+[ECO "A15"]
+[WhiteElo "2418"]
+[BlackElo "2324"]
+[PlyCount "69"]
+[EventDate "2020.??.??"]
+
+1. Nf3 d6 2. c4 Nf6 3. e3 e5 4. Qc2 Be7 5. Nc3 O-O 6. b3 c5 7. Bb2 Nc6 8. a3 a6
+9. Ng5 h6 10. h4 g6 11. Nge4 Bf5 12. Bd3 Nxe4 13. Nxe4 Bxe4 14. Bxe4 f5 15.
+Bd5+ Kh7 16. h5 g5 17. g4 Qd7 18. gxf5 Qxf5 19. Be4 Qxe4 20. Qxe4+ Kh8 21. Qg6
+Rf6 22. Qe4 Raf8 23. Rf1 Bd8 24. O-O-O b5 25. Qxc6 bxc4 26. bxc4 d5 27. Bxe5
+Ba5 28. Bxf6+ Rxf6 29. Qxf6+ Kg8 30. f4 g4 31. f5 g3 32. Rg1 Bxd2+ 33. Kxd2 Kh7
+34. Rxg3 d4 35. Qg7# 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Dohani"]
+[Black "Ngc99"]
+[Result "1/2-1/2"]
+[ECO "A04"]
+[WhiteElo "2376"]
+[BlackElo "2352"]
+[PlyCount "37"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. Nf3 Nf6 2. b3 c5 3. Bb2 b6 4. c4 Bb7 5. g3 d6 6. Bg2 Nbd7 7. O-O e6 8. d4
+Be7 9. dxc5 dxc5 10. Qc2 O-O 11. Nc3 Bc6 12. Rad1 Qc7 13. Rd2 Rfd8 14. Rfd1 Nf8
+15. Nb5 Qb7 16. Nd6 Qc7 17. Nb5 Qb7 18. Nd6 Qc7 19. Nb5 1/2-1/2
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Paanoos"]
+[Black "rudolf85"]
+[Result "1-0"]
+[ECO "D00"]
+[WhiteElo "2377"]
+[BlackElo "2425"]
+[PlyCount "97"]
+[EventDate "2020.??.??"]
+
+1. d4 d5 2. Nc3 c6 3. Bf4 Nf6 4. f3 Nbd7 5. Qd2 Nh5 6. Be3 e5 7. g4 Nhf6 8.
+O-O-O Bb4 9. a3 Bxc3 10. Qxc3 e4 11. g5 Nh5 12. fxe4 dxe4 13. Nh3 Nb6 14. Nf4
+Nxf4 15. Bxf4 Nd5 16. Qd2 Qe7 17. h4 e3 18. Bxe3 Qxe3 19. Bg2 Qxd2+ 20. Kxd2
+O-O 21. e4 Nf4 22. Bf3 Re8 23. Rhe1 Bd7 24. c4 Ng6 25. h5 Ne7 26. Kc3 Rad8 27.
+Rd2 f6 28. gxf6 gxf6 29. Rf2 Rf8 30. Ref1 Kh8 31. Be2 f5 32. e5 Be6 33. Bf3 Rf7
+34. Rg2 Rdf8 35. h6 f4 36. Rfg1 Nf5 37. Rh2 Ng3 38. d5 cxd5 39. cxd5 Bf5 40. e6
+Re7 41. Rh4 Bg6 42. Rxf4 Rxf4 43. Rxg3 Rf5 44. Be4 Rf6 45. Bxg6 Rxg6 46. Rf3
+Re8 47. Rf7 Rxh6 48. d6 Rhxe6 49. d7 1-0
+
+[Event "Rated Blitz tournament nLsDCFvz"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "coventry"]
+[Black "dukenebur"]
+[Result "1/2-1/2"]
+[ECO "D34"]
+[WhiteElo "2359"]
+[BlackElo "2362"]
+[PlyCount "21"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. Nf3 d5 2. d4 c5 3. c4 e6 4. cxd5 exd5 5. Nc3 Nf6 6. Bg5 Be7 7. g3 c4 8. Bg2
+O-O 9. O-O Nc6 10. Ne5 Be6 11. Rc1 1/2-1/2
+
+[Event "Rated Blitz tournament hM7PUvgg"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Club-Jaque-al-Rey"]
+[Black "Fasmc17"]
+[Result "1-0"]
+[ECO "B54"]
+[WhiteElo "2533"]
+[BlackElo "2336"]
+[PlyCount "137"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. f3 Bd7 6. c4 g6 7. Nc3 Bg7 8. Be3
+Nc6 9. Qd2 Ne5 10. Be2 h5 11. Rc1 Kf8 12. b3 Kg8 13. Nd5 e6 14. Nxf6+ Bxf6 15.
+Kf2 a6 16. h3 Bh4+ 17. g3 Be7 18. f4 Nc6 19. Bf3 e5 20. Nxc6 Bxc6 21. h4 f5 22.
+exf5 Bxf3 23. Kxf3 gxf5 24. Qd5+ Kg7 25. fxe5 dxe5 26. Qxe5+ Bf6 27. Qd5 Qe7
+28. Bc5 Qe4+ 29. Qxe4 fxe4+ 30. Kxe4 Rhe8+ 31. Kf3 Rac8 32. Be3 Bb2 33. Rcd1
+Rcd8 34. Bg5 Rf8+ 35. Kg2 Rde8 36. Rd7+ Kg6 37. Rd6+ Kh7 38. Rd2 Bc3 39. Rf2
+Rxf2+ 40. Kxf2 Bd4+ 41. Kf3 Kg6 42. Rd1 Rf8+ 43. Bf4 Be5 44. Rd5 Bxf4 45. gxf4
+Re8 46. Re5 Rd8 47. Rd5 Re8 48. Rd6+ Kf5 49. Rd7 Re1 50. Rxb7 Rf1+ 51. Ke3 Kg4
+52. Rg7+ Kxh4 53. Ke4 Ra1 54. f5 Rxa2 55. f6 Rf2 56. f7 Kh3 57. Ke5 h4 58. Ke6
+Re2+ 59. Kd7 Rd2+ 60. Ke8 Re2+ 61. Kf8 Rf2 62. Kg8 Kh2 63. f8=Q Rxf8+ 64. Kxf8
+a5 65. c5 h3 66. c6 Kh1 67. c7 a4 68. c8=Q axb3 69. Qxh3# 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "HustlersCorner"]
+[Black "PeruVirtual"]
+[Result "1-0"]
+[ECO "A04"]
+[WhiteElo "2336"]
+[BlackElo "2309"]
+[PlyCount "59"]
+[EventDate "2020.??.??"]
+
+1. Nf3 g6 2. c4 Bg7 3. Nc3 c5 4. e3 Nc6 5. d4 Nf6 6. d5 Na5 7. e4 d6 8. Bd3 O-O
+9. h3 e6 10. O-O a6 11. a4 Rb8 12. Bg5 Qb6 13. Qc2 exd5 14. exd5 Qb3 15. Qxb3
+Nxb3 16. Rae1 Bd7 17. Bf4 Ne8 18. Ne4 Rd8 19. Nxd6 Bxa4 20. Nxb7 Rd7 21. Rxe8
+Rxe8 22. Nd6 Red8 23. Ne4 h6 24. Bc2 f5 25. Bxb3 fxe4 26. Bxa4 Rf7 27. Ne5 Rxf4
+28. Nxg6 Rf7 29. Nh4 Bxb2 30. d6 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "lord_barre"]
+[Black "MrMania"]
+[Result "1-0"]
+[ECO "B52"]
+[WhiteElo "2409"]
+[BlackElo "2385"]
+[PlyCount "97"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 c5 2. Nf3 d6 3. Bb5+ Bd7 4. a4 Bxb5 5. axb5 Nf6 6. Nc3 Nbd7 7. O-O g6 8.
+Re1 Bg7 9. d3 O-O 10. Nd5 Nxd5 11. exd5 Nb6 12. c4 Nd7 13. Ra2 Qc7 14. Rxe7 Qd8
+15. Re1 Ne5 16. Bf4 Nxf3+ 17. Qxf3 Bd4 18. b3 a6 19. bxa6 Rxa6 20. Rxa6 bxa6
+21. Qg3 Re8 22. Rxe8+ Qxe8 23. Be3 Bxe3 24. Qxe3 Qb8 25. d4 cxd4 26. Qd3 a5 27.
+g3 Qb6 28. Kg2 h5 29. Kf3 Kg7 30. Ke4 f5+ 31. Kf4 Kf6 32. h4 Qc5 33. f3 Qb6 34.
+g4 fxg4 35. fxg4 hxg4 36. Kxg4 Qa7 37. Qe4 Qd7+ 38. Kg3 Qa7 39. Qe6+ Kg7 40.
+Qxd6 d3 41. Qe5+ Kh7 42. d6 Qg1+ 43. Kf3 d2 44. Qe7+ Kh6 45. Qg5+ Qxg5 46.
+hxg5+ Kg7 47. Ke2 Kf7 48. Kxd2 Ke6 49. c5 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Akylbekov_Nasir"]
+[Black "WildBreath"]
+[Result "1-0"]
+[ECO "C47"]
+[WhiteElo "2301"]
+[BlackElo "2421"]
+[PlyCount "111"]
+[EventDate "2020.??.??"]
+
+1. e4 e5 2. Nf3 Nc6 3. Nc3 Nf6 4. d4 exd4 5. Nxd4 Bb4 6. Nxc6 bxc6 7. Bd3 d5 8.
+exd5 cxd5 9. O-O O-O 10. Bg5 c6 11. Qf3 Be7 12. Rae1 h6 13. Bxh6 gxh6 14. Qe3
+Re8 15. Qxh6 Bf8 16. Rxe8 Qxe8 17. Qxf6 Bg7 18. Qh4 Rb8 19. Nd1 c5 20. b3 Be6
+21. Ne3 Qc8 22. Qh7+ Kf8 23. Nf5 Bxf5 24. Bxf5 Qe8 25. Bd3 a5 26. a4 c4 27.
+bxc4 d4 28. Qf5 Qxa4 29. h4 Qc6 30. Qxa5 Qf6 31. Qg5 Qxg5 32. hxg5 f6 33. f4
+fxg5 34. fxg5+ Ke7 35. g6 Be5 36. Rf7+ Kd6 37. Rf5 Rg8 38. c5+ Kd5 39. c6 Rxg6
+40. Rxe5+ Kxe5 41. Bxg6 Kd6 42. Bd3 Kxc6 43. Kf2 Kc5 44. Kf3 Kd6 45. Kf4 Kc5
+46. Ke4 Kb4 47. Kxd4 Ka3 48. g4 Kb2 49. g5 Kc1 50. g6 Kd2 51. g7 Kc1 52. g8=Q
+Kb2 53. Qb3+ Kc1 54. c4 Kd2 55. Qc2+ Ke1 56. Qe2# 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "BillyLaimbeer"]
+[Black "victor325"]
+[Result "1-0"]
+[ECO "D15"]
+[WhiteElo "2376"]
+[BlackElo "2313"]
+[PlyCount "101"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. Nf3 d5 2. d4 Nf6 3. c4 c6 4. Nc3 a6 5. a4 e6 6. e3 a5 7. Bd3 Na6 8. O-O Nb4
+9. Bb1 b6 10. e4 Ba6 11. exd5 Bxc4 12. dxe6 Bxf1 13. exf7+ Kxf7 14. Kxf1 Bd6
+15. Bf5 Re8 16. Ng5+ Kg8 17. Be6+ Rxe6 18. Nxe6 Qd7 19. Ng5 Qf5 20. Kg1 Ng4 21.
+Qb3+ Nd5 22. f3 Bxh2+ 23. Kh1 Bg3 24. Bd2 Nf2+ 25. Kg1 h6 26. Nge4 Nxe4 27.
+Nxe4 Bc7 28. Rc1 Qg6 29. Qc2 Kh8 30. Qxc6 Qxc6 31. Rxc6 Bd8 32. Rd6 Nf6 33.
+Nxf6 Bxf6 34. Bc3 Rb8 35. Kf2 Kg8 36. Rc6 Kf7 37. g4 Ke7 38. Ke3 Kd7 39. Rc4
+Rc8 40. Rxc8 Kxc8 41. Ke4 Kd7 42. Kd5 Kc7 43. Ke6 Kc6 44. d5+ Kc5 45. Bxf6 gxf6
+46. d6 b5 47. axb5 Kxb5 48. d7 Kb4 49. d8=Q Kb3 50. Qxa5 Kxb2 51. Qf5 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "mixo23"]
+[Black "Dimitriy1975"]
+[Result "0-1"]
+[ECO "A02"]
+[WhiteElo "2415"]
+[BlackElo "2389"]
+[PlyCount "94"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. f4 c5 2. Nf3 g6 3. e4 Bg7 4. Bc4 Nc6 5. O-O e6 6. d3 Nge7 7. Qe1 O-O 8. f5
+d5 9. Bb3 dxe4 10. dxe4 exf5 11. Nc3 Nd4 12. Nxd4 cxd4 13. Nd5 fxe4 14. Qxe4
+Nxd5 15. Bxd5 Bf5 16. Rxf5 gxf5 17. Qxf5 Qf6 18. Qxf6 Bxf6 19. Bxb7 Rab8 20.
+Ba6 d3 21. Bxd3 Bxb2 22. Bxb2 Rxb2 23. a4 Rfb8 24. Kf2 Kg7 25. a5 R2b4 26. a6
+R4b6 27. g3 Rd8 28. Ra3 Rd7 29. Ra5 h6 30. Ke3 Re6+ 31. Kd2 Rb6 32. Rf5 Rxa6
+33. Ke3 Re6+ 34. Kd2 Rf6 35. Rh5 Rf2+ 36. Ke3 Rf6 37. c4 Re6+ 38. Be4 Rde7 39.
+Rh4 f5 40. c5 Rxe4+ 41. Kd3 Rxh4 42. gxh4 Kf6 43. c6 Rc7 44. Kc4 Rxc6+ 45. Kd5
+Rb6 46. h5 Rb8 47. h4 a6 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "vava05"]
+[Black "Akali666"]
+[Result "0-1"]
+[ECO "C21"]
+[WhiteElo "2404"]
+[BlackElo "2521"]
+[PlyCount "32"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 e5 2. d4 exd4 3. c3 dxc3 4. Nxc3 Nc6 5. Nf3 d6 6. Bc4 Nf6 7. Ng5 Ne5 8.
+Bb3 h6 9. Nf3 Be7 10. Bf4 Ng6 11. Bg3 O-O 12. h3 Nh5 13. Bh2 Nhf4 14. O-O c6
+15. Qd2 Bg5 16. Nxg5 Qxg5 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "BlueGreensun"]
+[Black "Kidefence"]
+[Result "1-0"]
+[ECO "B03"]
+[WhiteElo "2743"]
+[BlackElo "2723"]
+[PlyCount "99"]
+[EventDate "2020.??.??"]
+
+1. e4 Nf6 2. e5 Nd5 3. c4 Nb6 4. d4 d6 5. f4 Bf5 6. Nc3 e6 7. Nf3 Nc6 8. Be2
+dxe5 9. fxe5 Bb4 10. O-O O-O 11. Bg5 Be7 12. Be3 Bg4 13. h3 Bh5 14. b3 Qd7 15.
+Qe1 Bxf3 16. Bxf3 Nxd4 17. Rd1 Nxf3+ 18. Rxf3 Qc6 19. Rg3 Bc5 20. Bxc5 Qxc5+
+21. Kh2 Rad8 22. Rxd8 Rxd8 23. Rg5 h6 24. Ne4 Qd4 25. Nf6+ Kf8 26. Nh7+ Kg8 27.
+Nf6+ Kh8 28. Qg3 gxf6 29. Rh5 Qd2 30. Qh4 fxe5 31. Rxh6+ Kg8 32. Rh8+ Kg7 33.
+Rxd8 Qf4+ 34. Qxf4 exf4 35. Rb8 e5 36. Rxb7 e4 37. Rxc7 Kf6 38. Kg1 e3 39. Kf1
+Ke5 40. Ke2 f5 41. Re7+ Kf6 42. Rxa7 Nd7 43. Rxd7 Ke5 44. Rd5+ Ke4 45. Rd7 f3+
+46. gxf3+ Kf4 47. Rd4+ Kg3 48. Kxe3 f4+ 49. Rxf4 Kxh3 50. Rg4 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "hungzhao"]
+[Black "chesslismab"]
+[Result "1-0"]
+[ECO "B03"]
+[WhiteElo "2625"]
+[BlackElo "2448"]
+[PlyCount "59"]
+[EventDate "2020.??.??"]
+
+1. e4 Nf6 2. e5 Nd5 3. d4 Nb6 4. a4 d5 5. a5 N6d7 6. e6 fxe6 7. f4 Nf6 8. Nf3
+c5 9. c3 cxd4 10. cxd4 Nc6 11. Ne5 Nxa5 12. Nc3 Nc6 13. Be3 Bd7 14. Bd3 a6 15.
+O-O Nb4 16. Be2 Qb6 17. Kh1 O-O-O 18. Qd2 Kb8 19. Nf7 Rg8 20. Nxd8 Qxd8 21. f5
+exf5 22. Bf4+ Ka8 23. Nb5 Bxb5 24. Bxb5 e6 25. Ra4 Ne4 26. Qe1 Qb6 27. Rxb4
+Bxb4 28. Qxb4 Qxb5 29. Qxb5 axb5 30. Ra1# 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Bigbier"]
+[Black "kingcobra23"]
+[Result "0-1"]
+[ECO "D15"]
+[WhiteElo "2371"]
+[BlackElo "2318"]
+[PlyCount "40"]
+[EventDate "2020.??.??"]
+
+1. d4 d5 2. c4 c6 3. Nf3 Nf6 4. Nc3 Bf5 5. cxd5 cxd5 6. Qb3 Qb6 7. Nxd5 Nxd5 8.
+Qxd5 e6 9. Qb3 Nc6 10. Qxb6 axb6 11. Bd2 Nb4 12. Bxb4 Bxb4+ 13. Kd1 Ke7 14. e3
+Rhc8 15. Bb5 Rc2 16. Nh4 Rxb2 17. Nxf5+ exf5 18. Rf1 Rd2+ 19. Kc1 Rc8+ 20. Kb1
+Ba3 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "fusionpro"]
+[Black "FedaMaster"]
+[Result "1-0"]
+[ECO "E62"]
+[WhiteElo "2433"]
+[BlackElo "2567"]
+[PlyCount "141"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 Nf6 2. g3 g6 3. Bg2 Bg7 4. c4 d6 5. Nf3 O-O 6. O-O Nc6 7. Nc3 e5 8. dxe5
+dxe5 9. Bg5 h6 10. Be3 Re8 11. Qc1 Ng4 12. Bc5 Nd4 13. e3 Ne6 14. Ba3 c6 15.
+Rd1 Qb6 16. Ne4 f5 17. c5 fxe4 18. cxb6 exf3 19. Bxf3 Ng5 20. Bg2 e4 21. h3 Ne5
+22. bxa7 Nxh3+ 23. Bxh3 Bxh3 24. Kh2 Bg4 25. Qc5 Bf3 26. Rd6 Ng4+ 27. Kg1 Re5
+28. Qxe5 Nxe5 29. Rxg6 Ng4 30. Rxg4 Bxg4 31. Bc5 Bf3 32. a4 Bf6 33. a5 Kf7 34.
+Bb6 Be5 35. Rc1 Bb8 36. Rc5 Ke6 37. axb8=Q Rxb8 38. Rh5 Rg8 39. Rxh6+ Kf7 40.
+Rh4 Kg7 41. Kf1 Kf7 42. Ke1 Ke7 43. Kd2 Ke6 44. Rh6+ Ke7 45. Rh4 Kf7 46. Rf4+
+Ke8 47. Rxe4+ Kd7 48. Rf4 Ke7 49. Rxf3 Ke6 50. Rf4 Kd5 51. g4 Kd6 52. Rd4+ Ke6
+53. Kc3 Ke5 54. Re4+ Kf6 55. Rf4+ Kg7 56. g5 Kh7 57. Rg4 Kg7 58. Rh4 Kg6 59.
+Rg4 Kg7 60. Rg3 Kf7 61. f4 Kg7 62. f5 Kf8 63. g6 Ke8 64. f6 Kd7 65. f7 Kd6 66.
+g7 Ke6 67. fxg8=Q+ Kd7 68. Qf7+ Kd6 69. g8=Q Ke5 70. Qg5+ Ke4 71. Rg4# 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Betovsky"]
+[Black "taras05"]
+[Result "0-1"]
+[ECO "A40"]
+[WhiteElo "2643"]
+[BlackElo "2469"]
+[PlyCount "74"]
+[EventDate "2020.??.??"]
+
+1. d4 g6 2. h4 Bg7 3. h5 Nf6 4. h6 Bf8 5. c4 d6 6. Nc3 Nbd7 7. e4 e5 8. Be3 Be7
+9. Be2 O-O 10. Nh3 Re8 11. Ng5 exd4 12. Bxd4 Nc5 13. Qc2 Ne6 14. Nxe6 Bxe6 15.
+O-O-O Nd7 16. Kb1 Bg5 17. g3 Bf6 18. f4 Bxd4 19. Rxd4 Qf6 20. Rdd1 Nc5 21. Bf3
+Rad8 22. b3 c6 23. Rhe1 Rd7 24. Qb2 Red8 25. Qa3 Qxc3 26. Qb2 Qxf3 27. Qd4 f5
+28. Re3 Qg4 29. exf5 Bxf5+ 30. Kb2 Qh5 31. Rde1 Qxh6 32. Re8+ Rxe8 33. Rxe8+
+Kf7 34. Qe3 Qg7+ 35. Ka3 Nd3 36. Ra8 Qb2+ 37. Ka4 Qxa2# 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "vassiukov"]
+[Black "vaillant77"]
+[Result "0-1"]
+[ECO "A48"]
+[WhiteElo "2352"]
+[BlackElo "2440"]
+[PlyCount "112"]
+[EventDate "2020.??.??"]
+
+1. d4 Nf6 2. Nf3 g6 3. Bf4 Bg7 4. e3 O-O 5. Nbd2 d6 6. c3 Nbd7 7. h3 Re8 8. Be2
+c6 9. O-O e5 10. dxe5 dxe5 11. Bh2 Qe7 12. Re1 Nf8 13. Qc2 Bf5 14. e4 Be6 15.
+Nxe5 Rad8 16. Nef3 Bh6 17. Rad1 Nh5 18. Bf1 Qf6 19. e5 Qf5 20. Ne4 Bd5 21. g4
+Qxf3 22. Bg2 Bxe4 23. Bxf3 Bxc2 24. Rxd8 Rxd8 25. gxh5 Ne6 26. hxg6 hxg6 27.
+Kg2 Bf4 28. Bg1 Bf5 29. h4 g5 30. h5 g4 31. Bd1 Kg7 32. Bb3 Kh6 33. a4 Kxh5 34.
+f3 gxf3+ 35. Kxf3 Bg4+ 36. Ke4 Kg5 37. Bxa7 b6 38. Bxb6 Bf5+ 39. Kf3 Bg4+ 40.
+Ke4 Rb8 41. a5 Re8 42. Bc4 f5+ 43. Kd3 Bg3 44. Rg1 Nf4+ 45. Kc2 Bh2 46. Rh1 Bg1
+47. Rxg1 Rxe5 48. a6 Nd5 49. a7 Ne3+ 50. Kb3 Rb5+ 51. Bxb5 Nc4 52. a8=Q Nd2+
+53. Ka3 Ne4 54. Qxc6 Kf4 55. Qg6 Nc5 56. Qxg4+ fxg4 0-1
+
+[Event "Rated Bullet tournament Ty5yUoqy"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "vervitu"]
+[Black "Superman89"]
+[Result "0-1"]
+[ECO "B20"]
+[WhiteElo "2320"]
+[BlackElo "2328"]
+[PlyCount "86"]
+[EventDate "2020.??.??"]
+
+1. e4 c5 2. b4 cxb4 3. a3 bxa3 4. Bxa3 d6 5. d4 Nc6 6. c3 g6 7. Bd3 Bg7 8. Ne2
+Nf6 9. O-O Bg4 10. d5 Bxe2 11. Qxe2 Ne5 12. Nd2 Nxd3 13. Qxd3 O-O 14. Bb2 a6
+15. Rac1 Rc8 16. c4 Nd7 17. Bxg7 Kxg7 18. Nf3 Ne5 19. Nxe5 dxe5 20. Qc3 f6 21.
+f4 exf4 22. Rxf4 Qc7 23. Rff1 Qc5+ 24. Kh1 b5 25. e5 Qxc4 26. exf6+ exf6 27.
+Qe3 Qxd5 28. Qe7+ Rf7 29. Qxf7+ Kxf7 30. Rxc8 Qd3 31. Rc7+ Ke6 32. Rfc1 g5 33.
+R7c6+ Kf5 34. h3 Kg6 35. Rc7 b4 36. Rf1 b3 37. Rcc1 b2 38. Rcd1 Qd4 39. Rxd4 a5
+40. Ra4 b1=Q 41. Rxa5 Qxf1+ 42. Kh2 Qf4+ 43. Kh1 Qe3 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "alireza3700"]
+[Black "Aisen_Mestnikov"]
+[Result "0-1"]
+[ECO "D00"]
+[WhiteElo "2358"]
+[BlackElo "2372"]
+[PlyCount "48"]
+[EventDate "2020.??.??"]
+
+1. d4 d5 2. Nc3 c6 3. Bg5 f6 4. Bh4 Qb6 5. f3 Qxb2 6. Na4 Qb4+ 7. c3 Qa5 8. e4
+e5 9. dxe5 fxe5 10. exd5 cxd5 11. Rb1 Nf6 12. Bb5+ Bd7 13. Bxf6 gxf6 14. Qxd5
+Bxb5 15. Rxb5 Qxa4 16. Qxb7 Bd6 17. Qxa8 Qxb5 18. Ne2 O-O 19. O-O Nd7 20. Qe4
+Nc5 21. Qg4+ Kf7 22. Ng3 Ne6 23. Nf5 Bc5+ 24. Kh1 Qxf1# 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "pro100still"]
+[Black "Sergei_Yudin01"]
+[Result "1-0"]
+[ECO "C55"]
+[WhiteElo "2362"]
+[BlackElo "2329"]
+[PlyCount "37"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 e5 2. Nf3 Nc6 3. Bc4 Be7 4. O-O Nf6 5. d4 exd4 6. e5 Ne4 7. Re1 Nc5 8.
+Nxd4 Nxd4 9. Qxd4 Ne6 10. Qd3 O-O 11. Nc3 b6 12. Bd5 c6 13. Be4 g6 14. Bh6 Re8
+15. Rad1 Nc5 16. Qf3 Nxe4 17. Nxe4 d5 18. exd6 Bxd6 19. Nf6+ 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Mondesespoir2700"]
+[Black "yaguigor"]
+[Result "0-1"]
+[ECO "B31"]
+[WhiteElo "2432"]
+[BlackElo "2441"]
+[PlyCount "54"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 c5 2. Nf3 Nc6 3. Bb5 g6 4. Bxc6 dxc6 5. O-O Bg7 6. d3 b6 7. a4 a5 8. Nbd2
+e5 9. Rb1 Ne7 10. Nc4 f6 11. h3 O-O 12. Nh2 g5 13. Ng4 Be6 14. Nce3 Qd7 15. Nh2
+Ng6 16. Qf3 Nf4 17. Neg4 h5 18. Ne3 Qf7 19. b3 Qg6 20. Kh1 Bh6 21. Nc4 g4 22.
+hxg4 hxg4 23. Qg3 Ne2 24. Qh4 Bg5 25. Nxe5 Qg7 26. Bxg5 fxg5 27. Qh5 Nf4 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "sutcunuri"]
+[Black "ajedrez2021"]
+[Result "1-0"]
+[ECO "A10"]
+[WhiteElo "2519"]
+[BlackElo "2594"]
+[PlyCount "73"]
+[EventDate "2020.??.??"]
+
+1. c4 g6 2. Nc3 Bg7 3. g3 c5 4. Bg2 d5 5. Nf3 d4 6. Ne4 Nf6 7. Nxc5 O-O 8. Nb3
+e5 9. Nxe5 Nc6 10. Nxc6 bxc6 11. Bxc6 Bh3 12. Bxa8 Qxa8 13. f3 d3 14. e3 g5 15.
+Kf2 g4 16. Nc5 Rc8 17. Nxd3 gxf3 18. Ke1 Ng4 19. Nf2 Bg2 20. Nxg4 Bxh1 21. Kf2
+Bg2 22. Kg1 f2+ 23. Nxf2 Bf3 24. Qf1 Rb8 25. Rb1 Qc6 26. b3 Qg6 27. Bb2 h5 28.
+Bxg7 h4 29. Be5 Re8 30. Bf4 Rd8 31. Nh3 Rxd2 32. Re1 Qe4 33. Nf2 Qf5 34. Rd1
+Bxd1 35. Nxd1 Qc2 36. Nf2 Re2 37. Kg2 1-0
+
+[Event "Rated Rapid game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Mivo11"]
+[Black "Fleetwood_Mac"]
+[Result "0-1"]
+[ECO "B33"]
+[WhiteElo "2432"]
+[BlackElo "2486"]
+[PlyCount "70"]
+[EventDate "2020.??.??"]
+[EventType "rapid"]
+
+1. e4 c5 2. Nf3 e6 3. Nc3 Nc6 4. d4 cxd4 5. Nxd4 Nf6 6. Ndb5 d6 7. Bf4 e5 8.
+Bg5 a6 9. Na3 b5 10. Bxf6 gxf6 11. Nd5 Be6 12. g3 Bg7 13. Bg2 O-O 14. O-O Ne7
+15. c4 Bxd5 16. cxd5 f5 17. exf5 Nxf5 18. Qd3 Ne7 19. Nc2 f5 20. a4 e4 21. Qb3
+bxa4 22. Rxa4 Rb8 23. Rb4 a5 24. Rb5 Qc7 25. Na3 Bd4 26. Nc4 Bc5 27. Nxa5 Rxb5
+28. Qxb5 Rb8 29. Qa4 Rxb2 30. g4 Bxf2+ 31. Rxf2 Qa7 32. Kh1 Rxf2 33. gxf5 Rxf5
+34. Qxe4 Qxa5 35. Qe6+ Kf8 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "zpxocivubyntmraeswdq"]
+[Black "elpepinillo14"]
+[Result "1-0"]
+[ECO "A20"]
+[WhiteElo "2685"]
+[BlackElo "2579"]
+[PlyCount "79"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. c4 e5 2. g3 Nf6 3. Bg2 d5 4. cxd5 Nxd5 5. Nf3 Nc6 6. O-O Be7 7. Nc3 Nb6 8.
+a3 O-O 9. b4 Be6 10. Rb1 f6 11. d3 a5 12. b5 Nd4 13. Nd2 c6 14. bxc6 Nxc6 15.
+Nce4 a4 16. Bb2 Ra5 17. Bc3 Ra8 18. Nc4 Nxc4 19. dxc4 Qxd1 20. Rfxd1 Bxa3 21.
+Rxb7 Nd4 22. Bxd4 exd4 23. Rxd4 Rfc8 24. Nd6 Bc5 25. Re4 Bxd6 26. Rxe6 Bf8 27.
+Bd5 a3 28. Re8+ Kh8 29. Rxc8 Rxc8 30. Ra7 Bc5 31. Ra6 Rb8 32. Kg2 h5 33. Ra5
+Bb4 34. Ra4 Bc5 35. Bf7 Rb2 36. Bg6 Kg8 37. Ra8+ Bf8 38. c5 a2 39. c6 Rxe2 40.
+c7 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Alex_Rosario"]
+[Black "Training88"]
+[Result "0-1"]
+[ECO "A04"]
+[WhiteElo "2343"]
+[BlackElo "2334"]
+[PlyCount "72"]
+[EventDate "2020.??.??"]
+
+1. Nf3 g6 2. d4 Bg7 3. c4 d6 4. Nc3 a6 5. e4 Nd7 6. Be2 c5 7. O-O cxd4 8. Nxd4
+Nc5 9. f3 Nf6 10. Be3 O-O 11. Qd2 Ne6 12. Rac1 Nxd4 13. Bxd4 Qc7 14. Kh1 Be6
+15. b3 Rac8 16. Rfd1 Qb8 17. Qe3 Rfd8 18. c5 dxc5 19. Bxc5 Rxd1+ 20. Rxd1 Nh5
+21. Nd5 Bxd5 22. Rxd5 e6 23. Rd1 Qc7 24. Bb6 Qc2 25. g4 Nf6 26. Rd2 Qc1+ 27.
+Kg2 Rc3 28. Bd3 h6 29. Bd4 Rc8 30. Bb2 Qc6 31. a4 Kh7 32. Bc4 b5 33. axb5 axb5
+34. Be2 Qc5 35. Bd4 Qb4 36. h4 Rd8 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "RigelStar"]
+[Black "abraniel"]
+[Result "0-1"]
+[ECO "D11"]
+[WhiteElo "2410"]
+[BlackElo "2402"]
+[PlyCount "38"]
+[EventDate "2020.??.??"]
+
+1. d4 c6 2. e3 d5 3. Nf3 Nf6 4. c4 g6 5. Nc3 Bg7 6. Qb3 O-O 7. cxd5 Nxd5 8. Ne5
+Bxe5 9. dxe5 Nxc3 10. bxc3 Nd7 11. f4 Nc5 12. Qa3 Nd3+ 13. Ke2 Bg4+ 14. Kd2
+Nf2+ 15. Kc2 Qd1+ 16. Kb2 Nxh1 17. Bc4 b5 18. Bb3 Qe2+ 19. Kb1 Bf5+ 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Frogkiller"]
+[Black "InsaneTryhard"]
+[Result "1-0"]
+[ECO "A00"]
+[WhiteElo "2366"]
+[BlackElo "2378"]
+[PlyCount "77"]
+[EventDate "2020.??.??"]
+
+1. g3 h5 2. Bg2 h4 3. gxh4 d5 4. Nf3 Nc6 5. d4 Nh6 6. Bf4 Nf5 7. Bg3 e6 8. c3
+Be7 9. Nbd2 Nxh4 10. Nxh4 Bxh4 11. Nf3 Bf6 12. Qc2 Bd7 13. e4 dxe4 14. Qxe4 Na5
+15. O-O Bc6 16. Qe2 Bd5 17. Rfe1 Qd7 18. Ne5 Qa4 19. b3 Qa3 20. c4 Bxg2 21.
+Kxg2 O-O-O 22. Nxf7 Bxd4 23. Rad1 Qc5 24. Nxh8 Qc6+ 25. Qf3 Rxh8 26. Qxc6 Nxc6
+27. Rxe6 Bf6 28. Rde1 Kd7 29. R6e4 a5 30. Rd1+ Kc8 31. Rd5 Nb4 32. Rxa5 Kd7 33.
+Rb5 Nxa2 34. Rxb7 Nc3 35. Rxc7+ Kd8 36. Re1 Rh5 37. Ra1 Be5 38. Bxe5 Rxe5 39.
+Rxg7 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "pmlmail"]
+[Black "LaBandaDelHacha"]
+[Result "1-0"]
+[ECO "C41"]
+[WhiteElo "2468"]
+[BlackElo "2320"]
+[PlyCount "77"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 Nf6 2. Nf3 d6 3. Nc3 Nbd7 4. e4 e5 5. Bc4 Be7 6. h3 O-O 7. a4 c6 8. O-O
+Qc7 9. Bg5 h6 10. Bh4 Re8 11. Bb3 b6 12. d5 Bb7 13. dxc6 Bxc6 14. Re1 Qb7 15.
+Qe2 a6 16. Qc4 Rf8 17. Nd5 Bxd5 18. exd5 Rac8 19. Qe2 Nc5 20. Bc4 b5 21. axb5
+axb5 22. Bxb5 Nxd5 23. Bxe7 Qxe7 24. c4 Nf4 25. Qf1 Qf6 26. b4 Ncd3 27. Re3
+Nxb4 28. Ra7 Nc2 29. Rc3 Nd4 30. Nxd4 exd4 31. Rf3 Qe5 32. g3 Ne6 33. Bd7 Nc5
+34. Bxc8 Rxc8 35. Rfxf7 Ne6 36. Qd3 Kh8 37. Qg6 Rg8 38. Rae7 Qg5 39. Rxe6 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "irakliberadze"]
+[Black "Maxterlopez"]
+[Result "0-1"]
+[ECO "C47"]
+[WhiteElo "2663"]
+[BlackElo "2667"]
+[PlyCount "28"]
+[EventDate "2020.??.??"]
+
+1. e4 e5 2. Nf3 Nc6 3. Nc3 Nf6 4. d4 exd4 5. Nxd4 Bb4 6. Nxc6 bxc6 7. Bd3 O-O
+8. O-O d5 9. exd5 Nxd5 10. Bg5 Qxg5 11. Nxd5 cxd5 12. c4 dxc4 13. Qc2 cxd3 14.
+Qb3 Bd6 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "SuperDonald"]
+[Black "BorisBulto"]
+[Result "0-1"]
+[ECO "D10"]
+[WhiteElo "2334"]
+[BlackElo "2378"]
+[PlyCount "48"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 d5 2. c4 c6 3. cxd5 cxd5 4. Bf4 Nc6 5. e3 Nf6 6. Nc3 a6 7. Be2 Bf5 8. Nf3
+e6 9. Qb3 Ra7 10. O-O b5 11. Rfc1 Na5 12. Qd1 Bd6 13. Ne5 O-O 14. Bd3 Bxd3 15.
+Qxd3 Qe7 16. a4 b4 17. Nd1 Rfa8 18. h3 Rc7 19. Bg5 Rac8 20. Rxc7 Qxc7 21. Qxa6
+Nb3 22. Rb1 Ne4 23. Bf4 Ned2 24. Nc6 Qxc6 0-1
+
+[Event "Rated Bullet tournament GAdGz1co"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "ScherlockKA"]
+[Black "Zuritadas"]
+[Result "0-1"]
+[ECO "D02"]
+[WhiteElo "2328"]
+[BlackElo "2389"]
+[PlyCount "104"]
+[EventDate "2020.??.??"]
+
+1. d4 Nf6 2. Nf3 d5 3. c4 e6 4. cxd5 exd5 5. e3 Bf5 6. h3 c6 7. Qb3 Qb6 8. Nc3
+Bd6 9. Bd2 O-O 10. Na4 Qxb3 11. axb3 Nbd7 12. Be2 b5 13. Nc3 a5 14. O-O Nb6 15.
+Rfc1 Rfc8 16. Nd1 a4 17. bxa4 Rxa4 18. b3 Rxa1 19. Rxa1 Bc2 20. Ra6 Rb8 21. Ba5
+Nfd7 22. Ne5 Bxe5 23. dxe5 Bxb3 24. Nc3 Bc4 25. Bg4 h5 26. Bf5 g6 27. e6 gxf5
+28. exd7 Nxd7 29. Rxc6 b4 30. Nxd5 Bxd5 31. Rd6 Be6 32. g4 b3 33. gxf5 Bxf5 34.
+Bc3 Be6 35. Bb2 Rc8 36. Kh2 Rc2 37. Bd4 b2 38. Bxb2 Rxb2 39. Kg3 Rb5 40. f4 Rf5
+41. Ra6 Nf6 42. Kf3 Bd5+ 43. Kf2 Ne4+ 44. Ke2 Rf6 45. Ra5 Kg7 46. Rxd5 Nc3+ 47.
+Kd3 Nxd5 48. Kd4 Nxf4 49. exf4 Rxf4+ 50. Ke3 Rh4 51. Ke2 Rxh3 52. Kf2 Rh4 0-1
+
+[Event "Rated Bullet tournament GAdGz1co"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "RaylessStarfish"]
+[Black "JeanGoulifet"]
+[Result "0-1"]
+[ECO "A11"]
+[WhiteElo "2392"]
+[BlackElo "2403"]
+[PlyCount "74"]
+[EventDate "2020.??.??"]
+
+1. c4 c6 2. g3 d5 3. cxd5 cxd5 4. Bg2 Nf6 5. Nf3 Nc6 6. O-O Bf5 7. d4 e6 8. Nc3
+Be7 9. Ne5 O-O 10. Nxc6 bxc6 11. Qa4 c5 12. Be3 c4 13. f3 Rb8 14. Bf2 Rxb2 15.
+e4 Bg6 16. e5 Nd7 17. f4 Qb6 18. g4 Qb7 19. f5 exf5 20. Nxd5 Nb6 21. Qa5 Qd7
+22. Nxe7+ Qxe7 23. Qc3 Rb5 24. gxf5 Bxf5 25. Qf3 Bd3 26. Rfe1 Nd5 27. Qg3 Nc3
+28. Be3 Ne2+ 29. Rxe2 Bxe2 30. Bg5 f6 31. exf6 Qf7 32. fxg7 Re8 33. a4 Rf5 34.
+h4 Bd3 35. Kh2 Qxg7 36. Rc1 h6 37. Qg4 hxg5 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "estocastico"]
+[Black "DoctorFromGallifrey"]
+[Result "0-1"]
+[ECO "E60"]
+[WhiteElo "2594"]
+[BlackElo "2547"]
+[PlyCount "78"]
+[EventDate "2020.??.??"]
+
+1. d4 Nf6 2. Nf3 g6 3. c4 Bg7 4. Nc3 O-O 5. e4 d6 6. h3 e5 7. d5 a5 8. g4 Na6
+9. Rg1 Nc5 10. Nd2 c6 11. g5 Nh5 12. Nb3 cxd5 13. Nxc5 d4 14. N5a4 dxc3 15.
+Nxc3 Nf4 16. Be3 Nxh3 17. Bxh3 Bxh3 18. Rh1 Be6 19. b3 a4 20. Rb1 axb3 21. axb3
+f5 22. gxf6 Qxf6 23. Nd5 Bxd5 24. Qxd5+ Rf7 25. Ke2 Ra2+ 26. Kd3 Qf3 27. Rhe1
+Rxf2 28. Ra1 Rb2 29. Rf1 Qe2+ 30. Kc3 Qxe3+ 31. Kxb2 Qe2+ 32. Ka3 h6 33. Qxf7+
+Kh7 34. Rg1 Qxe4 35. Rae1 Qc2 36. Re2 Qd3 37. Reg2 g5 38. Qe6 Qe4 39. Rf2 Qd4
+0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Yoseqpuedo"]
+[Black "imdejong"]
+[Result "0-1"]
+[ECO "A00"]
+[WhiteElo "2420"]
+[BlackElo "2351"]
+[PlyCount "92"]
+[EventDate "2020.??.??"]
+
+1. e3 e6 2. f4 d5 3. Nf3 c5 4. Be2 Nc6 5. O-O Bd6 6. d3 Nge7 7. Nc3 O-O 8. e4
+d4 9. Nb1 b5 10. Qe1 a5 11. Kh1 a4 12. Qg3 Nb4 13. Bd1 Ba6 14. Qh3 Ng6 15. f5
+exf5 16. exf5 Ne5 17. Ng5 h6 18. Ne4 f6 19. Bxh6 gxh6 20. Qxh6 Ra7 21. a3 Rh7
+22. Qd2 Nbc6 23. Rf3 Nxf3 24. gxf3 Rxh2+ 25. Qxh2 Bxh2 26. Kxh2 Qc7+ 27. Kg2
+Kf7 28. Nbd2 Rg8+ 29. Kf2 Qh2+ 30. Ke1 Rg1+ 31. Nf1 Ne5 32. Be2 Qh1 33. Kd2
+Nxf3+ 34. Bxf3 Qxf3 35. Neg3 Rg2+ 36. Kc1 Rxg3 37. Nxg3 Qxg3 38. Kb1 Qe1+ 39.
+Ka2 Qxa1+ 40. Kxa1 c4 41. Kb1 cxd3 42. c3 b4 43. Kc1 dxc3 44. b3 bxa3 45. bxa4
+a2 46. Kd1 a1=Q# 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "chesslismab"]
+[Black "Molot_ua"]
+[Result "1-0"]
+[ECO "B12"]
+[WhiteElo "2445"]
+[BlackElo "2376"]
+[PlyCount "57"]
+[EventDate "2020.??.??"]
+
+1. e4 c6 2. d4 d6 3. e5 dxe5 4. dxe5 Qa5+ 5. Nd2 Qxe5+ 6. Be2 Bg4 7. Ngf3 Bxf3
+8. Nxf3 Qc7 9. O-O Nf6 10. c4 Nbd7 11. b4 e5 12. b5 e4 13. bxc6 bxc6 14. Nd4
+Bc5 15. Nf5 g6 16. Ng3 O-O 17. Bb2 Rfe8 18. Qc2 Ne5 19. Kh1 Neg4 20. Bxg4 Nxg4
+21. Qc3 Qe5 22. Qxe5 Nxe5 23. Nxe4 Nxc4 24. Nf6+ Kf8 25. Nxe8 Nxb2 26. Rab1 Nd3
+27. Nc7 Nxf2+ 28. Rxf2 Bxf2 29. Nxa8 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "ROBESPIERR"]
+[Black "two64brocc"]
+[Result "1-0"]
+[ECO "A04"]
+[WhiteElo "2546"]
+[BlackElo "2638"]
+[PlyCount "71"]
+[EventDate "2020.??.??"]
+
+1. Nf3 d6 2. g3 Kd7 3. Bg2 Qe8 4. O-O Kd8 5. c4 Nc6 6. d4 e6 7. Nc3 Bd7 8. d5
+exd5 9. cxd5 Ne5 10. Nd4 h5 11. h3 f6 12. f4 Nf7 13. e4 h4 14. g4 g6 15. f5
+gxf5 16. exf5 Bh6 17. Ne6+ Kc8 18. Bxh6 Rxh6 19. Rc1 Ne7 20. Qd4 Ne5 21. Ne4
+Bxe6 22. dxe6 N7c6 23. Qd2 Qh8 24. b4 a6 25. a4 Kd8 26. b5 axb5 27. axb5 Ne7
+28. b6 N7c6 29. bxc7+ Kxc7 30. Qxd6+ Kc8 31. Rb1 Ra2 32. Rfc1 Qd8 33. Qb4 Rh7
+34. Nd6+ Kb8 35. Bxc6 Rc7 36. Bxb7 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Steed28"]
+[Black "Allshad"]
+[Result "1-0"]
+[ECO "A81"]
+[WhiteElo "2396"]
+[BlackElo "2318"]
+[PlyCount "53"]
+[EventDate "2020.??.??"]
+
+1. d4 f5 2. g3 Nf6 3. Bg2 g6 4. c3 Bg7 5. Nh3 O-O 6. Qb3+ Kh8 7. Bxb7 Bxb7 8.
+Qxb7 Nc6 9. Nf4 e5 10. dxe5 Nxe5 11. Nd2 c6 12. O-O Qe8 13. Nf3 Nxf3+ 14. exf3
+g5 15. Nd3 Qh5 16. Kg2 Rae8 17. h3 Re2 18. Qxa7 Rfe8 19. f4 Ne4 20. fxg5 Nxg3
+21. Kxg3 h6 22. Qxd7 hxg5 23. Qxf5 Rf8 24. Qg4 Qe8 25. Bxg5 Be5+ 26. Kg2 Rf7
+27. Qxe2 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Cazulo97"]
+[Black "kingcobra23"]
+[Result "1-0"]
+[ECO "A01"]
+[WhiteElo "2361"]
+[BlackElo "2325"]
+[PlyCount "47"]
+[EventDate "2020.??.??"]
+
+1. b3 a5 2. Bb2 a4 3. f4 e6 4. Nf3 Nf6 5. e3 a3 6. Bc3 Ne4 7. Be2 Nxc3 8. Nxc3
+d5 9. O-O Bd6 10. d4 c6 11. Ne5 O-O 12. Bd3 Bxe5 13. fxe5 g6 14. Qg4 b6 15. Ne2
+Ba6 16. Ng3 Bxd3 17. cxd3 Nd7 18. Nh5 Qe7 19. Rf3 Kh8 20. Nf6 Nxf6 21. exf6 Qd6
+22. Qg5 h5 23. Qh6+ Kg8 24. Qg7# 1-0
+
+[Event "Rated Blitz tournament hM7PUvgg"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "samidescalona2002"]
+[Black "matussalen"]
+[Result "0-1"]
+[ECO "A45"]
+[WhiteElo "2445"]
+[BlackElo "2311"]
+[PlyCount "32"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 Nf6 2. Bf4 e6 3. e3 d5 4. Nd2 a6 5. Ngf3 c5 6. c3 Nc6 7. Bd3 Bd6 8. Ne5
+O-O 9. Qf3 Qe7 10. Qh3 g6 11. g4 Nd7 12. Ndf3 f6 13. Nxd7 Bxd7 14. Bxd6 Qxd6
+15. g5 e5 16. gxf6 Bxh3 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "velikos"]
+[Black "jdef"]
+[Result "1-0"]
+[ECO "A53"]
+[WhiteElo "2408"]
+[BlackElo "2303"]
+[PlyCount "39"]
+[EventDate "2020.??.??"]
+
+1. d4 d6 2. c4 Nf6 3. Nf3 Nbd7 4. g3 e5 5. Bg2 exd4 6. O-O g6 7. Nxd4 Bg7 8.
+Nc3 O-O 9. Bg5 Nc5 10. Qd2 Ne6 11. Nxe6 fxe6 12. Bh6 e5 13. Nd5 c6 14. Nxf6+
+Qxf6 15. Rad1 Rd8 16. Bg5 Qf8 17. Bxd8 Qxd8 18. Qxd6 Qxd6 19. Rxd6 Bf5 20. e4
+1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "hungzhao"]
+[Black "metalkingGT"]
+[Result "1/2-1/2"]
+[ECO "C05"]
+[WhiteElo "2628"]
+[BlackElo "2439"]
+[PlyCount "47"]
+[EventDate "2020.??.??"]
+
+1. e4 e6 2. d4 d5 3. Nd2 Nf6 4. e5 Nfd7 5. c3 f6 6. Bd3 fxe5 7. dxe5 Nxe5 8.
+Qh5+ Nf7 9. Ngf3 Qf6 10. O-O Qh6 11. Qg4 Nc6 12. Ne4 e5 13. Qxc8+ Rxc8 14. Bxh6
+Nxh6 15. Neg5 e4 16. Rfe1 Be7 17. Nxe4 dxe4 18. Bxe4 Kf7 19. Bxc6 bxc6 20. Ne5+
+Kf6 21. Nd7+ Kf7 22. Ne5+ Kf6 23. Nd7+ Kf7 24. Ne5+ 1/2-1/2
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Akali666"]
+[Black "vava05"]
+[Result "1-0"]
+[ECO "A46"]
+[WhiteElo "2525"]
+[BlackElo "2400"]
+[PlyCount "129"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 Nf6 2. Nf3 e6 3. Bf4 d5 4. e3 Bd6 5. Bg3 Bxg3 6. hxg3 c5 7. Nbd2 Nc6 8.
+c3 cxd4 9. exd4 Qc7 10. Bd3 Bd7 11. Qe2 O-O-O 12. Ne5 Nxe5 13. dxe5 Ne4 14.
+Bxe4 dxe4 15. Nc4 Bc6 16. Nd6+ Kb8 17. O-O-O f6 18. Qg4 fxe5 19. Qxe6 e3 20.
+fxe3 Bxg2 21. Rh4 Bf3 22. Rd2 Qd7 23. Qxe5 Ka8 24. Rf4 Rhe8 25. Qd4 Bc6 26. Rf7
+Qe6 27. Rxg7 Qxe3 28. Qxe3 Rxe3 29. g4 Rg3 30. g5 a6 31. c4 Rf8 32. c5 Ka7 33.
+b3 Rf1+ 34. Kb2 Rf8 35. Nxb7 Bxb7 36. c6 Kb6 37. cxb7 Rb8 38. Rdd7 Rg2+ 39. Ka3
+a5 40. Rc7 Rxg5 41. Rxg5 Kxc7 42. Rg7+ Kb6 43. Rxh7 Rxb7 44. Rxb7+ Kxb7 45. Kb2
+Kb6 46. Kc3 Kc5 47. a3 Kb5 48. Kd4 Kb6 49. Kc4 Kc6 50. a4 Kb6 51. Kd5 Kb7 52.
+Kc5 Ka6 53. Kc6 Ka7 54. Kb5 Kb7 55. Kxa5 Kc7 56. Kb5 Kb7 57. b4 Ka7 58. Kc6 Kb8
+59. b5 Ka7 60. Kc7 Ka8 61. a5 Ka7 62. b6+ Ka8 63. b7+ Ka7 64. b8=Q+ Ka6 65.
+Qb6# 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Kralj56"]
+[Black "Kelevra90"]
+[Result "1-0"]
+[ECO "D35"]
+[WhiteElo "2452"]
+[BlackElo "2465"]
+[PlyCount "111"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 Nf6 2. c4 e6 3. Nc3 d5 4. cxd5 exd5 5. Bg5 c6 6. e3 Nbd7 7. Bd3 Be7 8.
+Nf3 Ne4 9. Bxe7 Qxe7 10. O-O O-O 11. Qc2 Ndf6 12. Rab1 Bf5 13. b4 a6 14. a4 g6
+15. b5 axb5 16. axb5 Nd6 17. bxc6 bxc6 18. Bxf5 Nxf5 19. Rfc1 c5 20. dxc5 Qxc5
+21. Rb5 Qc7 22. h3 Rfc8 23. Qd1 Nd6 24. Rbb1 Qc6 25. Ne5 Qe8 26. Ng4 Nxg4 27.
+hxg4 Rd8 28. Nxd5 Ne4 29. Qd4 Qe6 30. Qxe4 Rxd5 31. Qxe6 fxe6 32. Rc7 Rad8 33.
+Rbb7 h5 34. Rg7+ Kf8 35. Rxg6 hxg4 36. Rxg4 Rh5 37. g3 e5 38. Kg2 Rf5 39. Rb5
+Re8 40. Re4 Kf7 41. f4 Kf6 42. Rexe5 Rfxe5 43. Rxe5 Rxe5 44. fxe5+ Kxe5 45. Kf3
+Kf5 46. g4+ Ke5 47. e4 Kf6 48. Kf4 Ke6 49. g5 Kf7 50. Kf5 Kg7 51. e5 Kf7 52.
+e6+ Ke7 53. g6 Ke8 54. Kf6 Kf8 55. e7+ Kg8 56. e8=Q# 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Valema"]
+[Black "Ngc99"]
+[Result "1-0"]
+[ECO "B30"]
+[WhiteElo "2304"]
+[BlackElo "2352"]
+[PlyCount "79"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 c5 2. Nf3 Nc6 3. g3 d6 4. Bg2 g6 5. O-O Bg7 6. Re1 Bg4 7. h3 Bxf3 8. Qxf3
+Nd4 9. Qd1 e6 10. c3 Nc6 11. d3 Nge7 12. h4 h5 13. Bg5 Qb6 14. Qc1 O-O 15. Nd2
+Rfe8 16. Nc4 Qc7 17. Bf4 e5 18. Bh6 b5 19. Bxg7 Kxg7 20. Ne3 Rad8 21. Bh3 Qb6
+22. Kg2 Rb8 23. f4 exf4 24. gxf4 b4 25. c4 Nd4 26. b3 Qc6 27. Qb2 Kg8 28. Rg1
+f5 29. Kh2 Nf3+ 30. Kh1 Nxg1 31. Rxg1 fxe4 32. Be6+ Kh7 33. Nd5 exd3 34. Qf6
+Rb7 35. Bf7 Rg8 36. Bxg8+ Kxg8 37. Kh2 Nxd5 38. Rxg6+ Kh7 39. Rh6+ Kg8 40. Rh8#
+1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "fedateam"]
+[Black "PimponNicois"]
+[Result "1-0"]
+[ECO "D44"]
+[WhiteElo "2345"]
+[BlackElo "2336"]
+[PlyCount "39"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 d5 2. c4 c6 3. Nf3 Nf6 4. Nc3 e6 5. Bg5 h6 6. Bh4 dxc4 7. e4 g5 8. Bg3 b5
+9. Qc2 Bb7 10. Rd1 Bg7 11. Be2 O-O 12. O-O Nbd7 13. d5 exd5 14. e5 Ne4 15. Nxe4
+dxe4 16. Qxe4 Nc5 17. Qe3 Qe7 18. Nd4 Nd3 19. Nf5 Qc5 20. Rxd3 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "abraniel"]
+[Black "RigelStar"]
+[Result "0-1"]
+[ECO "A00"]
+[WhiteElo "2408"]
+[BlackElo "2404"]
+[PlyCount "118"]
+[EventDate "2020.??.??"]
+
+1. g3 d5 2. Bg2 e6 3. c4 Nf6 4. cxd5 exd5 5. Nf3 c6 6. O-O Be7 7. Nc3 O-O 8. e4
+d4 9. Ne2 c5 10. e5 Nd5 11. d3 Nc6 12. Nf4 Nxf4 13. Bxf4 Nb4 14. a3 Nd5 15. Bd2
+Bf5 16. Qb3 Nb6 17. a4 Be6 18. Qc2 Rc8 19. b3 Nd5 20. Rfe1 b6 21. h4 h6 22.
+Rad1 Nc7 23. Bc1 Qd5 24. Nd2 Qd7 25. Nc4 Nd5 26. f4 Nb4 27. Qf2 Rb8 28. Be4 Bg4
+29. f5 Bxd1 30. Rxd1 f6 31. e6 Qd8 32. Bf4 Rc8 33. g4 Nd5 34. Bc1 Nc3 35. Bf3
+Nxd1 36. Bxd1 a6 37. Bf3 b5 38. Nd2 Bd6 39. axb5 axb5 40. Ne4 Be5 41. g5 fxg5
+42. Bg4 gxh4 43. e7 Qxe7 44. f6 Bxf6 45. Bxc8 Rxc8 46. Bxh6 Rf8 47. Qg2 Qe5 48.
+Bd2 Qf5 49. Kh1 g5 50. Be1 g4 51. Bxh4 Bxh4 52. Ng3 Qg6 53. Qd5+ Rf7 54. Ne4
+Qh7 55. Qd8+ Bxd8+ 56. Kg2 Qg7 57. Nf6+ Qxf6 58. Kg1 Qf2+ 59. Kh1 Rh7# 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "WildBreath"]
+[Black "PeruVirtual"]
+[Result "1-0"]
+[ECO "B01"]
+[WhiteElo "2413"]
+[BlackElo "2304"]
+[PlyCount "109"]
+[EventDate "2020.??.??"]
+
+1. e4 d5 2. Nc3 d4 3. Nce2 c5 4. d3 Nc6 5. g3 g6 6. Bg2 Bg7 7. Nh3 Nf6 8. O-O
+O-O 9. f4 e5 10. f5 gxf5 11. exf5 Re8 12. Kh1 e4 13. dxe4 Nxe4 14. Nef4 Nf6 15.
+Nh5 Ne5 16. Nxg7 Kxg7 17. Bg5 h6 18. Bf4 Neg4 19. Qd2 Ne3 20. Bf3 Bxf5 21. g4
+Bg6 22. Rg1 Nfd5 23. Bg3 Nxc2 24. Rac1 d3 25. g5 h5 26. Nf4 Nxf4 27. Bxf4 Nd4
+28. Bg2 Be4 29. Rxc5 Bxg2+ 30. Qxg2 Re2 31. Be5+ Kg6 32. Qf1 b6 33. Bxd4 bxc5
+34. Qf6+ Qxf6 35. gxf6+ Kf5 36. Bxc5 Ke6 37. Bb4 Rc8 38. Bc3 Rc4 39. Rd1 Rg4
+40. Rxd3 Rgg2 41. Rh3 Rxh2+ 42. Rxh2 Re1+ 43. Bxe1 Kf5 44. Rxh5+ Kg6 45. Ra5
+Kxf6 46. Rxa7 Kg7 47. Rxf7+ Kxf7 48. b4 Ke6 49. a4 Kd6 50. a5 Kc6 51. Kg1 Kb5
+52. Kf2 Ka6 53. Ke2 Kb5 54. Kd1 Ka6 55. Kc2 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "taras05"]
+[Black "Betovsky"]
+[Result "0-1"]
+[ECO "B01"]
+[WhiteElo "2478"]
+[BlackElo "2635"]
+[PlyCount "82"]
+[EventDate "2020.??.??"]
+
+1. e4 d5 2. exd5 Nf6 3. Bc4 Nxd5 4. Nf3 Nb6 5. Bb3 Bf5 6. d4 e6 7. c3 Be7 8.
+Be3 O-O 9. Nbd2 c5 10. Qe2 c4 11. Nxc4 Nxc4 12. Bxc4 Nc6 13. Bd3 Rc8 14. Bxf5
+exf5 15. O-O Re8 16. Qd3 Bf6 17. Qxf5 Na5 18. Ng5 g6 19. Qg4 Rxe3 20. Nxf7 Kxf7
+21. fxe3 Kg7 22. e4 Rc7 23. e5 Bg5 24. Rf3 Nc6 25. Raf1 h5 26. Qe6 Qg8 27. Qd6
+Re7 28. g3 h4 29. Rf6 Qe8 30. gxh4 Bxh4 31. Qd5 Qd7 32. Qg2 g5 33. R6f5 Kg6 34.
+Rf6+ Kh7 35. Rd6 Qe8 36. Qe4+ Kg8 37. Rdf6 Rg7 38. Rg6 Qxg6 39. Qg2 g4 40. Kh1
+g3 41. e6 Qxe6 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Aisen_Mestnikov"]
+[Black "alireza3700"]
+[Result "1-0"]
+[ECO "D24"]
+[WhiteElo "2377"]
+[BlackElo "2353"]
+[PlyCount "75"]
+[EventDate "2020.??.??"]
+
+1. d4 d5 2. c4 dxc4 3. Nf3 Nf6 4. Nc3 a6 5. a4 Nc6 6. e4 Na5 7. Bg5 h6 8. Bh4
+g5 9. Bg3 e6 10. Ne5 Bb4 11. f3 b5 12. axb5 axb5 13. Be2 Bb7 14. O-O O-O 15.
+Nxb5 c5 16. dxc5 Bxc5+ 17. Kh1 Qb6 18. Nc3 Nb3 19. Na4 Qb5 20. Nxc5 Nxc5 21.
+Rb1 Nb3 22. Bxc4 Qxc4 23. Nxc4 Rac8 24. Nd6 Rcd8 25. Qxb3 Ba6 26. e5 Nd5 27.
+Rfd1 Rb8 28. Qc2 Rfd8 29. Rxd5 exd5 30. Qf5 Bc8 31. Qxf7+ Kh8 32. Qf6+ Kg8 33.
+Qxd8+ Kh7 34. Qf6 Ba6 35. Ne8 Rxe8 36. e6 Re7 37. Qxe7+ Kg6 38. Qf7# 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Akylbekov_Nasir"]
+[Black "AbdAlQadir"]
+[Result "1-0"]
+[ECO "C15"]
+[WhiteElo "2309"]
+[BlackElo "2323"]
+[PlyCount "67"]
+[EventDate "2020.??.??"]
+
+1. e4 e6 2. d4 d5 3. Nc3 Bb4 4. a3 Bxc3+ 5. bxc3 dxe4 6. Qg4 Nf6 7. Qxg7 Rg8 8.
+Qh6 Nbd7 9. Ne2 c5 10. Bb2 Qb6 11. O-O-O Rg6 12. Qe3 Ng4 13. Qf4 Ndf6 14. h3
+Nd5 15. Qg3 Nge3 16. fxe3 Rxg3 17. Nxg3 Nxe3 18. Re1 Nxf1 19. Rhxf1 cxd4 20.
+Nxe4 f5 21. Ng5 Bd7 22. cxd4 O-O-O 23. Nf7 Rg8 24. Rf2 Qa5 25. Rfe2 Rg3 26.
+Nd6+ Kd8 27. Nc4 Qb4 28. Ne5 Qa5 29. Nf7+ Ke7 30. Ne5 Qa6 31. d5 Kd6 32. Nf7+
+Kxd5 33. Rd2+ Kc6 34. Ne5+ 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Kidefence"]
+[Black "BlueGreensun"]
+[Result "0-1"]
+[ECO "C41"]
+[WhiteElo "2717"]
+[BlackElo "2749"]
+[PlyCount "46"]
+[EventDate "2020.??.??"]
+
+1. e4 d6 2. d4 Nf6 3. Nc3 e5 4. Nf3 Nbd7 5. Bc4 Be7 6. dxe5 dxe5 7. Bd5 O-O 8.
+O-O Nxd5 9. Nxd5 Bd6 10. Be3 h6 11. h3 Nf6 12. Nxf6+ Qxf6 13. Qe2 Qg6 14. Nd2
+Bxh3 15. Qf3 Be6 16. b3 f5 17. exf5 Bxf5 18. Qxb7 e4 19. Qd5+ Kh8 20. Rad1 Rae8
+21. Bxa7 Bh3 22. g3 Bxg3 23. Nxe4 Rxe4 0-1
+
+[Event "Rated Blitz tournament hM7PUvgg"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Pomberito"]
+[Black "GlennTipton"]
+[Result "1-0"]
+[ECO "C96"]
+[WhiteElo "2338"]
+[BlackElo "2463"]
+[PlyCount "97"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3
+O-O 9. h3 Na5 10. Bc2 c5 11. d4 Nd7 12. d5 Nb6 13. b3 f5 14. Nbd2 f4 15. Nf1 g5
+16. N3h2 Nd7 17. Bd2 Nf6 18. Bd3 Bd7 19. Be2 Nb7 20. Ng4 Qe8 21. Nxf6+ Rxf6 22.
+Bh5 Qf8 23. Bg4 Be8 24. Nh2 Qg7 25. Be6+ Kh8 26. Ng4 Rf8 27. f3 h5 28. Nh2 Nd8
+29. Bf5 Nf7 30. a4 bxa4 31. bxa4 Nh6 32. Be6 Rf6 33. Rb1 Rg6 34. Rb7 Qf8 35. c4
+Bf7 36. Bd7 g4 37. fxg4 Bh4 38. Rf1 Bg3 39. gxh5 Bxh2+ 40. Kxh2 Rg5 41. Bxf4
+exf4 42. Rxf4 Qg8 43. Bg4 Bxh5 44. Qa1+ Re5 45. Bxh5 Qg5 46. Qf1 Qxh5 47. Rf8+
+Rxf8 48. Qxf8+ Ng8 49. Qg7# 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "JLRHei"]
+[Black "murderoflegends"]
+[Result "1-0"]
+[ECO "D11"]
+[WhiteElo "2338"]
+[BlackElo "2429"]
+[PlyCount "71"]
+[EventDate "2020.??.??"]
+
+1. d4 d5 2. c4 c6 3. Nf3 Nf6 4. g3 Bf5 5. Bg2 e6 6. O-O Bd6 7. Nc3 Nbd7 8. Nd2
+O-O 9. e4 dxe4 10. Ndxe4 Be7 11. Bf4 Nxe4 12. Nxe4 Nf6 13. Nc3 Rc8 14. Re1 Qb6
+15. Qd2 Rfd8 16. Be3 Ng4 17. Rad1 Nxe3 18. fxe3 Bb4 19. a3 Be7 20. c5 Qc7 21.
+Qf2 Bg6 22. Rf1 b6 23. cxb6 Qxb6 24. h4 c5 25. d5 Bf6 26. Ne4 Bxe4 27. Bxe4
+exd5 28. Bxd5 Qc7 29. Kh2 Kh8 30. Qf4 Be5 31. Qxf7 Bxg3+ 32. Kh1 Qe5 33. Be6
+Qxb2 34. Rxd8+ Rxd8 35. Qf8+ Rxf8 36. Rxf8# 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Dohani"]
+[Black "camilomunoz0107"]
+[Result "0-1"]
+[ECO "A04"]
+[WhiteElo "2375"]
+[BlackElo "2350"]
+[PlyCount "94"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. Nf3 Nf6 2. b3 d5 3. Bb2 Bf5 4. e3 Nbd7 5. d4 e6 6. Bd3 c6 7. Bxf5 exf5 8.
+Ne5 Bd6 9. Nxd7 Qxd7 10. Qf3 Ne4 11. O-O O-O 12. Re1 a5 13. a4 Bb4 14. Rd1 Rfe8
+15. c3 Bd6 16. Nd2 b5 17. Nxe4 fxe4 18. Qe2 Rec8 19. c4 bxc4 20. bxc4 Bb4 21.
+Ba3 Rab8 22. c5 f5 23. g3 Bxa3 24. Rxa3 Rb4 25. Qa6 Rcb8 26. Qxa5 Qb7 27. Rda1
+g5 28. h3 h5 29. Kg2 Rf8 30. Rg1 Kh7 31. h4 f4 32. hxg5 f3+ 33. Kh2 Ra8 34.
+Qxb4 Qxb4 35. Rga1 Kg6 36. a5 Ra6 37. Kh3 Kxg5 38. Kh2 Kg4 39. Ra4 Qb5 40. R4a2
+h4 41. gxh4 Kxh4 42. Ra3 Qb8+ 43. Kg1 Ra7 44. Kf1 Qb5+ 45. Kg1 Rg7+ 46. Kh1 Rg2
+47. R3a2 Qb8 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "profaVa"]
+[Black "JiangoFett"]
+[Result "1-0"]
+[ECO "B22"]
+[WhiteElo "2370"]
+[BlackElo "2394"]
+[PlyCount "139"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 c5 2. c3 Nf6 3. e5 Nd5 4. d4 cxd4 5. Nf3 Nc6 6. cxd4 d6 7. Bc4 Nb6 8. Bb3
+dxe5 9. d5 Na5 10. Nc3 g6 11. Nxe5 Nxb3 12. Qxb3 Bg7 13. Bf4 O-O 14. O-O Nd7
+15. Nxd7 Qxd7 16. Rfe1 b6 17. Be5 Bb7 18. Bxg7 Kxg7 19. Rad1 Rad8 20. Qb4 Rfe8
+21. Qd4+ Kg8 22. Ne4 Bxd5 23. Qe5 Qe6 24. Qxe6 Bxe6 25. b3 Bf5 26. Ng3 e6 27.
+f4 Bg4 28. Rxd8 Rxd8 29. Ne4 Kg7 30. Kf2 Bf5 31. Ng3 Kf6 32. Ke3 Rd3+ 33. Kf2
+a5 34. Re3 Rd2+ 35. Re2 Rxe2+ 36. Kxe2 Bb1 37. a3 b5 38. b4 axb4 39. axb4 Ba2
+40. Ne4+ Ke7 41. Ke3 Bd5 42. Nc3 Bc6 43. g3 Kd6 44. g4 f6 45. g5 fxg5 46. fxg5
+Ke5 47. h4 Kf5 48. Ne2 Kg4 49. Nd4 Bd7 50. Nf3 Kg3 51. Ne5 Be8 52. Nf3 Bc6 53.
+Nd4 Bd5 54. Nxb5 Kxh4 55. Kf4 Kh3 56. Nc3 Bb7 57. b5 Kg2 58. b6 Kf2 59. Na4 Ke2
+60. Nc5 Bc6 61. Nxe6 Bb7 62. Nf8 h5 63. gxh6 g5+ 64. Kxg5 Bc6 65. h7 Be8 66.
+h8=Q Kd3 67. Qf6 Kc4 68. Ne6 Kb5 69. Nf4 Ka6 70. Qe7 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "txebyshev"]
+[Black "BerserkAdopter"]
+[Result "0-1"]
+[ECO "B01"]
+[WhiteElo "2356"]
+[BlackElo "2437"]
+[PlyCount "90"]
+[EventDate "2020.??.??"]
+
+1. e4 d5 2. exd5 Qxd5 3. Nc3 Qd8 4. Bc4 c6 5. Nf3 Nf6 6. Ne5 e6 7. d4 Bd6 8.
+O-O Bxe5 9. dxe5 Qxd1 10. Rxd1 Nd5 11. Ne4 O-O 12. Bg5 h6 13. Bh4 Nd7 14. c3
+Nxe5 15. Be2 Nf4 16. Bf1 b6 17. Bg3 Nfg6 18. Nd6 Rd8 19. h4 h5 20. Be2 Ng4 21.
+Bf3 Ba6 22. Bxc6 Rab8 23. Nb5 Bxb5 24. Bxb5 Rxd1+ 25. Rxd1 Rc8 26. Ba6 Re8 27.
+Be2 N4e5 28. Bxh5 Nc4 29. Bxg6 fxg6 30. b3 Na5 31. c4 Kf7 32. Be5 Ke7 33. Bxg7
+e5 34. Bxe5 Ke6 35. f4 Nc6 36. Rd6+ Kf5 37. Rxc6 Ke4 38. Rxg6 Ke3 39. h5 Rd8
+40. h6 Rd1+ 41. Kh2 Rd8 42. h7 b5 43. h8=Q Rd2 44. Bg7 Ke2 45. Qh3 bxc4 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Lil_D"]
+[Black "Bulingot"]
+[Result "1-0"]
+[ECO "A00"]
+[WhiteElo "2303"]
+[BlackElo "2356"]
+[PlyCount "87"]
+[EventDate "2020.??.??"]
+
+1. g3 c5 2. Bg2 g6 3. d3 Bg7 4. e4 Nc6 5. f4 d6 6. Ne2 e6 7. h3 Nge7 8. O-O O-O
+9. Nbc3 Rb8 10. g4 b5 11. Ng3 b4 12. Nce2 a5 13. h4 f5 14. g5 a4 15. a3 b3 16.
+c3 Ba6 17. Rf2 Qc7 18. h5 e5 19. hxg6 hxg6 20. exf5 Nxf5 21. Nxf5 Rxf5 22. Ng3
+Ne7 23. Nxf5 gxf5 24. Qh5 Bxd3 25. g6 e4 26. Be3 d5 27. Rd1 Rb6 28. Bh3 Rxg6+
+29. Rg2 Rxg2+ 30. Kxg2 d4 31. cxd4 cxd4 32. Rc1 Qd8 33. Bxf5 Nxf5 34. Qxf5 Bc2
+35. Bxd4 Qxd4 36. Qe6+ Kf8 37. Qc8+ Ke7 38. Qb7+ Qd7 39. Qa6 Qd3 40. Qxd3 exd3
+41. Re1+ Kd6 42. Re3 d2 43. Rg3 d1=Q 44. Rg6+ 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Glig"]
+[Black "Parwis"]
+[Result "1-0"]
+[ECO "A15"]
+[WhiteElo "2454"]
+[BlackElo "2481"]
+[PlyCount "81"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. c4 Nf6 2. g3 e6 3. Bg2 Be7 4. Nc3 d5 5. Nf3 O-O 6. O-O b6 7. cxd5 Nxd5 8. d4
+Bb7 9. Re1 Nd7 10. e4 Nxc3 11. bxc3 c5 12. Qc2 cxd4 13. cxd4 Rc8 14. Qa4 a6 15.
+Ba3 b5 16. Bxe7 Qxe7 17. Qa5 Rc2 18. d5 exd5 19. Nd4 Rc4 20. exd5 Qf6 21. Nc6
+Rc2 22. f4 Bxc6 23. dxc6 Qd4+ 24. Kh1 Qf2 25. Rg1 Nf6 26. Qe1 Qc5 27. Qd1 h5
+28. Rc1 Rc4 29. Rxc4 bxc4 30. h3 h4 31. g4 c3 32. Qd3 Qf2 33. Rc1 Qxf4 34. Qxc3
+Ne4 35. Qc4 Nf2+ 36. Kg1 Qg3 37. Kf1 Nxh3 38. Qd4 Nf4 39. Be4 h3 40. c7 Rc8 41.
+Qd8+ 1-0
+
+[Event "Rated Blitz tournament hM7PUvgg"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "balachess2006"]
+[Black "juancruzariasTDF"]
+[Result "1-0"]
+[ECO "D02"]
+[WhiteElo "2412"]
+[BlackElo "2424"]
+[PlyCount "87"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. Nf3 d5 2. d4 e6 3. Bf4 f5 4. e3 Nf6 5. Nbd2 Bd6 6. Ne5 O-O 7. Be2 Nbd7 8.
+Bg3 Ne4 9. Nxe4 fxe4 10. f4 exf3 11. Bxf3 Nxe5 12. dxe5 Bc5 13. Qd3 Qg5 14. Bf4
+Rxf4 15. exf4 Qxf4 16. Qe2 Bd7 17. g3 Qd4 18. Kf1 Rf8 19. Kg2 Bc6 20. Rhf1 Qxb2
+21. Rab1 Qxa2 22. Bg4 d4+ 23. Kh3 Qd5 24. Rxf8+ Bxf8 25. Qf2 Be7 26. Rf1 Be8
+27. Qf4 c5 28. Bf3 Qd7 29. Ra1 a6 30. Rb1 b5 31. Ra1 Qc8 32. Qe4 h6 33. Qb7 Qd8
+34. Rxa6 c4 35. Rxe6 Bd7 36. Bg4 Bxe6 37. Bxe6+ Kh8 38. Qxb5 d3 39. cxd3 cxd3
+40. Bg4 d2 41. Qe2 Bg5 42. Kg2 Qd5+ 43. Bf3 Qxe5 44. Qxe5 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "metalkingGT"]
+[Black "lewisbort"]
+[Result "1-0"]
+[ECO "A04"]
+[WhiteElo "2442"]
+[BlackElo "2374"]
+[PlyCount "95"]
+[EventDate "2020.??.??"]
+
+1. Nf3 c6 2. g3 d6 3. Bg2 Bd7 4. O-O g6 5. d3 Bg7 6. c4 Nf6 7. Nc3 O-O 8. Rb1
+a5 9. a3 a4 10. b4 axb3 11. Rxb3 Qc8 12. Qc2 Na6 13. Qb1 Rb8 14. d4 Re8 15. e4
+e5 16. Be3 Ng4 17. dxe5 Nxe3 18. fxe3 dxe5 19. Na4 b5 20. cxb5 cxb5 21. Nc3 Nc5
+22. Rb4 Rd8 23. Nd5 Be6 24. Rc1 Qa6 25. Rxc5 Bf8 26. Rcxb5 Bxb4 27. Rxb8 Rxb8
+28. Nxb4 Qe2 29. Qd3 Qb2 30. Bf1 Rc8 31. Nd5 Rc1 32. Ng5 Bg4 33. Nf6+ Kg7 34.
+Nxg4 Qa1 35. Nf3 f6 36. Qd7+ Kf8 37. Qd8+ Kf7 38. Qxf6+ Ke8 39. Qxe5+ Kd7 40.
+Qxa1 Kc8 41. Qxc1+ Kd8 42. Qc6 Ke7 43. Qf6+ Kd7 44. Nge5+ Kc8 45. Qc6+ Kb8 46.
+Nd7+ Ka7 47. Qb6+ Ka8 48. Qb8# 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "rudolf85"]
+[Black "Paanoos"]
+[Result "1-0"]
+[ECO "A00"]
+[WhiteElo "2419"]
+[BlackElo "2384"]
+[PlyCount "39"]
+[EventDate "2020.??.??"]
+
+1. e3 g6 2. d4 Bg7 3. Nf3 c5 4. Be2 cxd4 5. exd4 Nf6 6. O-O O-O 7. c3 d5 8. b3
+Nc6 9. Bb2 a5 10. Nbd2 a4 11. bxa4 Qa5 12. Re1 Qxa4 13. Qxa4 Rxa4 14. Nb3 b6
+15. Bb5 Nxd4 16. Bxa4 Nc2 17. Rad1 Nxe1 18. Rxe1 e6 19. Ba3 Rd8 20. Be7 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Phutressniak"]
+[Black "Odirovski"]
+[Result "0-1"]
+[ECO "D43"]
+[WhiteElo "2421"]
+[BlackElo "2454"]
+[PlyCount "124"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 Nf6 2. Nf3 d5 3. c4 c6 4. Nc3 e6 5. cxd5 exd5 6. Bg5 Qb6 7. Qc2 Nbd7 8.
+e3 h6 9. Bh4 g5 10. Bg3 Nh5 11. Rc1 Nxg3 12. hxg3 Bg7 13. Bd3 Nf6 14. O-O Ng4
+15. Na4 Qd8 16. Nc5 h5 17. Bf5 h4 18. gxh4 gxh4 19. Bxc8 Qxc8 20. Nd3 Qf5 21.
+Nf4 Qxc2 22. Rxc2 Ke7 23. b4 a6 24. Rb1 Nf6 25. Ne5 Ne4 26. Ned3 Bf6 27. a4 Kd6
+28. Nc5 Ra7 29. b5 axb5 30. axb5 Nxc5 31. dxc5+ Kd7 32. bxc6+ bxc6 33. e4 dxe4
+34. Rd1+ Kc7 35. Re2 Re8 36. Rde1 Ra1 37. Rxa1 Bxa1 38. Kh2 Bd4 39. Kh3 Bxc5
+40. Kxh4 Bd6 41. Kg4 Re5 42. g3 Kd7 43. Ng2 Ke6 44. Ne3 f5+ 45. Kh3 Bc5 46. Rc2
+Bxe3 47. fxe3 c5 48. g4 Kd5 49. gxf5 Rxf5 50. Kg3 Rf3+ 51. Kg4 Rxe3 52. Rd2+
+Rd3 53. Rh2 c4 54. Rh5+ Kd4 55. Kf4 Rf3+ 56. Kg4 Rf8 57. Rh8 Rxh8 58. Kf5 Rf8+
+59. Kg4 e3 60. Kg3 e2 61. Kg4 e1=Q 62. Kh3 Qg1 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "ajedrez2021"]
+[Black "sutcunuri"]
+[Result "1-0"]
+[ECO "A39"]
+[WhiteElo "2587"]
+[BlackElo "2526"]
+[PlyCount "123"]
+[EventDate "2020.??.??"]
+
+1. c4 c5 2. Nf3 g6 3. g3 Bg7 4. Bg2 Nf6 5. O-O O-O 6. Nc3 Nc6 7. d4 cxd4 8.
+Nxd4 Nxd4 9. Qxd4 d6 10. b3 a6 11. Bb2 Rb8 12. Rac1 b5 13. Rfd1 bxc4 14. Qxc4
+a5 15. h4 Be6 16. Qd3 Qd7 17. Bf3 Rfc8 18. Rd2 Bg4 19. Rdc2 Bf5 20. e4 Bg4 21.
+Kg2 Bxf3+ 22. Qxf3 Qe6 23. Nd5 Rxc2 24. Rxc2 Nxe4 25. Nc7 Qf5 26. Bxg7 Kxg7 27.
+Re2 Qxf3+ 28. Kxf3 f5 29. Kf4 Kf6 30. f3 e5+ 31. Ke3 Nc3 32. Rc2 d5 33. Kd3 d4
+34. Rxc3 dxc3 35. Nd5+ Ke6 36. Nxc3 Rd8+ 37. Kc4 h6 38. Nb5 g5 39. Na7 Rd4+ 40.
+Kc5 gxh4 41. gxh4 Rxh4 42. Nc6 Rh2 43. Nd8+ Kf6 44. Nc6 Rxa2 45. Kb6 Rb2 46.
+Nxa5 h5 47. Kc5 Rxb3 48. Nc4 h4 49. Nd6 Re3 50. Ne8+ Kg5 51. Nc7 Kf4 52. Nd5+
+Kxf3 53. Ne7 Re4 54. Nxf5 Rf4 55. Kd6 h3 56. Ne7 Rg4 57. Nd5 Kg3 58. Nf6 Kh2
+59. Ne4 Rg3 60. Nf6 Rg2 61. Ke6 Rf2 62. Ng4+ 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "vaillant77"]
+[Black "vassiukov"]
+[Result "1-0"]
+[ECO "A40"]
+[WhiteElo "2444"]
+[BlackElo "2348"]
+[PlyCount "63"]
+[EventDate "2020.??.??"]
+
+1. d4 e6 2. Nf3 f5 3. g3 Nf6 4. Bg2 d5 5. O-O Bd6 6. b3 c6 7. Bb2 Nbd7 8. Nbd2
+O-O 9. c4 Qa5 10. a3 Qd8 11. b4 Qe8 12. c5 Bc7 13. e3 Ne4 14. Ne1 Rf6 15. Nd3
+Rh6 16. f3 Nxd2 17. Qxd2 e5 18. dxe5 Nxe5 19. Nxe5 Bxe5 20. Bxe5 Qxe5 21. Qd4
+Qe7 22. e4 fxe4 23. fxe4 dxe4 24. Qxe4 Re6 25. Qc4 Kh8 26. Rad1 Bd7 27. Rxd7
+Qxd7 28. Bh3 Rae8 29. Bxe6 Qe7 30. Rf7 Qg5 31. Qf4 Qg6 32. Rf8+ 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "kingcobra23"]
+[Black "Cazulo97"]
+[Result "0-1"]
+[ECO "B21"]
+[WhiteElo "2320"]
+[BlackElo "2366"]
+[PlyCount "58"]
+[EventDate "2020.??.??"]
+
+1. e4 c5 2. d4 cxd4 3. c3 d5 4. exd5 Qxd5 5. cxd4 Nc6 6. Nf3 e5 7. Nc3 Bb4 8.
+Bd2 Bxc3 9. Bxc3 e4 10. Ne5 Nxe5 11. dxe5 Ne7 12. Qxd5 Nxd5 13. Bb5+ Bd7 14.
+Bxd7+ Kxd7 15. Rd1 Ke6 16. Bd4 Rhc8 17. O-O Rc2 18. Rfe1 Rd8 19. Rxe4 Nb4 20.
+Ree1 Nc6 21. Bc3 Rxd1 22. Rxd1 g6 23. f4 a5 24. g4 a4 25. Rd6+ Ke7 26. f5 gxf5
+27. gxf5 a3 28. f6+ Ke8 29. e6 fxe6 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "BlueGreensun"]
+[Black "Kidefence"]
+[Result "1-0"]
+[ECO "B03"]
+[WhiteElo "2754"]
+[BlackElo "2712"]
+[PlyCount "87"]
+[EventDate "2020.??.??"]
+
+1. e4 Nf6 2. e5 Nd5 3. d4 d6 4. c4 Nb6 5. f4 g6 6. Nc3 Bg7 7. Nf3 O-O 8. Be2
+Bg4 9. b3 Nc6 10. d5 Nb4 11. Bb2 c6 12. a3 Na6 13. dxc6 bxc6 14. exd6 exd6 15.
+O-O Nc5 16. b4 Ne6 17. Qd2 d5 18. cxd5 cxd5 19. Ne5 Bxe2 20. Nxe2 Nc4 21. Nxc4
+dxc4 22. Qc2 Bxb2 23. Qxb2 Rc8 24. f5 Ng7 25. f6 Ne6 26. Rad1 Qb6+ 27. Kh1 Rfd8
+28. Qc1 Rxd1 29. Rxd1 Qf2 30. Nc3 Qxf6 31. Nd5 Qe5 32. Ne7+ Kg7 33. Nxc8 c3 34.
+Nd6 Ng5 35. Nc4 Qf6 36. Rf1 Qd4 37. Qxg5 Qxc4 38. Qf6+ Kg8 39. h3 c2 40. Rc1 h5
+41. Qd8+ Kg7 42. Qd2 Qb3 43. Rxc2 Qxa3 44. Qc3+ 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "InsaneTryhard"]
+[Black "Frogkiller"]
+[Result "0-1"]
+[ECO "B21"]
+[WhiteElo "2372"]
+[BlackElo "2372"]
+[PlyCount "58"]
+[EventDate "2020.??.??"]
+
+1. e4 c5 2. d4 cxd4 3. c3 dxc3 4. Nxc3 Nc6 5. Nf3 e6 6. Bc4 a6 7. O-O b5 8. Bb3
+Bb7 9. Re1 Nge7 10. Nd5 d6 11. Bg5 h6 12. Bf6 Qb8 13. Rc1 Ng6 14. h4 exd5 15.
+exd5+ Nce5 16. Nxe5 dxe5 17. d6 Bxd6 18. Bxg7 Rg8 19. Bxh6 Nxh4 20. Bxf7+ Kxf7
+21. Qh5+ Rg6 22. Qxh4 Rxg2+ 23. Kf1 Qg8 24. Rcd1 Rg1+ 25. Ke2 Rxe1+ 26. Kxe1
+Ke6 27. Kd2 Qg6 28. Qh3+ Qf5 29. Qxf5+ Kxf5 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "chesslismab"]
+[Black "hungzhao"]
+[Result "0-1"]
+[ECO "A40"]
+[WhiteElo "2450"]
+[BlackElo "2625"]
+[PlyCount "116"]
+[EventDate "2020.??.??"]
+
+1. d4 e6 2. Nf3 Nf6 3. g3 b6 4. Bg2 Bb7 5. O-O c5 6. dxc5 Bxc5 7. c4 Be7 8. a3
+d6 9. Nc3 Nbd7 10. Nd4 Bxg2 11. Kxg2 Qc7 12. Qd3 Rc8 13. b3 a6 14. Bg5 Ne5 15.
+Qd2 Qb7+ 16. f3 h6 17. Bxf6 Bxf6 18. Rac1 Be7 19. Rfd1 O-O 20. Nc2 Bg5 21. Ne3
+Rfd8 22. h4 Be7 23. Ne4 b5 24. cxb5 Rxc1 25. Rxc1 axb5 26. Qa5 Nc6 27. Qc3 Rc8
+28. Qd3 d5 29. Nc5 Bxc5 30. Rxc5 b4 31. axb4 Nxb4 32. Qc3 Rxc5 33. Qxc5 Na6 34.
+Qc3 Qb5 35. Nc2 Qxe2+ 36. Kh3 Qf1+ 37. Kh2 Qb5 38. Nd4 Qb4 39. Qc8+ Kh7 40.
+Nxe6 Qd2+ 41. Kh3 fxe6 42. Qxa6 Qe3 43. Qf1 Qxb3 44. f4 Qe3 45. h5 g6 46. Qb1
+Qe4 47. Qxe4 dxe4 48. hxg6+ Kxg6 49. Kg2 h5 50. Kf2 Kf5 51. Ke3 Kg4 52. Kxe4
+Kxg3 53. Ke5 Kg4 54. Kxe6 Kxf4 55. Kf6 h4 56. Kg6 h3 57. Kf6 h2 58. Ke6 h1=Q
+0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "macp1988"]
+[Black "aminmohamad64"]
+[Result "0-1"]
+[ECO "A41"]
+[WhiteElo "2424"]
+[BlackElo "2383"]
+[PlyCount "46"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 g6 2. e4 Bg7 3. c4 d6 4. Nc3 Nc6 5. Be3 e5 6. d5 Nce7 7. Bd3 f5 8. f3 Nf6
+9. Nge2 O-O 10. Qd2 f4 11. Bf2 g5 12. O-O-O a6 13. b4 b5 14. c5 a5 15. a3 axb4
+16. axb4 c6 17. cxd6 Qxd6 18. Bc5 Qd7 19. dxc6 Nxc6 20. Bxb5 Qb7 21. Kb2 Be6
+22. Ra1 Rad8 23. Bxc6 Rxd2+ 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "karakosh"]
+[Black "LordGrim2500"]
+[Result "1-0"]
+[ECO "D01"]
+[WhiteElo "2384"]
+[BlackElo "2478"]
+[PlyCount "45"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 Nf6 2. Nc3 d5 3. Bg5 c6 4. Nf3 Bf5 5. e3 Nbd7 6. Bd3 Bxd3 7. cxd3 e6 8.
+O-O Qb6 9. Qd2 Bd6 10. Na4 Qa6 11. a3 c5 12. dxc5 Nxc5 13. Nxc5 Bxc5 14. Bxf6
+gxf6 15. e4 Rd8 16. Qh6 Qxd3 17. Qxf6 Rg8 18. Ne5 Rxg2+ 19. Kxg2 Qxe4+ 20. Kg1
+Rd7 21. Nxd7 Qg4+ 22. Kh1 Be7 23. f3 1-0
+
+[Event "Rated Blitz tournament hM7PUvgg"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Supelyel"]
+[Black "samidescalona2002"]
+[Result "1-0"]
+[ECO "E85"]
+[WhiteElo "2376"]
+[BlackElo "2437"]
+[PlyCount "49"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. c4 Nf6 2. Nc3 g6 3. f3 d6 4. e4 Bg7 5. d4 O-O 6. Be3 e5 7. Nge2 Nh5 8. Qd2
+Nc6 9. O-O-O Bd7 10. g4 exd4 11. Nxd4 Nxd4 12. Bxd4 Bxd4 13. Qxd4 Nf4 14. e5
+Ne6 15. Qd2 Bc6 16. Bg2 dxe5 17. Qe2 Qf6 18. Rhe1 Nf4 19. Qf2 Rad8 20. Bf1 Bxf3
+21. Qxf3 Nd3+ 22. Rxd3 Qg5+ 23. Qe3 Qh4 24. Rxd8 Rxd8 25. h3 1-0
+
+[Event "Rated Blitz tournament OxRShNHO"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Alfilparanoico"]
+[Black "elveneno"]
+[Result "0-1"]
+[ECO "B09"]
+[WhiteElo "2475"]
+[BlackElo "2475"]
+[PlyCount "64"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 Nf6 2. Nc3 g6 3. e4 d6 4. f4 Bg7 5. Nf3 O-O 6. Bd3 Na6 7. Bxa6 bxa6 8.
+Be3 Bb7 9. Qd3 Qc8 10. O-O a5 11. Rfe1 Ng4 12. Bd2 Re8 13. h3 Nf6 14. e5 Nd7
+15. e6 fxe6 16. Ng5 Nf8 17. Qc4 d5 18. Qa4 c5 19. Be3 Bc6 20. Qxa5 cxd4 21. Bd2
+dxc3 22. Bxc3 d4 23. Bd2 Qb7 24. Nxe6 Nxe6 25. Rxe6 Bxg2 26. Rae1 Bxh3 27. R6e2
+e5 28. Kh2 Bg4 29. Rg2 Bf3 30. Rf2 e4 31. Bb4 e3 32. Rff1 Rad8 0-1
+
+[Event "Rated Rapid game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Ahmet19114"]
+[Black "GMRAC"]
+[Result "1-0"]
+[ECO "B06"]
+[WhiteElo "2312"]
+[BlackElo "2409"]
+[PlyCount "129"]
+[EventDate "2020.??.??"]
+[EventType "rapid"]
+
+1. e4 g6 2. d4 Bg7 3. Nf3 c6 4. Bd3 d5 5. e5 Bg4 6. h3 Bxf3 7. Qxf3 e6 8. Nd2
+Ne7 9. c4 Nd7 10. cxd5 exd5 11. O-O c5 12. dxc5 O-O 13. Qe2 Nxe5 14. Nf3 Nxf3+
+15. Qxf3 Re8 16. Bg5 Qc7 17. Rfe1 Qxc5 18. Rac1 Qd6 19. Bf4 Qf6 20. Rc7 Nc6 21.
+Rxe8+ Rxe8 22. Bd2 Qxf3 23. gxf3 Ne5 24. Be2 Nc6 25. Bb5 Rd8 26. Bxc6 bxc6 27.
+b3 Bd4 28. Rxc6 Bb6 29. a4 Rd7 30. b4 f5 31. a5 Bc7 32. b5 Kf7 33. Kf1 Bd8 34.
+Ke2 Rb7 35. Rc5 Rb8 36. Bf4 Ra8 37. Bc7 Bxc7 38. Rxc7+ Ke6 39. Ke3 Rb8 40. Rc5
+g5 41. Kd4 h6 42. Rxd5 h5 43. f4 gxf4 44. a6 f3 45. h4 Rh8 46. Re5+ Kf6 47. Rc5
+Rd8+ 48. Rd5 Rb8 49. Kc5 Rc8+ 50. Kb4 Rc2 51. Kb3 Rxf2 52. b6 Rg2 53. b7 Rg8
+54. Rc5 f2 55. Rc1 Ke7 56. Rf1 Kd6 57. Rxf2 Kc6 58. Rxf5 Kb6 59. Rf6+ Kc5 60.
+Rf5+ Kd4 61. Rxh5 Re8 62. Rb5 Rb8 63. Kb4 Kd3 64. Rc5 Rd8 65. Rc8 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "gmmitkov"]
+[Black "Evgen_88"]
+[Result "1-0"]
+[ECO "C11"]
+[WhiteElo "2495"]
+[BlackElo "2538"]
+[PlyCount "66"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 e6 2. Nc3 d5 3. d4 Nf6 4. e5 Nfd7 5. f4 c5 6. Nf3 Nc6 7. Be3 Qb6 8. a3
+cxd4 9. Nxd4 Bc5 10. Ncb5 O-O 11. b4 Bxd4 12. Nxd4 Nxd4 13. Bxd4 Qc7 14. Bd3 a5
+15. O-O b6 16. Qe2 f5 17. exf6 Nxf6 18. Rae1 axb4 19. axb4 Ra2 20. h3 Bd7 21.
+Qe3 Ne4 22. Re2 Rb8 23. c3 Rxe2 24. Bxe2 Bc6 25. Be5 Qc8 26. Bxb8 Qxb8 27. Qd4
+h6 28. Bd3 Nf6 29. Qe5 Qc8 30. f5 exf5 31. Bxf5 Bd7 32. Bxd7 Qxd7 33. Re1 Qc6
+1-0
+
+[Event "Rated Blitz tournament nLsDCFvz"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "spidernv"]
+[Black "dukenebur"]
+[Result "1-0"]
+[ECO "A30"]
+[WhiteElo "2423"]
+[BlackElo "2363"]
+[PlyCount "63"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. c4 c5 2. g3 Nc6 3. Bg2 e5 4. Nc3 d6 5. e3 Be6 6. b3 Be7 7. Nge2 h5 8. d4 Bf5
+9. h3 Nf6 10. Bb2 a6 11. Nd5 Nxd5 12. cxd5 Nb4 13. e4 Bg6 14. a3 cxd4 15. axb4
+O-O 16. O-O f5 17. exf5 Bxf5 18. f4 Qb6 19. Kh2 Qxb4 20. fxe5 Rac8 21. Nxd4 Bg6
+22. Rxf8+ Rxf8 23. Qe1 Qb6 24. Ne6 Rf5 25. exd6 Bxd6 26. Nxg7 Rf2 27. Qe6+ Kh7
+28. Ne8 Rxb2 29. Qd7+ Kh6 30. Qg7+ Kg5 31. h4+ Kg4 32. Qxg6# 1-0
+
+[Event "Rated Bullet tournament GAdGz1co"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Zuritadas"]
+[Black "RaylessStarfish"]
+[Result "0-1"]
+[ECO "B01"]
+[WhiteElo "2394"]
+[BlackElo "2387"]
+[PlyCount "128"]
+[EventDate "2020.??.??"]
+
+1. e4 d5 2. exd5 Nf6 3. c4 e6 4. Be2 exd5 5. d4 c6 6. cxd5 Nxd5 7. Nf3 Bd6 8.
+O-O O-O 9. Nc3 Nd7 10. Nxd5 cxd5 11. Bg5 f6 12. Bh4 b6 13. Qb3 Bb7 14. Bg3 Bxg3
+15. hxg3 Re8 16. Rfe1 Nf8 17. Nd2 Ne6 18. Qd3 Qd6 19. Bf3 Rad8 20. Nf1 Qb4 21.
+Ne3 Qxd4 22. Rad1 Qxd3 23. Rxd3 Nc5 24. Bxd5+ Kf8 25. Bxb7 Rxd3 26. Ba6 Rd2 27.
+b4 Nd3 28. Bxd3 Rxd3 29. Rc1 Re7 30. Rc8+ Kf7 31. Nf5 Re1+ 32. Kh2 Rd7 33. g4
+g6 34. Ne3 Re2 35. Kg3 Rxa2 36. g5 fxg5 37. Nc4 Rd3+ 38. f3 h5 39. Ne5+ Kf6 40.
+Nxd3 Ra3 41. Rd8 Kg7 42. Rd7+ Kh6 43. f4 gxf4+ 44. Kxf4 Rc3 45. g4 Rc4+ 46. Ke5
+Rxg4 47. Nf4 Rg5+ 48. Ke6 h4 49. Nd5 Rf5 50. Nf6 Kg5 51. Rg7 Rxf6+ 52. Ke7 Rf5
+53. Rh7 Rf6 54. Rxh4 Kf5 55. Rf4+ Kxf4 56. Kxf6 g5 57. b5 g4 58. Ke6 g3 59. Kd6
+g2 60. Kc6 g1=Q 61. Kb7 Qc5 62. Kxa7 Qxb5 63. Kb7 Qc5 64. Kb8 b5 0-1
+
+[Event "Rated Bullet tournament GAdGz1co"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "JeanGoulifet"]
+[Black "ScherlockKA"]
+[Result "1-0"]
+[ECO "A43"]
+[WhiteElo "2409"]
+[BlackElo "2324"]
+[PlyCount "99"]
+[EventDate "2020.??.??"]
+
+1. d4 c5 2. d5 d6 3. Nc3 g6 4. e4 b5 5. Bxb5+ Bd7 6. Bxd7+ Nxd7 7. f3 Bg7 8.
+Nge2 Ngf6 9. O-O Rb8 10. Rb1 O-O 11. Bg5 h6 12. Be3 Qa5 13. Qd2 Kh7 14. Nd1
+Qxa2 15. Ndc3 Qa5 16. Ra1 Qb6 17. b3 Ne8 18. Na4 Qb4 19. Rad1 Qxd2 20. Bxd2 Nc7
+21. Bc3 Nb5 22. Bxg7 Kxg7 23. Nec3 Nd4 24. Rf2 Rb4 25. Nb2 Rfb8 26. Nd3 R4b7
+27. Rfd2 a5 28. Ra1 Nxb3 29. cxb3 Rxb3 30. Nd1 c4 31. Nc1 Rb1 32. Rxb1 Rxb1 33.
+Rc2 Nb6 34. Ne3 a4 35. Nxc4 Nxc4 36. Rxc4 a3 37. Kf2 a2 38. Nxa2 Rb2+ 39. Kg3
+Rxa2 40. Rc7 h5 41. Rxe7 Kf6 42. Rd7 Ra6 43. h3 Rb6 44. h4 Ra6 45. Rc7 Rb6 46.
+Rc6 Rxc6 47. dxc6 Ke7 48. Kf4 Kd8 49. Kg5 Kc7 50. Kf6 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Tigerscot"]
+[Black "JLeon"]
+[Result "0-1"]
+[ECO "A45"]
+[WhiteElo "2464"]
+[BlackElo "2569"]
+[PlyCount "115"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 Nf6 2. Nc3 c5 3. d5 d6 4. e4 g6 5. Nf3 Bg7 6. Be2 Bg4 7. O-O O-O 8. Bf4
+a6 9. a4 Nbd7 10. h3 Bxf3 11. Bxf3 Rb8 12. Be2 Ne8 13. Qd2 Nc7 14. Bh6 b5 15.
+Bxg7 Kxg7 16. Nd1 Nb6 17. a5 Nd7 18. Ne3 Nf6 19. f3 e5 20. Kf2 Nh5 21. g3 Kh8
+22. Rg1 Qe7 23. Raf1 Ne8 24. Ke1 Neg7 25. Kd1 c4 26. Qb4 Rfc8 27. c3 Qg5 28.
+Ng4 f5 29. h4 Qe7 30. Nh6 f4 31. g4 Ng3 32. g5 Nxf1 33. Bxf1 Rc5 34. Bh3 Nh5
+35. Be6 Kg7 36. Qa3 Ng3 37. Qa1 b4 38. Kc2 bxc3 39. bxc3 Qb7 40. Rb1 Qxb1+ 41.
+Qxb1 Rxb1 42. Kxb1 Rxa5 43. Nf7 Rb5+ 44. Kc2 Rb6 45. Nd8 a5 46. Bd7 Nf1 47.
+Ne6+ Kg8 48. Be8 Ne3+ 49. Kc1 Ng2 50. Nd8 Rb8 51. Bf7+ Kg7 52. Nc6 Rb3 53. Be6
+Rxc3+ 54. Kb2 Rxf3 55. Nxa5 c3+ 56. Kc2 Ne1+ 57. Kd1 c2+ 58. Kd2 0-1
+
+[Event "Rated Blitz tournament hM7PUvgg"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "RCSA007"]
+[Black "Club-Jaque-al-Rey"]
+[Result "1-0"]
+[ECO "D06"]
+[WhiteElo "2425"]
+[BlackElo "2536"]
+[PlyCount "117"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 d5 2. c4 c5 3. cxd5 Qxd5 4. Nf3 cxd4 5. Nc3 Qa5 6. Nxd4 Nf6 7. Nb3 Qc7 8.
+g3 Bd7 9. Bg2 Bc6 10. e4 Nbd7 11. O-O Rd8 12. Be3 Nb6 13. Qe2 e6 14. Rac1 Qb8
+15. Na5 Bb4 16. Nxc6 bxc6 17. a3 Be7 18. h3 O-O 19. Rfd1 Qb7 20. Re1 Rfe8 21.
+Rc2 Rd7 22. Rec1 Red8 23. Na2 Na4 24. b4 Qb5 25. Qf3 Rc8 26. Nc3 Nxc3 27. Rxc3
+h6 28. Bf1 Qa4 29. b5 Qxe4 30. Qxe4 Nxe4 31. Rxc6 Rcd8 32. a4 Bg5 33. Bxg5 hxg5
+34. Rc8 Rxc8 35. Rxc8+ Kh7 36. Rc2 Kg6 37. a5 Nd2 38. Bg2 Nb3 39. Ra2 Nc1 40.
+Ra3 Ne2+ 41. Kh2 Nd4 42. b6 axb6 43. axb6 Nb5 44. Ra8 Nd6 45. Bc6 Re7 46. Ra7
+Kf6 47. Rxe7 Kxe7 48. b7 Nxb7 49. Bxb7 Kd6 50. Kg2 Ke5 51. Bf3 f5 52. Bb7 g6
+53. Bc8 Kf6 54. Kf3 e5 55. Ke3 e4 56. Kd4 Kg7 57. Ke5 Kf7 58. Be6+ Kg7 59. Bd5
+1-0
+
+[Event "Rated Blitz tournament hM7PUvgg"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Fasmc17"]
+[Black "lama17"]
+[Result "0-1"]
+[ECO "A41"]
+[WhiteElo "2333"]
+[BlackElo "2332"]
+[PlyCount "48"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 g6 2. c4 Bg7 3. Nc3 d6 4. e4 Nd7 5. f3 e5 6. Be3 Ne7 7. dxe5 Nxe5 8. Rc1
+O-O 9. b3 f5 10. c5 fxe4 11. Nxe4 Nf5 12. Bf2 d5 13. Nc3 c6 14. Nce2 Re8 15. g4
+Nh4 16. Rc3 Nexf3+ 17. Rxf3 Nxf3+ 18. Nxf3 Bxg4 19. Bg2 Qf6 20. Bh4 Qe6 21. Rf1
+Qe4 22. Rf2 Re6 23. Nfg1 Qb4+ 24. Qd2 Bc3 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Paanoos"]
+[Black "rudolf85"]
+[Result "1-0"]
+[ECO "C11"]
+[WhiteElo "2379"]
+[BlackElo "2424"]
+[PlyCount "177"]
+[EventDate "2020.??.??"]
+
+1. d4 d5 2. Nc3 Nf6 3. Bg5 e6 4. e4 dxe4 5. Nxe4 Nbd7 6. Nf3 Be7 7. Bxf6 Nxf6
+8. Bd3 Bd7 9. Qe2 Bc6 10. Nxf6+ Bxf6 11. c3 a5 12. Be4 Qd7 13. Bxc6 Qxc6 14.
+O-O O-O 15. Rfe1 Qb6 16. Ne5 Bxe5 17. dxe5 Rad8 18. Rad1 a4 19. Qc2 Qc6 20. b3
+axb3 21. axb3 g6 22. c4 h5 23. h3 Kg7 24. Qc3 b5 25. Rc1 Rd7 26. cxb5 Qxb5 27.
+Qc4 Qb6 28. Qf4 Rfd8 29. Qf6+ Kg8 30. Kh2 Qb4 31. Re3 Qe7 32. Qxe7 Rxe7 33.
+Rec3 Rd5 34. f4 Rb5 35. Rxc7 Rxc7 36. Rxc7 Rxb3 37. h4 Kg7 38. Ra7 Rb8 39. Kg3
+Rf8 40. Ra3 Rg8 41. Rd3 Rf8 42. Rd6 Re8 43. Rd7 Rf8 44. Rd6 Rg8 45. Rc6 Rf8 46.
+Rc7 Rg8 47. Kf3 Rh8 48. g3 Rg8 49. Ke4 Rf8 50. Rc5 Rd8 51. Rc4 Rd1 52. Rd4 Re1+
+53. Kf3 Rg1 54. Kf2 Ra1 55. Rd2 Ra3 56. Re2 Ra8 57. Re3 Re8 58. Kf3 Rf8 59. Rd3
+Rg8 60. Ke3 Rf8 61. Rd7 Re8 62. Rb7 Rd8 63. Rb4 Rc8 64. Rd4 Rc3+ 65. Ke4 Rc2
+66. Rd3 Rc1 67. Ke3 Rg1 68. Kf2 Rh1 69. Rd2 Rb1 70. Kf3 Rb7 71. Ke3 Rc7 72. Rd3
+Re7 73. Kf3 f6 74. Re3 fxe5 75. Kf2 Rf7 76. Rxe5 Rf5 77. Kf3 Rf6 78. Ke4 Kf7
+79. Rc5 Rf5 80. Rc8 Kf6 81. Rc7 g5 82. hxg5+ Kg6 83. Rc6 Rf6 84. gxf6 h4 85.
+Rxe6 Kh5 86. f5 hxg3 87. f7 Kg4 88. f8=Q g2 89. Qg8+ 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Ridics"]
+[Black "Filemon64"]
+[Result "0-1"]
+[ECO "B23"]
+[WhiteElo "2306"]
+[BlackElo "2320"]
+[PlyCount "77"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 e6 2. Nc3 c5 3. d4 cxd4 4. Qxd4 Nc6 5. Qd1 Nf6 6. Be3 Bb4 7. f3 d5 8.
+exd5 Nxd5 9. Bd2 O-O 10. Nxd5 exd5 11. Bxb4 Re8+ 12. Ne2 Qh4+ 13. g3 Qxb4+ 14.
+Kf2 Qxb2 15. Bg2 Qb6+ 16. Kf1 d4 17. Rb1 Qc5 18. Qd3 Bf5 19. Rb5 Bxd3 20. Rxc5
+Bxe2+ 21. Kf2 Ba6 22. Rb1 Re2+ 23. Kg1 Rae8 24. Bf1 Re1 25. Kf2 Rxb1 26. Bxa6
+bxa6 27. Rxc6 Rb2 28. Kf1 Rxa2 29. Rc4 d3 30. cxd3 Rb8 31. Rc1 a5 32. d4 a4 33.
+d5 Rxh2 34. d6 Rh1+ 35. Kg2 Rxc1 36. d7 a3 37. Kh3 a2 38. d8=Q+ Rxd8 39. Kg4
+0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Molot_ua"]
+[Black "Yoseqpuedo"]
+[Result "1-0"]
+[ECO "A00"]
+[WhiteElo "2371"]
+[BlackElo "2413"]
+[PlyCount "73"]
+[EventDate "2020.??.??"]
+
+1. d3 e6 2. c3 f5 3. Nd2 Nf6 4. h3 Be7 5. g4 O-O 6. Bg2 Kh8 7. gxf5 exf5 8.
+Ngf3 d5 9. Rg1 Nc6 10. Qa4 Bd6 11. Nf1 Bd7 12. Qh4 Ne7 13. Bh1 Be8 14. Ng5 Ng6
+15. Qd4 c5 16. Qe3 Bf4 17. Qxc5 Bxc1 18. Rxc1 Rc8 19. Qxa7 Qe7 20. Ne3 f4 21.
+Nf5 Qd7 22. Nd4 Qe7 23. Nge6 Rf7 24. Rxg6 hxg6 25. Bf3 Bd7 26. Ng5 Rff8 27.
+Qxb7 Rce8 28. Kd2 Rb8 29. Qc7 Rxb2+ 30. Ke1 Rc8 31. Qxf4 Kg8 32. Qh4 Bf5 33.
+Bxd5+ Be6 34. Qh8+ Kxh8 35. Bxe6 Rf8 36. Nf7+ Rxf7 37. Nf5 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "bayrischerFuchs"]
+[Black "alphonsea"]
+[Result "0-1"]
+[ECO "A57"]
+[WhiteElo "2374"]
+[BlackElo "2310"]
+[PlyCount "104"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 Nf6 2. c4 c5 3. d5 b5 4. cxb5 a6 5. f3 e6 6. e4 exd5 7. e5 Nh5 8. Qxd5
+Ra7 9. Bc4 d6 10. Nc3 Qh4+ 11. Kf1 Be6 12. Qxe6+ fxe6 13. Bxe6 Ng3+ 14. hxg3
+Qxh1 15. Bh3 h5 16. Bf4 dxe5 17. Bxe5 Nd7 18. Bf4 Nf6 19. Re1+ Re7 20. Rd1 axb5
+21. Nxb5 h4 22. Nd6+ Kd8 23. Nf7+ Ke8 24. Nxh8 hxg3 25. Ng6 Nh5 26. Bg5 Rb7 27.
+Bf5 Nf6 28. Bh3 c4 29. b3 Bc5 30. Ke2 cxb3 31. axb3 Rxb3 32. Ne5 Rb2+ 33. Kd3
+Rxg2 34. Bxg2 Qxg2 35. Ne2 Bd6 36. Bxf6 gxf6 37. Nc4 Qxf3+ 38. Ne3 Bc5 39. Nd4
+Bxd4 40. Kxd4 g2 41. Rg1 f5 42. Rxg2 f4 43. Rg8+ Kf7 44. Re8 fxe3 45. Rxe3 Qf2
+46. Kd3 Kg7 47. Re4 Qf1+ 48. Kd4 Qa1+ 49. Kd5 Qa8+ 50. Ke6 Kg6 51. Ke5 Qe8+ 52.
+Kf4 Qf7+ 0-1
+
+[Event "Rated Blitz tournament hM7PUvgg"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "emmacristal"]
+[Black "Janemba"]
+[Result "0-1"]
+[ECO "E06"]
+[WhiteElo "2341"]
+[BlackElo "2312"]
+[PlyCount "66"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 Nf6 2. c4 e6 3. Nf3 d5 4. g3 Be7 5. Bg2 O-O 6. O-O b6 7. Qc2 Bb7 8. b3
+Nbd7 9. Nc3 Rc8 10. Bb2 dxc4 11. bxc4 Bb4 12. Rfd1 a5 13. h4 Qe7 14. a3 Bxc3
+15. Qxc3 Ne4 16. Qe3 f5 17. Ng5 Ndf6 18. a4 c5 19. Ba3 Ng4 20. Qf4 Ngxf2 21.
+dxc5 bxc5 22. Rdb1 Bc6 23. Rb6 Nxg5 24. Kxf2 Bxg2 25. Kxg2 Ne4 26. Rab1 Rc7 27.
+Qe5 Qf6 28. Qxc7 Qc3 29. Qf4 h6 30. Rxe6 Qc2 31. Re1 Qxc4 32. Rg6 Kh7 33. h5
+Qd5 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Atomrod"]
+[Black "Midnight_Mushroom"]
+[Result "1-0"]
+[ECO "E17"]
+[WhiteElo "2488"]
+[BlackElo "2431"]
+[PlyCount "53"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 Nf6 2. Nf3 b6 3. c4 Bb7 4. Nc3 e6 5. a3 g6 6. g3 Bg7 7. Bg2 O-O 8. d5
+exd5 9. cxd5 c5 10. dxc6 dxc6 11. O-O c5 12. Bf4 Bc6 13. Ne5 Bxg2 14. Kxg2 Nh5
+15. Qxd8 Nxf4+ 16. gxf4 Rxd8 17. Rfd1 Na6 18. Nb5 Bxe5 19. fxe5 Kf8 20. f4 Ke8
+21. Kf3 Rd7 22. Rxd7 Kxd7 23. a4 Nc7 24. Rd1+ Kc6 25. Rd6+ Kb7 26. Rd7 Rc8 27.
+Rxf7 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Dynamovec"]
+[Black "Maybach77"]
+[Result "1-0"]
+[ECO "B02"]
+[WhiteElo "2406"]
+[BlackElo "2367"]
+[PlyCount "41"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 Nf6 2. d3 e5 3. f4 exf4 4. Bxf4 d5 5. e5 Nfd7 6. Nf3 c5 7. c3 Nc6 8. d4
+Qb6 9. Qd2 Be7 10. Be3 cxd4 11. cxd4 O-O 12. Nc3 Bb4 13. Bd3 f6 14. e6 Nde5 15.
+dxe5 d4 16. Nxd4 Nxd4 17. Bxd4 Qxe6 18. O-O Rd8 19. exf6 Rxd4 20. Bxh7+ Kxh7
+21. Qxd4 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "PimponNicois"]
+[Black "fedateam"]
+[Result "1-0"]
+[ECO "B21"]
+[WhiteElo "2330"]
+[BlackElo "2350"]
+[PlyCount "119"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 c5 2. Nf3 a6 3. d4 cxd4 4. c3 dxc3 5. Nxc3 Nc6 6. Bc4 e6 7. O-O Bb4 8.
+Qe2 Nge7 9. Bf4 O-O 10. Rfd1 Re8 11. Rac1 Bxc3 12. Rxc3 d5 13. Re3 Na5 14. Bd3
+d4 15. Nxd4 Qxd4 16. Bb5 Qxd1+ 17. Qxd1 axb5 18. Be5 Nac6 19. Bd6 e5 20. Rg3
+Rd8 21. Rd3 Be6 22. Bxe7 Rxd3 23. Qxd3 Nxe7 24. a3 Nc6 25. Qxb5 Rd8 26. h3 Rd7
+27. a4 f6 28. a5 Nd4 29. Qb6 Kf7 30. b4 Bc4 31. Kh2 Bb5 32. Qc5 Ba6 33. h4 h5
+34. f3 Nb5 35. f4 Re7 36. Qd5+ Kg6 37. Qd8 Rc7 38. Qe8+ Kh6 39. f5 Kh7 40.
+Qxh5+ Kg8 41. Qe8+ Kh7 42. h5 Nd4 43. Qg6+ Kh8 44. h6 Be2 45. hxg7+ Rxg7 46.
+Qxf6 Bf3 47. gxf3 Nxf3+ 48. Kh3 Ng1+ 49. Kh4 Nf3+ 50. Kh5 Kh7 51. Qh6+ Kg8 52.
+Qf6 Kh7 53. Qh6+ Kg8 54. Qxg7+ Kxg7 55. Kg4 Nd2 56. Kg3 Nc4 57. Kg4 Kf7 58. Kg5
+Nb6 59. Kg4 Na4 60. Kg5 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "alireza3700"]
+[Black "Aisen_Mestnikov"]
+[Result "0-1"]
+[ECO "D00"]
+[WhiteElo "2348"]
+[BlackElo "2383"]
+[PlyCount "126"]
+[EventDate "2020.??.??"]
+
+1. d4 d5 2. Nc3 c6 3. f3 g6 4. e4 Bg7 5. Be3 e5 6. dxe5 Ne7 7. exd5 cxd5 8.
+Bb5+ Nbc6 9. Nge2 O-O 10. Qd2 Nxe5 11. O-O-O a6 12. Bd3 Nxd3+ 13. Qxd3 Bf5 14.
+Qd2 Rc8 15. Nd4 b5 16. Nxf5 Nxf5 17. Bg5 Qa5 18. Kb1 Bxc3 19. bxc3 Qxc3 20.
+Qxc3 Rxc3 21. Rxd5 Rfc8 22. Rhd1 Rxc2 23. Bf6 Re2 24. Rd7 Re6 25. Bb2 Ne3 26.
+Rd8+ Re8 27. Rxc8 Rxc8 28. Rd7 Nc4 29. Ra7 Nxb2 30. Kxb2 Rc5 31. Rxa6 Re5 32.
+Kb3 Kg7 33. g3 Re2 34. h4 Re3+ 35. Kb4 Rxf3 36. Kxb5 Rxg3 37. a4 Rg4 38. a5
+Rxh4 39. Rc6 Rh5+ 40. Rc5 Rh1 41. Rc4 Rb1+ 42. Rb4 Rd1 43. Ra4 Rd7 44. a6 h5
+45. Kb6 Rd6+ 46. Kb7 Rxa6 47. Kxa6 g5 48. Kb5 Kg6 49. Ra1 h4 50. Rf1 f5 51. Rh1
+g4 52. Kc4 Kg5 53. Kd3 g3 54. Ke2 f4 55. Kf3 Kh5 56. Rh3 Kg5 57. Kg2 Kg4 58.
+Rh1 f3+ 59. Kf1 h3 60. Kg1 g2 61. Kf2 gxh1=Q 62. Ke3 Qg2 63. Ke4 f2+ 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "estocastico"]
+[Black "ROBESPIERR"]
+[Result "0-1"]
+[ECO "D40"]
+[WhiteElo "2588"]
+[BlackElo "2553"]
+[PlyCount "96"]
+[EventDate "2020.??.??"]
+
+1. d4 d5 2. Nf3 e6 3. c4 Nf6 4. Nc3 c5 5. Bf4 cxd4 6. Nxd4 Nc6 7. cxd5 exd5 8.
+e3 Bb4 9. Rc1 O-O 10. Be2 Ne4 11. O-O Nxc3 12. bxc3 Bd6 13. Bg3 Bxg3 14. hxg3
+Re8 15. Rb1 Ne5 16. Qa4 g6 17. Rfd1 Bg4 18. Bxg4 Nxg4 19. Rxb7 Qf6 20. Nf3 h5
+21. Qf4 Qxf4 22. gxf4 Rab8 23. Rxa7 Rb2 24. Rf1 Rc8 25. Ng5 Rxc3 26. a4 Rcc2
+27. Nh3 Ra2 28. a5 Nxe3 29. Re1 Nf5 30. Ng5 Re2 31. Rxe2 Rxe2 32. a6 Ra2 33.
+Nxf7 d4 34. Ne5 Nh6 35. f3 Nf5 36. Nxg6 d3 37. Rd7 d2 38. Ne5 Ra1+ 39. Kf2 d1=Q
+40. Rxd1 Rxd1 41. Nc6 Rd2+ 42. Kf1 Ra2 43. a7 Ne3+ 44. Kg1 Rxg2+ 45. Kh1 Ra2
+46. f5 h4 47. f6 h3 48. Ne5 Nf5 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Betovsky"]
+[Black "taras05"]
+[Result "0-1"]
+[ECO "A00"]
+[WhiteElo "2638"]
+[BlackElo "2474"]
+[PlyCount "168"]
+[EventDate "2020.??.??"]
+
+1. a3 a5 2. b3 d5 3. Bb2 Nd7 4. d3 e6 5. c4 Ngf6 6. cxd5 exd5 7. Nf3 c6 8. g3
+Bd6 9. Bg2 Qe7 10. O-O O-O 11. e4 dxe4 12. dxe4 Re8 13. e5 Nxe5 14. Nxe5 Bxe5
+15. Re1 Nd7 16. Bh3 f6 17. f4 Bd4+ 18. Bxd4 Qxe1+ 19. Qxe1 Rxe1+ 20. Kf2 Re8
+21. Nc3 Nf8 22. Bf1 Be6 23. Bb6 Rac8 24. b4 Nd7 25. Be3 axb4 26. axb4 Ra8 27.
+Rd1 Nf8 28. b5 Bf7 29. bxc6 bxc6 30. Bg2 Rac8 31. Rd6 Ng6 32. h4 Ne7 33. Na4
+Red8 34. Rxd8+ Rxd8 35. Bb6 Rd2+ 36. Kf1 Ra2 37. Nc3 Ra1+ 38. Kf2 Nd5 39. Bd4
+Nxc3 40. Bxc3 Ra2+ 41. Kg1 Rc2 42. Be1 Rc1 43. Kf2 Rxe1 44. Kxe1 Bd5 45. Bf1
+Kf7 46. Kd2 g6 47. Bd3 Ke6 48. h5 f5 49. hxg6 hxg6 50. Be2 Kf6 51. Bd3 g5 52.
+Ke3 gxf4+ 53. gxf4 Ke6 54. Be2 Be4 55. Kd4 Kd6 56. Bc4 c5+ 57. Kc3 Bd5 58. Be2
+Be6 59. Bd1 Kc6 60. Bc2 Bd5 61. Bxf5 Kd6 62. Bd3 Be6 63. Bc2 Bf7 64. Kd2 Ke7
+65. Ke3 Kf6 66. f5 Be6 67. Kf4 Bf7 68. Bb3 Be8 69. Be6 Bf7 70. Bxf7 Kxf7 71.
+Ke5 Ke7 72. f6+ Kf7 73. Kf5 c4 74. Kg5 c3 75. Kf5 c2 76. Ke5 c1=Q 77. Kf5 Qc2+
+78. Kg5 Qd2+ 79. Kf5 Qe2 80. Kg5 Qf2 81. Kg4 Qg2+ 82. Kh5 Qf2 83. Kg4 Qe2+ 84.
+Kh4 Qe3 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "troisi"]
+[Black "murderoflegends"]
+[Result "1-0"]
+[ECO "A00"]
+[WhiteElo "2374"]
+[BlackElo "2422"]
+[PlyCount "53"]
+[EventDate "2020.??.??"]
+
+1. g3 h5 2. Bg2 h4 3. gxh4 Rxh4 4. d4 d5 5. Nf3 Rh5 6. c4 c6 7. cxd5 cxd5 8.
+Nc3 Nc6 9. Bf4 Nf6 10. Bg3 Bg4 11. Ne5 Bh3 12. Bxh3 Rxh3 13. Qa4 Qb6 14. Nxc6
+bxc6 15. b3 e6 16. O-O Bb4 17. Rac1 Ke7 18. a3 Bd6 19. Bxd6+ Kxd6 20. f3 Rah8
+21. e4 Ke7 22. e5 Nd7 23. Rf2 Rb8 24. b4 Rbh8 25. Qd1 Nf8 26. Na4 Ke8 27. Nxb6
+1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "vassiukov"]
+[Black "vaillant77"]
+[Result "0-1"]
+[ECO "A46"]
+[WhiteElo "2344"]
+[BlackElo "2448"]
+[PlyCount "64"]
+[EventDate "2020.??.??"]
+
+1. d4 Nf6 2. Nf3 e6 3. Bf4 b6 4. e3 Bb7 5. Nbd2 Be7 6. h3 O-O 7. Bd3 d6 8. Qe2
+Nbd7 9. c3 Re8 10. Bh2 Nf8 11. e4 Ng6 12. g4 e5 13. d5 Nf4 14. Bxf4 exf4 15.
+O-O-O Nd7 16. Qf1 Ne5 17. Nxe5 dxe5 18. Nf3 Bc5 19. Bc2 a5 20. Qg2 a4 21. a3
+Ba6 22. Rhe1 Qe7 23. g5 Bxa3 24. bxa3 Qxa3+ 25. Kd2 c6 26. Ra1 Qc5 27. dxc6
+Rad8+ 28. Kc1 Qxc3 29. Rxa4 Bd3 30. Ra2 Ra8 31. Rb2 Ra1+ 32. Rb1 Qxc2# 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "allan-cantonjos"]
+[Black "Brocha"]
+[Result "0-1"]
+[ECO "A45"]
+[WhiteElo "2414"]
+[BlackElo "2450"]
+[PlyCount "38"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 Nf6 2. Nc3 g6 3. e4 Bg7 4. f3 d6 5. Be3 O-O 6. Qd2 e5 7. Nge2 exd4 8.
+Nxd4 Nc6 9. O-O-O Bd7 10. Kb1 Qe8 11. g4 Nxd4 12. Bxd4 b5 13. h4 b4 14. Bxf6
+Bxf6 15. Nd5 Qe5 16. Nxf6+ Qxf6 17. Qxb4 Qxf3 18. Bc4 Rab8 19. Qc3 Qxc3 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "WildBreath"]
+[Black "Donald666Trump"]
+[Result "1-0"]
+[ECO "C50"]
+[WhiteElo "2417"]
+[BlackElo "2389"]
+[PlyCount "31"]
+[EventDate "2020.??.??"]
+
+1. e4 e5 2. Nf3 Nc6 3. Bc4 Bc5 4. d3 Nf6 5. O-O d6 6. h3 a6 7. Be3 Bxe3 8. fxe3
+Na5 9. Bb3 Nxb3 10. axb3 O-O 11. Qe1 Re8 12. Nh4 d5 13. Nd2 dxe4 14. dxe4 Nxe4
+15. Nxe4 Qxh4 16. Qxh4 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "RigelStar"]
+[Black "abraniel"]
+[Result "0-1"]
+[ECO "A40"]
+[WhiteElo "2410"]
+[BlackElo "2402"]
+[PlyCount "138"]
+[EventDate "2020.??.??"]
+
+1. d4 c6 2. Nf3 d5 3. h3 Nf6 4. Bf4 g6 5. e3 Bg7 6. Be2 Nh5 7. O-O Nxf4 8. exf4
+O-O 9. c3 Qb6 10. Nbd2 Qxb2 11. Qc1 Qb6 12. a4 Qc7 13. a5 Qxf4 14. a6 Nxa6 15.
+Bxa6 bxa6 16. Qa3 e5 17. g3 Qf5 18. g4 Qf4 19. Qd6 Bxg4 20. hxg4 Qxg4+ 21. Kh1
+Rad8 22. Qxc6 e4 23. Nh2 Qe2 24. Rad1 Rfe8 25. Qc7 Qd3 26. Qg3 Qe2 27. Qe3 Qh5
+28. Rg1 f5 29. Rde1 Bh6 30. Qe2 Qh3 31. Rg3 Qh4 32. Kg2 f4 33. Qg4 f3+ 34. Kg1
+Qxg4 35. Rxg4 Bxd2 36. Rd1 Bxc3 37. Rg5 Re7 38. Ng4 Rc7 39. Ne3 Bb4 40. Rxd5
+Rcd7 41. Rxd7 Rxd7 42. d5 a5 43. Ra1 Kg7 44. Kf1 Bc5 45. Nc4 Bb6 46. Nxa5 Rc7
+47. d6 Rd7 48. Nc4 Bc5 49. Rd1 Bb4 50. Rd4 Bc5 51. Rxe4 Bxd6 52. Rd4 Rc7 53.
+Nxd6 Rc1+ 54. Rd1 Rb1 55. Ke1 Kh6 56. Rxb1 a5 57. Rd1 a4 58. Rd3 a3 59. Rxa3
+Kg5 60. Rxf3 Kg4 61. Rg3+ Kh4 62. Ne4 h6 63. Nd2 g5 64. Nf3+ Kh5 65. Kf1 Kg6
+66. Rg1 g4 67. Nh2 h5 68. Nxg4 Kf5 69. f3 h4 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "BerserkAdopter"]
+[Black "txebyshev"]
+[Result "1-0"]
+[ECO "C00"]
+[WhiteElo "2442"]
+[BlackElo "2351"]
+[PlyCount "105"]
+[EventDate "2020.??.??"]
+
+1. e4 e6 2. d3 d5 3. Nd2 dxe4 4. dxe4 e5 5. Ngf3 f6 6. Nxe5 fxe5 7. Qh5+ Kd7 8.
+Qxe5 Nf6 9. Bc4 Qe7 10. Qf5+ Kd8 11. Qf4 Nc6 12. O-O Qe5 13. Qe3 Bc5 14. Qd3+
+Qd4 15. Qb3 Na5 16. Qd3 Qxd3 17. Bxd3 Be6 18. Kh1 Ke7 19. a3 Nc6 20. f4 Rad8
+21. f5 Bf7 22. Nf3 Ng4 23. Bg5+ Kd7 24. h3 Nge5 25. Bxd8 Rxd8 26. Bb5 Ke7 27.
+Ng5 Bg8 28. Rad1 Rxd1 29. Rxd1 Bd6 30. Nf3 Nxf3 31. gxf3 Be5 32. c3 Nd8 33. Kg2
+c6 34. Be2 Nf7 35. Kf2 Nd6 36. Ke3 Nc4+ 37. Bxc4 Bxc4 38. f4 Bf6 39. e5 Bh4 40.
+Ke4 g6 41. Rd4 gxf5+ 42. Kxf5 Be6+ 43. Ke4 Bd5+ 44. Ke3 Bg3 45. f5 Bf4+ 46.
+Rxf4 Kf7 47. Rd4 Kf8 48. e6 Ke7 49. f6+ Ke8 50. Rf4 Kd8 51. Rf5 Kc7 52. Rxd5
+Kb6 53. Re5 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Bulingot"]
+[Black "Lil_D"]
+[Result "1-0"]
+[ECO "A40"]
+[WhiteElo "2349"]
+[BlackElo "2310"]
+[PlyCount "67"]
+[EventDate "2020.??.??"]
+
+1. d4 g6 2. h4 h6 3. h5 g5 4. f4 gxf4 5. Bxf4 d6 6. e4 Bg7 7. Nc3 Nc6 8. d5 Ne5
+9. Nf3 Ng4 10. Qd2 N8f6 11. O-O-O O-O 12. Kb1 c6 13. Bd3 b5 14. Rh4 b4 15. Ne2
+cxd5 16. exd5 a5 17. Ng3 Nxd5 18. Be4 Nxf4 19. Qxf4 e5 20. Qd2 d5 21. Bxd5 Be6
+22. Bxe6 Qf6 23. Rxg4 e4 24. Qc1 exf3 25. Nf5 fxe6 26. Rxg7+ Qxg7 27. Nxg7 Kxg7
+28. gxf3 Rf7 29. Rg1+ Kf8 30. Qxh6+ Ke7 31. Qg5+ Kd7 32. Qb5+ Ke7 33. Rd1 Kf8
+34. Qg5 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "self_service"]
+[Black "legbreaker"]
+[Result "0-1"]
+[ECO "D31"]
+[WhiteElo "2424"]
+[BlackElo "2346"]
+[PlyCount "98"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. c4 e6 2. Nc3 d5 3. d4 a6 4. Bf4 dxc4 5. a4 Nc6 6. e3 Na5 7. Nf3 Nf6 8. Ne5
+Bb4 9. Rc1 b5 10. Be2 Nd5 11. Bg3 Bb7 12. O-O Nb3 13. Rc2 Nxc3 14. bxc3 Bd6 15.
+Bf3 Bxf3 16. Qxf3 O-O 17. e4 c5 18. Nc6 Qd7 19. e5 Bc7 20. Rd1 cxd4 21. cxd4
+Bb6 22. axb5 axb5 23. Bf4 Rac8 24. Nb4 Nxd4 25. Qg4 Rfd8 26. Rcd2 Qe7 27. Bh6
+Qf8 28. h4 Nf5 29. Bg5 Rxd2 30. Rxd2 h6 31. Bf6 Qxb4 32. Rd7 Qe1+ 33. Kh2 Rf8
+34. h5 Qxf2 35. Bxg7 Nxg7 36. Qe4 Qg1+ 37. Kh3 Qh1+ 38. Kg3 Qe1+ 39. Qxe1 Bc5
+40. Qf1 c3 41. Qe2 c2 42. Rd1 cxd1=Q 43. Qxd1 Be7 44. Kh2 Bg5 45. Qe2 b4 46.
+Qf3 b3 47. Qxb3 Re8 48. Qc4 Rd8 49. Qd3 Rxd3 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "jpboyeras"]
+[Black "AzFert"]
+[Result "0-1"]
+[ECO "A46"]
+[WhiteElo "2339"]
+[BlackElo "2432"]
+[PlyCount "84"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. Nf3 Nf6 2. d4 e6 3. Bf4 b6 4. e3 Bb7 5. Be2 h6 6. h3 Bd6 7. O-O Bxf4 8. exf4
+O-O 9. c4 d5 10. cxd5 Nxd5 11. Qd2 Nd7 12. Nc3 N7f6 13. Rfd1 Qd6 14. Ne5 Rfd8
+15. Rac1 a6 16. g3 Nxc3 17. bxc3 c5 18. Qe3 cxd4 19. Rxd4 Qa3 20. Rc2 Rac8 21.
+Rcd2 Rxd4 22. cxd4 Rc1+ 23. Bf1 Qxe3 24. fxe3 Ne4 25. Rg2 f6 26. Nd3 Ra1 27. g4
+Bd5 28. h4 Bxa2 29. g5 hxg5 30. hxg5 fxg5 31. fxg5 Bd5 32. Nf4 b5 33. Rc2 Bc4
+34. Ne2 Rxf1+ 35. Kxf1 Ng3+ 36. Kf2 Nxe2 37. e4 a5 38. Ke3 a4 39. d5 exd5 40.
+exd5 Kf7 41. d6 Ke6 42. Rd2 Kd7 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "yaguigor"]
+[Black "Mondesespoir2700"]
+[Result "1-0"]
+[ECO "B32"]
+[WhiteElo "2446"]
+[BlackElo "2426"]
+[PlyCount "63"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 c5 2. Nf3 Nc6 3. d4 cxd4 4. Nxd4 e5 5. Nb5 a6 6. Nd6+ Bxd6 7. Qxd6 Qf6 8.
+Qd1 Qg6 9. Nc3 Nf6 10. Qd6 Ng8 11. Qxg6 hxg6 12. Be3 Nge7 13. O-O-O b5 14. Bc5
+Bb7 15. f3 Rc8 16. a3 f6 17. Be2 Nd8 18. Be3 Ne6 19. Rd2 Bc6 20. h3 g5 21. Rhd1
+Ng6 22. Nd5 Ngf4 23. Bf1 Bxd5 24. exd5 Nd8 25. a4 Nf7 26. axb5 axb5 27. Bxb5
+Nd6 28. Bf1 Ra8 29. b3 Ke7 30. Kb2 Ra5 31. Ra1 Rxd5 32. Bxf4 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Kidefence"]
+[Black "BlueGreensun"]
+[Result "0-1"]
+[ECO "C41"]
+[WhiteElo "2707"]
+[BlackElo "2759"]
+[PlyCount "56"]
+[EventDate "2020.??.??"]
+
+1. e4 d6 2. d4 Nf6 3. Nc3 e5 4. Nf3 Nbd7 5. Bd3 Be7 6. dxe5 dxe5 7. O-O O-O 8.
+h3 Nc5 9. Be3 Nxd3 10. cxd3 Bd6 11. Qb3 c6 12. Rad1 b6 13. d4 exd4 14. Bxd4 Bb8
+15. Be5 Qe7 16. Bxb8 Rxb8 17. e5 Nd7 18. Rfe1 Nc5 19. Qc4 Be6 20. Qg4 Bxg4 21.
+hxg4 Rfd8 22. Rc1 h6 23. b4 Nd3 24. e6 Nxe1 25. exf7+ Qxf7 26. Rxe1 Re8 27. Rb1
+Rbd8 28. Na4 Qxa2 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "hungzhao"]
+[Black "chesslismab"]
+[Result "1-0"]
+[ECO "B03"]
+[WhiteElo "2628"]
+[BlackElo "2447"]
+[PlyCount "45"]
+[EventDate "2020.??.??"]
+
+1. e4 Nf6 2. e5 Nd5 3. d4 Nb6 4. a4 a5 5. c4 d6 6. exd6 exd6 7. Nc3 Be7 8. Bd3
+O-O 9. Nge2 Na6 10. O-O Nb4 11. d5 Nxd3 12. Qxd3 g6 13. b3 Bf5 14. Qd2 Bf6 15.
+Bb2 Re8 16. Ng3 Bd7 17. f4 Qe7 18. Rae1 Qf8 19. Nce4 Bg7 20. f5 gxf5 21. Nh5
+Rxe4 22. Bxg7 Qe7 23. Bf6 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Cazulo97"]
+[Black "InsaneTryhard"]
+[Result "1-0"]
+[ECO "B95"]
+[WhiteElo "2371"]
+[BlackElo "2366"]
+[PlyCount "69"]
+[EventDate "2020.??.??"]
+
+1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f3 Qb6 8. Nb3
+Qc7 9. Qd2 Nbd7 10. O-O-O h6 11. Be3 b5 12. g4 Bb7 13. h4 h5 14. g5 Ng8 15. g6
+fxg6 16. Nd4 Nc5 17. Rg1 e5 18. Nb3 Ne7 19. Bh3 Nxb3+ 20. axb3 Rd8 21. Nd5 Nxd5
+22. exd5 Qf7 23. f4 exf4 24. Bxf4 Be7 25. Be6 Qf6 26. Bg5 Qf3 27. Rdf1 Rf8 28.
+Rxf3 Rxf3 29. Qe2 Rf8 30. Qe4 Ra8 31. Qxg6+ Kd8 32. Bxe7+ Kxe7 33. Qxg7+ Rf7
+34. Qxf7+ Kd8 35. Qd7# 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "jdef"]
+[Black "Bigbier"]
+[Result "1-0"]
+[ECO "B20"]
+[WhiteElo "2305"]
+[BlackElo "2363"]
+[PlyCount "47"]
+[EventDate "2020.??.??"]
+
+1. e4 c5 2. d3 Nc6 3. Nc3 d6 4. Nf3 g6 5. g3 Bg7 6. Bg2 Nf6 7. O-O O-O 8. Re1
+Rb8 9. e5 dxe5 10. Nxe5 Nxe5 11. Rxe5 Qc7 12. Re1 Ra8 13. Bf4 Qb6 14. b3 Nh5
+15. Be3 Bxc3 16. Bd2 Bxa1 17. Qxa1 Re8 18. Bh6 f6 19. Bd5+ e6 20. Bc4 Bd7 21.
+g4 Ng7 22. Qxf6 Re7 23. Qxe7 Ne8 24. Qf8# 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Pharaohs-Curse"]
+[Black "emiliofelixramirez"]
+[Result "0-1"]
+[ECO "A40"]
+[WhiteElo "2354"]
+[BlackElo "2394"]
+[PlyCount "82"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 g6 2. c4 Bg7 3. Nc3 c5 4. d5 d6 5. e4 Nf6 6. Bd3 Na6 7. a3 Nc7 8. h3 O-O
+9. Nf3 a6 10. a4 b6 11. O-O Rb8 12. e5 Nfe8 13. Re1 b5 14. axb5 axb5 15. cxb5
+e6 16. dxe6 Nxe6 17. Nd5 dxe5 18. Bc4 Nd6 19. b3 e4 20. Ra7 exf3 21. Qxf3 Bb7
+22. Bf4 Nxf4 23. Qxf4 Nxc4 24. Ne7+ Kh8 25. bxc4 Qd4 26. Qc7 Ba8 27. Nc6 Bxc6
+28. bxc6 Rbc8 29. Qb6 Qxc4 30. Ree7 Qc1+ 31. Kh2 Qf4+ 32. Kg1 Bd4 33. Ra2 c4
+34. Qb7 c3 35. c7 Qd6 36. Rxf7 Qc5 37. Rxf8+ Rxf8 38. Ra8 c2 39. Rxf8+ Qxf8 40.
+c8=Q Bxf2+ 41. Kh1 c1=Q+ 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "joshuawaitzkin"]
+[Black "metalkingGT"]
+[Result "0-1"]
+[ECO "A01"]
+[WhiteElo "2517"]
+[BlackElo "2447"]
+[PlyCount "102"]
+[EventDate "2020.??.??"]
+
+1. b3 c5 2. Bb2 Nc6 3. e3 e5 4. Bb5 d6 5. Ne2 Bd7 6. O-O f5 7. d4 cxd4 8. exd4
+e4 9. d5 Ne5 10. Bxd7+ Nxd7 11. c4 Ngf6 12. Nd4 Nc5 13. Nxf5 Qd7 14. Nd4 Be7
+15. b4 Nd3 16. Bc3 O-O 17. Ne6 Rf7 18. Nd2 Rc8 19. Qe2 b5 20. Bxf6 Bxf6 21.
+Nxe4 Bxa1 22. Qxd3 bxc4 23. Qg3 Be5 24. Qh3 c3 25. N4g5 h6 26. Nxf7 Kxf7 27.
+Qf5+ Ke7 28. Qg6 c2 29. Rc1 Bf6 30. Rxc2 Rxc2 31. Qxc2 Kf7 32. Qc7 Qxc7 33.
+Nxc7 Bc3 34. Nb5 Bxb4 35. Nxa7 Kf6 36. Nc6 Bc5 37. Kf1 Kf5 38. f3 Kf4 39. Ke2
+Bg1 40. a4 Bxh2 41. a5 Bg1 42. a6 Bb6 43. a7 Bxa7 44. Nxa7 Ke5 45. Nc6+ Kxd5
+46. Kf2 Kxc6 47. Ke3 Kd7 48. Kd4 Ke6 49. f4 d5 50. g3 Kd6 51. g4 Ke6 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Donald666Trump"]
+[Black "Frogkiller"]
+[Result "0-1"]
+[ECO "B90"]
+[WhiteElo "2384"]
+[BlackElo "2378"]
+[PlyCount "52"]
+[EventDate "2020.??.??"]
+
+1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Be3 e5 7. Nb3 Be6 8. f4
+Nbd7 9. f5 Bxb3 10. axb3 Rc8 11. Qf3 h5 12. O-O-O Qc7 13. Kb1 b5 14. Rc1 h4 15.
+Bg5 Be7 16. Bd3 b4 17. Nd1 a5 18. Ne3 Qc6 19. Rhe1 a4 20. bxa4 Qxa4 21. Bc4 Ra8
+22. c3 b3 23. Bxb3 Qxb3 24. Rcd1 Ra2 25. Rd2 O-O 26. Bxh4 Rfa8 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Chesscoach46"]
+[Black "seleneitor13"]
+[Result "0-1"]
+[ECO "B46"]
+[WhiteElo "2328"]
+[BlackElo "2313"]
+[PlyCount "150"]
+[EventDate "2020.??.??"]
+
+1. e4 c5 2. d4 cxd4 3. Nf3 e6 4. Nxd4 a6 5. Nc3 Nc6 6. Be3 Nge7 7. Qd2 Ng6 8.
+O-O-O Be7 9. Nxc6 bxc6 10. f4 Bb7 11. h4 Nxh4 12. g3 Ng6 13. Bh3 d5 14. f5 exf5
+15. exf5 Ne5 16. Bd4 Nc4 17. Qe2 O-O 18. g4 Bf6 19. g5 Bxd4 20. Rxd4 Qxg5+ 21.
+Kb1 Rfe8 22. Qd1 Qe3 23. Rg4 Qb6 24. b3 Qb4 25. Qd4 f6 26. Rhg1 Na3+ 27. Kb2
+Qxd4 28. Rxd4 Nb5 29. Nxb5 axb5 30. Rdg4 Re7 31. Bg2 Rae8 32. Bf1 c5 33. Bxb5
+Rd8 34. a4 d4 35. Bc4+ Bd5 36. a5 Bxc4 37. bxc4 Ra8 38. c3 Rxa5 39. cxd4 cxd4
+40. Rxd4 Rc7 41. Rgd1 Kf7 42. Rd7+ Rxd7 43. Rxd7+ Kf8 44. Rd5 Rxd5 45. cxd5 Ke7
+46. Kc3 Kd6 47. Kd4 h5 48. Ke4 h4 49. Kf3 Kxd5 50. Kg4 Ke5 51. Kf3 Kxf5 52. Kg2
+g5 53. Kh2 Kg6 54. Kg2 f5 55. Kf2 g4 56. Kg2 Kg5 57. Kh2 h3 58. Kg1 f4 59. Kf1
+g3 60. Kg1 Kg4 61. Kh1 f3 62. Kg1 f2+ 63. Kf1 h2 64. Ke2 h1=Q 65. Kd3 Qh2 66.
+Kd4 g2 67. Kd5 f1=Q 68. Ke6 g1=Q 69. Ke7 Qhg2 70. Kd8 Q2f2 71. Kc7 Q1e1 72. Kc8
+Qfd2 73. Kc7 Qec1+ 74. Kb7 Qdb2+ 75. Ka6 Qca1# 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "H-Random"]
+[Black "mixo23"]
+[Result "0-1"]
+[ECO "B10"]
+[WhiteElo "2387"]
+[BlackElo "2409"]
+[PlyCount "46"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 c6 2. Nc3 d5 3. Nf3 g6 4. d4 Bg7 5. Bd3 Bg4 6. h3 Bxf3 7. Qxf3 e6 8. O-O
+Ne7 9. Bg5 Nd7 10. Ne2 O-O 11. e5 c5 12. c3 f6 13. exf6 Nxf6 14. Nf4 Nh5 15.
+Qe3 Nxf4 16. Bxf4 Qd7 17. Rfe1 cxd4 18. cxd4 Nc6 19. Qxe6+ Qxe6 20. Rxe6 Rxf4
+21. Rae1 Bxd4 22. R1e2 Raf8 23. Bb5 Rxf2 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "sutcunuri"]
+[Black "ajedrez2021"]
+[Result "0-1"]
+[ECO "B06"]
+[WhiteElo "2521"]
+[BlackElo "2592"]
+[PlyCount "70"]
+[EventDate "2020.??.??"]
+
+1. e4 g6 2. d4 Bg7 3. Bc4 c5 4. Bxf7+ Kxf7 5. c3 cxd4 6. Nf3 dxc3 7. O-O cxb2
+8. Bxb2 Bxb2 9. Qb3+ Kf8 10. Qxb2 Nf6 11. e5 Nd5 12. e6 Nf6 13. Rd1 d5 14. Qe2
+Nc6 15. Nc3 Qd6 16. Ng5 Kg7 17. Rab1 h6 18. Nf3 Bxe6 19. Rxb7 Rhb8 20. Rdb1
+Rxb7 21. Rxb7 Rb8 22. Rxb8 Qxb8 23. h3 Qd6 24. Nb5 Qd7 25. Nbd4 Nxd4 26. Nxd4
+Bf7 27. Qe5 Qd6 28. Qe3 e5 29. Nf3 d4 30. Qxe5 Qxe5 31. Nxe5 Bxa2 32. Nc6 d3
+33. Kf1 d2 34. Ke2 Ne4 35. f3 Bc4+ 0-1
+
+[Event "Rated Blitz tournament hM7PUvgg"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Lidiodelgado"]
+[Black "Supelyel"]
+[Result "1-0"]
+[ECO "A46"]
+[WhiteElo "2376"]
+[BlackElo "2383"]
+[PlyCount "63"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 Nf6 2. Nf3 d6 3. c4 Nbd7 4. g3 c6 5. Bg2 Qc7 6. O-O e5 7. b3 Be7 8. Bb2
+O-O 9. Nc3 Re8 10. e4 Bf8 11. h3 a5 12. Re1 h6 13. Qc2 b6 14. Rad1 g6 15. a3
+Bg7 16. d5 cxd5 17. cxd5 Ba6 18. Rc1 Rac8 19. Bf1 Bxf1 20. Kxf1 Nc5 21. Kg2
+Ncxe4 22. Re3 Nxc3 23. Rxc3 Qb7 24. Rxc8 e4 25. Rxe8+ Nxe8 26. Qxe4 Qd7 27.
+Bxg7 Kxg7 28. Qd4+ Kh7 29. Qxb6 Ng7 30. Qc7 Qf5 31. Qxd6 Nh5 32. Qe5 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "lamadestr"]
+[Black "Steed28"]
+[Result "0-1"]
+[ECO "C30"]
+[WhiteElo "2305"]
+[BlackElo "2400"]
+[PlyCount "89"]
+[EventDate "2020.??.??"]
+
+1. e4 e5 2. f4 Nc6 3. Nf3 d5 4. exd5 Qxd5 5. Nc3 Qd6 6. fxe5 Qe7 7. d4 Bg4 8.
+Bb5 O-O-O 9. Bxc6 bxc6 10. Qd3 Qb4 11. Be3 Bxf3 12. gxf3 Ne7 13. Qa6+ Kd7 14.
+O-O-O Rb8 15. Na4 Nd5 16. Rhe1 Be7 17. a3 Qb5 18. Qxb5 cxb5 19. Nc5+ Bxc5 20.
+dxc5 c6 21. f4 Ke6 22. Bd2 h5 23. h4 g6 24. Re4 Rhd8 25. Rd4 Ne7 26. Rd6+ Rxd6
+27. cxd6 Nf5 28. Be1 Kd7 29. Bf2 a5 30. b4 axb4 31. axb4 Ra8 32. Kb2 Ra4 33. c3
+Ne7 34. Be3 Nd5 35. Bd2 Nb6 36. Kb3 Nc4 37. Bc1 Ra1 38. Kc2 Ra2+ 39. Kb3 Rh2
+40. Rf1 Rxh4 41. f5 Nxe5 42. fxg6 f6 43. Rxf6 Rg4 44. Rf7+ Kxd6 45. g7 0-1
+
+[Event "Rated Bullet tournament GAdGz1co"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "RaylessStarfish"]
+[Black "dragonwelb"]
+[Result "0-1"]
+[ECO "A15"]
+[WhiteElo "2393"]
+[BlackElo "2389"]
+[PlyCount "108"]
+[EventDate "2020.??.??"]
+
+1. c4 Nf6 2. g3 c5 3. Bg2 Nc6 4. Nf3 d6 5. O-O g6 6. Nc3 Bg7 7. d4 cxd4 8. Nxd4
+Bd7 9. e3 O-O 10. b3 a6 11. Bb2 Rc8 12. Rc1 Nxd4 13. exd4 b5 14. cxb5 axb5 15.
+Qd2 e6 16. d5 e5 17. Rfe1 Qb6 18. b4 Rc4 19. a3 Rfc8 20. Bf1 R4c7 21. Nd1 Ng4
+22. Rxc7 Rxc7 23. h3 Bh6 24. Qe2 Nf6 25. Ne3 Qb8 26. Qd2 Qc8 27. Rc1 Ne4 28.
+Rxc7 Qxc7 29. Qd3 f5 30. g4 Bf4 31. gxf5 gxf5 32. Ng2 Bg5 33. Be2 Qb6 34. Ne3
+Kf7 35. Nd1 Kg6 36. Kg2 h6 37. Bf3 Nf6 38. Qc2 h5 39. Be2 h4 40. Bf1 Qb7 41.
+Be2 Qxd5+ 42. f3 Be6 43. Qd3 Qxd3 44. Bxd3 Bc4 45. Kf1 Bxd3+ 46. Kf2 Bc4 47.
+Ne3 e4 48. Nxf5 Kxf5 49. fxe4+ Kxe4 50. Kg2 Nd5 51. Kh1 Nf4 52. Kh2 Ne2 53. Kh1
+Ng3+ 54. Kh2 Bf4 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "murderoflegends"]
+[Black "hawth0rne"]
+[Result "0-1"]
+[ECO "B43"]
+[WhiteElo "2416"]
+[BlackElo "2439"]
+[PlyCount "52"]
+[EventDate "2020.??.??"]
+
+1. e4 c5 2. Nf3 e6 3. d4 cxd4 4. Nxd4 a6 5. Nc3 Qc7 6. Be3 b5 7. f3 Bb7 8. Qd2
+Nf6 9. O-O-O b4 10. Nce2 d5 11. exd5 Nxd5 12. Kb1 Nxe3 13. Qxe3 Be7 14. g4 Nd7
+15. h4 Ne5 16. Bg2 Nc4 17. Qd3 Bd5 18. Nf4 Qxf4 19. Rhe1 O-O 20. g5 Rac8 21.
+Nb3 Rfd8 22. Bh3 a5 23. Nxa5 Nxa5 24. Qxd5 exd5 25. Rxd5 Rxd5 26. Rxe7 Rd1# 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "MrMania"]
+[Black "lord_barre"]
+[Result "1-0"]
+[ECO "A00"]
+[WhiteElo "2380"]
+[BlackElo "2414"]
+[PlyCount "89"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. g3 d5 2. Bg2 Nf6 3. Nf3 Nbd7 4. O-O e5 5. d4 e4 6. Ne5 Nxe5 7. dxe5 Ng4 8.
+c4 dxc4 9. Qa4+ Qd7 10. Qxc4 Nxe5 11. Qxe4 Qe6 12. Nc3 c6 13. Bf4 Ng6 14. Bc7
+Bc5 15. Qxe6+ Bxe6 16. Ne4 Be7 17. Bd6 Bd5 18. Bxe7 Kxe7 19. Nc5 Bxg2 20. Kxg2
+b6 21. Nd3 c5 22. a4 c4 23. Nb4 Kd6 24. Rfc1 Rac8 25. a5 b5 26. a6 Kc5 27. Nd3+
+Kb6 28. Nb4 Rhd8 29. e4 Ne5 30. Nd5+ Rxd5 31. exd5 Nd3 32. Rc2 Kc5 33. b3 Kxd5
+34. bxc4+ bxc4 35. Rb1 Rc6 36. Rb7 Rxa6 37. Rxf7 Nb4 38. Rc1 Rc6 39. Rxg7 c3
+40. Rxa7 c2 41. Rxh7 Nd3 42. Rd7+ Ke4 43. Rxc2 Rxc2 44. Rf7 Ne1+ 45. Kf1 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "vaillant77"]
+[Black "vassiukov"]
+[Result "0-1"]
+[ECO "A01"]
+[WhiteElo "2452"]
+[BlackElo "2339"]
+[PlyCount "55"]
+[EventDate "2020.??.??"]
+
+1. b3 e5 2. Bb2 f6 3. c4 c6 4. e3 d5 5. d4 e4 6. cxd5 cxd5 7. Nc3 f5 8. Rc1 Nc6
+9. Nge2 Nf6 10. Ng3 Bd6 11. Bb5 O-O 12. Qe2 f4 13. exf4 Bxf4 14. Rd1 a6 15.
+Bxc6 bxc6 16. O-O Bg4 17. f3 exf3 18. gxf3 Re8 19. Qg2 Be6 20. Nce2 Be3+ 21.
+Kh1 Qd7 22. Bc1 Bh3 23. Qxh3 Qxh3 24. Bxe3 Rxe3 25. Rg1 Rxf3 26. Rc1 Re8 27.
+Rxc6 Ne4 28. Rc3 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "WildBreath"]
+[Black "troisi"]
+[Result "1/2-1/2"]
+[ECO "A00"]
+[WhiteElo "2415"]
+[BlackElo "2381"]
+[PlyCount "169"]
+[EventDate "2020.??.??"]
+
+1. h4 e6 2. h5 d5 3. d3 h6 4. a4 Nf6 5. a5 c5 6. e3 a6 7. Nd2 Nc6 8. Nb3 c4 9.
+dxc4 Bb4+ 10. Bd2 Bxd2+ 11. Qxd2 O-O 12. cxd5 exd5 13. Nf3 Be6 14. Bd3 Ne4 15.
+Bxe4 dxe4 16. Qxd8 Rfxd8 17. Nfd4 Nxd4 18. Nxd4 Bd5 19. O-O-O Rac8 20. Kb1 Kf8
+21. b3 Ke7 22. c4 Be6 23. Nxe6 Kxe6 24. Rxd8 Rxd8 25. Kc2 f5 26. Rd1 Rf8 27. g3
+f4 28. exf4 Kf5 29. Rd5+ Kg4 30. Kd2 Kf3 31. Ke1 Rf6 32. b4 b6 33. axb6 Rxb6
+34. b5 axb5 35. cxb5 Re6 36. Rc5 Rb6 37. Rc3+ Kg4 38. Ke2 Rxb5 39. Ke3 Rxh5 40.
+Kxe4 Rh2 41. Ke3 g5 42. fxg5 hxg5 43. Rc4+ Kh5 44. Kf3 Rh1 45. Rc8 Ra1 46. Rh8+
+Kg6 47. Kg2 Ra3 48. Rc8 Ra6 49. Rc4 Kh5 50. Kf3 g4+ 51. Kg2 Ra5 52. Rc2 Kg5 53.
+Re2 Rf5 54. Re4 Rb5 55. Rf4 Rd5 56. Rf8 Rd7 57. Rg8+ Kf5 58. Rh8 Rg7 59. Rh1
+Kg5 60. Rh4 Re7 61. Rh8 Rg7 62. Ra8 Re7 63. Ra5+ Re5 64. Ra4 Kf5 65. Rf4+ Kg5
+66. Rc4 Re6 67. Rc2 Kg6 68. Rc1 Re4 69. Rg1 Kg5 70. Rf1 Re1 71. f3 Rxf1 72.
+Kxf1 gxf3 73. Kf2 Kg4 74. Kg1 Kxg3 75. Kf1 f2 76. Ke2 Kg2 77. Ke3 f1=Q 78. Ke4
+Qf2 79. Kd5 Qf3+ 80. Kd6 Qe3 81. Kc6 Qf4 82. Kc5 Qe4 83. Kd6 Qf5 84. Kc6 Kf1
+85. Kd6 1/2-1/2
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "MFRenePilartte"]
+[Black "Son_Goku7"]
+[Result "0-1"]
+[ECO "D90"]
+[WhiteElo "2343"]
+[BlackElo "2386"]
+[PlyCount "104"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 Nf6 2. c4 g6 3. Nf3 Bg7 4. Nc3 d5 5. cxd5 Nxd5 6. Bd2 O-O 7. e4 Nf6 8.
+Be2 c5 9. d5 Ng4 10. O-O Nd7 11. h3 Nge5 12. Nxe5 Nxe5 13. f4 Nd7 14. Be3 b6
+15. Qd2 Bb7 16. Rad1 Nf6 17. Kh1 Ne8 18. Bf3 Nd6 19. b3 f6 20. Bg4 Bc8 21. Bxc8
+Qxc8 22. f5 gxf5 23. Bh6 fxe4 24. Bxg7 Kxg7 25. Qf4 Kh8 26. Nxe4 Nxe4 27. Qxe4
+Qd7 28. Rfe1 Rf7 29. d6 Re8 30. Qe6 Qxe6 31. Rxe6 Rd8 32. dxe7 Rxd1+ 33. Kh2
+Rxe7 34. Rxe7 a5 35. Re6 b5 36. Rb6 c4 37. Rxb5 c3 38. Rc5 Rd2 39. Rxa5 c2 40.
+Rc5 Kg8 41. b4 Kf7 42. b5 Ke6 43. b6 Kd6 44. Rc3 c1=Q 45. Rxc1 Rxa2 46. Rb1 Ra8
+47. Kg3 Rb8 48. Kf4 Ke6 49. b7 h6 50. Kg4 f5+ 51. Kh5 Kf6 52. Kxh6 Rh8# 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "rudolf85"]
+[Black "Paanoos"]
+[Result "0-1"]
+[ECO "A00"]
+[WhiteElo "2418"]
+[BlackElo "2385"]
+[PlyCount "130"]
+[EventDate "2020.??.??"]
+
+1. e3 c5 2. d4 cxd4 3. exd4 d5 4. Nf3 Nc6 5. Be2 Bg4 6. O-O e6 7. c3 Bd6 8.
+Nfd2 Bxe2 9. Qxe2 Nge7 10. Nf3 Qc7 11. Bg5 Ng6 12. Nbd2 h6 13. Be3 Nf4 14. Bxf4
+Bxf4 15. Rfe1 g5 16. Nf1 O-O-O 17. a4 Rdg8 18. a5 h5 19. b4 h4 20. b5 Nxa5 21.
+Ne5 Bxe5 22. dxe5 Kb8 23. b6 Qxb6 24. Reb1 Qc7 25. Ne3 Nc4 26. Nxc4 dxc4 27.
+Qe3 b6 28. Rb4 Rd8 29. Rab1 Rd5 30. Qf3 Rhd8 31. h3 Qd7 32. Qf6 Rd1+ 33. Kh2
+Rxb1 34. Rxb1 Rc8 35. Qxg5 Rc5 36. Re1 Qc7 37. Re3 Kb7 38. Qf6 a5 39. Qxh4 Rxe5
+40. Rf3 Re4+ 41. Qg3 Qxg3+ 42. Kxg3 a4 43. h4 Re5 44. Rf4 a3 45. Rxc4 Ra5 46.
+Rb4 a2 47. Ra4 a1=Q 48. Rxa1 Rxa1 49. Kg4 Ra3 50. g3 Rxc3 51. f3 Rc5 52. h5 Rc6
+53. h6 Rc8 54. Kg5 Rh8 55. Kf6 Rh7 56. Kg5 Rxh6 57. g4 b5 58. Kf4 b4 59. g5 b3
+60. gxh6 b2 61. h7 b1=Q 62. h8=Q Qc1+ 63. Kg4 Qc4+ 64. Kg3 Qc5 65. Qg7 Kc6 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Alex_Rosario"]
+[Black "nakarian10"]
+[Result "1-0"]
+[ECO "B07"]
+[WhiteElo "2337"]
+[BlackElo "2367"]
+[PlyCount "123"]
+[EventDate "2020.??.??"]
+
+1. e4 c6 2. d4 d6 3. Nc3 g6 4. f4 Bg7 5. Nf3 e6 6. Be3 Ne7 7. Qd2 c5 8. dxc5 d5
+9. exd5 exd5 10. Bd4 O-O 11. O-O-O Be6 12. h4 h5 13. Bxg7 Kxg7 14. Nd4 Bg4 15.
+Be2 Bxe2 16. Ncxe2 Nbc6 17. Nb3 d4 18. Nexd4 Nxd4 19. Qxd4+ Qxd4 20. Nxd4 Rac8
+21. Rhe1 Nc6 22. Nxc6 Rxc6 23. Rd5 Rf6 24. g3 Rc8 25. b4 a5 26. a3 axb4 27.
+axb4 Rfc6 28. c3 b6 29. Ree5 b5 30. Kd2 Ra8 31. Re2 Ra2+ 32. Kd3 Ra3 33. Rd6
+Rca6 34. Rb6 R6a4 35. Rb2 Ra1 36. Rxb5 Rd1+ 37. Kc4 Raa1 38. c6 Rd8 39. Rc5 Rc8
+40. c7 Ra7 41. b5 Raxc7 42. Rxc7 Rxc7+ 43. Kb4 f6 44. c4 Kf7 45. c5 Ke7 46. b6
+Rc8 47. Kb5 Kd7 48. Re2 Rd8 49. Rd2+ Kc8 50. Rxd8+ Kxd8 51. c6 Kc8 52. Kc5 f5
+53. Kd6 g5 54. fxg5 f4 55. gxf4 Kd8 56. f5 Ke8 57. g6 Kf8 58. f6 Kg8 59. Ke7
+Kh8 60. c7 Kg8 61. b7 Kh8 62. c8=Q# 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "BlueGreensun"]
+[Black "Kidefence"]
+[Result "0-1"]
+[ECO "B03"]
+[WhiteElo "2764"]
+[BlackElo "2702"]
+[PlyCount "152"]
+[EventDate "2020.??.??"]
+
+1. e4 Nf6 2. e5 Nd5 3. d4 d6 4. c4 Nb6 5. Nc3 Bf5 6. f4 e6 7. Nf3 Be7 8. Bd3
+O-O 9. Bxf5 exf5 10. b3 Nc6 11. d5 Nb4 12. O-O c6 13. Ba3 dxe5 14. fxe5 cxd5
+15. Bxb4 Bxb4 16. Nxd5 Bc5+ 17. Kh1 Nxd5 18. cxd5 Re8 19. d6 Qd7 20. Rc1 b6 21.
+Qd5 Rad8 22. Ng5 h6 23. Nh3 Qe6 24. Qxe6 Rxe6 25. Rce1 f6 26. Rxf5 fxe5 27.
+Rfxe5 Rxe5 28. Rxe5 Rxd6 29. g3 Rd2 30. Nf4 Rxa2 31. Re8+ Kf7 32. Rc8 Rb2 33.
+Rc7+ Kf6 34. Rxa7 Rxb3 35. Nh5+ Kg6 36. g4 Bd4 37. h4 Rh3+ 38. Kg2 Rxh4 39.
+Nf4+ Kf6 40. Nh5+ Ke6 41. Kg3 Rh1 42. Nf4+ Kd6 43. Ra8 Be5 44. Rd8+ Kc7 45. Re8
+Bxf4+ 46. Kxf4 Rd1 47. Re7+ Rd7 48. Re6 Kb7 49. Re8 Rc7 50. Rg8 b5 51. Kg3 Kb6
+52. Rf8 Rb7 53. Rc8 Ka5 54. Rc2 Rb6 55. Rb2 Ka6 56. Rb1 Kb7 57. Ra1 b4 58. Rc1
+b3 59. Rb1 b2 60. g5 Rb3+ 61. Kg4 hxg5 62. Kf5 Rb6 63. Ke4 Ka6 64. Kd4 Kb5 65.
+Kc3 Ka6 66. Rxb2 Kb7 67. Ra2 Rc6+ 68. Kd3 Kc7 69. Ke3 Kd7 70. Ke2 Rc7 71. Kf1
+Ke7 72. Kg1 Kf7 73. Kg2 Re7 74. Kg3 Re6 75. Kg4 Kg6 76. Rb2 Re4+ 0-1
+
+[Event "Rated Blitz tournament hM7PUvgg"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "matussalen"]
+[Black "Velociraptorblue"]
+[Result "1/2-1/2"]
+[ECO "D11"]
+[WhiteElo "2323"]
+[BlackElo "2383"]
+[PlyCount "52"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 d5 2. c4 c6 3. Nf3 Nf6 4. e3 a6 5. a4 Bf5 6. Bd3 Be4 7. Nc3 e6 8. O-O
+Bxd3 9. Qxd3 Bb4 10. b3 Nbd7 11. Bb2 O-O 12. Nd2 e5 13. dxe5 Nxe5 14. Qe2 dxc4
+15. Nxc4 Nxc4 16. Qxc4 Qe7 17. Rad1 Rad8 18. Qh4 Qe5 19. Qxb4 h5 20. h3 b5 21.
+axb5 cxb5 22. Qf4 Qe6 23. b4 Qb3 24. Ba1 Rfe8 25. g4 hxg4 26. hxg4 Rc8 1/2-1/2
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Atomrod"]
+[Black "NEKI_NOVI_KLINAC"]
+[Result "1-0"]
+[ECO "A40"]
+[WhiteElo "2492"]
+[BlackElo "2448"]
+[PlyCount "87"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 e6 2. Nf3 d5 3. Bg5 Be7 4. Bxe7 Nxe7 5. Nbd2 b6 6. e4 Bb7 7. e5 Nd7 8.
+Bd3 c5 9. c3 Rc8 10. O-O Nf5 11. Bxf5 exf5 12. Re1 O-O 13. e6 fxe6 14. Rxe6
+cxd4 15. Nxd4 Nc5 16. Re5 f4 17. N2f3 Qd7 18. Qe2 Rce8 19. Re1 Rxe5 20. Qxe5
+Nd3 21. Qe6+ Qxe6 22. Rxe6 Nxb2 23. Ne5 Nc4 24. Re7 Nxe5 25. Rxb7 Rc8 26. Ne6
+d4 27. Nxd4 Rxc3 28. h3 Rc1+ 29. Kh2 f3 30. gxf3 Rd1 31. Ne6 Rd7 32. Rb8+ Kf7
+33. Ng5+ Kg6 34. f4 Nd3 35. Kg3 h6 36. Nf3 Kh7 37. Ne5 Rc7 38. Nxd3 Rc2 39. f5
+Rxa2 40. Ne5 Ra3+ 41. f3 Ra5 42. f4 g6 43. fxg6+ Kg7 44. Rb7+ 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "MrSuccess"]
+[Black "Midnight_Mushroom"]
+[Result "0-1"]
+[ECO "B93"]
+[WhiteElo "2581"]
+[BlackElo "2426"]
+[PlyCount "62"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. f4 e5 7. Nf3 Qc7 8. Be3
+Nbd7 9. Qd2 Be7 10. O-O-O O-O 11. Kb1 exf4 12. Bxf4 Ne5 13. Nd4 Be6 14. g4 b5
+15. g5 Nh5 16. Be3 b4 17. Nd5 Bxd5 18. exd5 Nc4 19. Bxc4 Qxc4 20. Nf5 Rfe8 21.
+Qg2 Bf8 22. Bd4 Re2 23. Qg4 Qxc2+ 24. Ka1 g6 25. Ng3 Nxg3 26. hxg3 Bg7 27. Bxg7
+Kxg7 28. Qd4+ Kg8 29. Rc1 Qe4 30. Qf6 Qe5 31. Qf3 Qxb2# 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "shinji_no_baka"]
+[Black "jdef"]
+[Result "1-0"]
+[ECO "D00"]
+[WhiteElo "2356"]
+[BlackElo "2312"]
+[PlyCount "51"]
+[EventDate "2020.??.??"]
+
+1. d4 d5 2. Bf4 e6 3. e3 Bd6 4. Bg3 Bxg3 5. hxg3 Nf6 6. Nf3 h6 7. Bd3 c6 8.
+Nbd2 Nbd7 9. Qe2 b6 10. Ne5 Bb7 11. c3 Qc7 12. f4 O-O-O 13. O-O-O Kb8 14. Nxf7
+Rhf8 15. Nxd8 Rxd8 16. g4 c5 17. g5 Ne4 18. Nxe4 dxe4 19. Ba6 hxg5 20. Bxb7
+Kxb7 21. fxg5 cxd4 22. exd4 Qc6 23. Kb1 Re8 24. Rh4 e5 25. Rxe4 Re6 26. d5 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Clark_Kent97"]
+[Black "Yoseqpuedo"]
+[Result "1-0"]
+[ECO "A01"]
+[WhiteElo "2565"]
+[BlackElo "2407"]
+[PlyCount "71"]
+[EventDate "2020.??.??"]
+
+1. b3 e6 2. Bb2 f5 3. Nf3 Nf6 4. e3 Be7 5. d4 O-O 6. c4 d6 7. Nbd2 Qe8 8. Bd3
+Nc6 9. a3 Qg6 10. Qc2 Kh8 11. O-O-O a5 12. h3 Rb8 13. g4 Qe8 14. gxf5 exf5 15.
+Bxf5 b5 16. Bxc8 Qxc8 17. cxb5 Rxb5 18. Qxc6 Rb6 19. Qc2 Qb8 20. Rhg1 a4 21. b4
+c5 22. dxc5 dxc5 23. Ng5 cxb4 24. Bxf6 Rc8 25. Nc4 Rxc4 26. Qxc4 Rxf6 27. Nf7+
+Rxf7 28. Qxf7 Bf6 29. axb4 Qc8+ 30. Kb1 a3 31. Qb3 Qf5+ 32. Ka2 Qxf2+ 33. Kxa3
+h6 34. Rgf1 Qg3 35. Rxf6 Kh7 36. Qd3+ 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "LordGrim2500"]
+[Black "LaBandaDelHacha"]
+[Result "0-1"]
+[ECO "B07"]
+[WhiteElo "2470"]
+[BlackElo "2316"]
+[PlyCount "184"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 d6 2. d4 Nf6 3. Nc3 e5 4. dxe5 dxe5 5. Qxd8+ Kxd8 6. Bc4 Be6 7. Bxe6 fxe6
+8. Nf3 Bd6 9. Bd2 Ke7 10. O-O-O a6 11. Ne1 Nc6 12. Nd3 b5 13. Rhe1 Rhb8 14. a3
+a5 15. f3 b4 16. Nb1 bxa3 17. Nxa3 Nd4 18. Nc4 Nd7 19. Bc3 Nb5 20. Bxe5 Nxe5
+21. Ndxe5 Ra6 22. Nxd6 cxd6 23. Nc4 a4 24. Na3 Nxa3 25. bxa3 Rc8 26. Re3 Rac6
+27. Rd2 Rc5 28. Red3 R8c6 29. Rd4 Rc4 30. Rxc4 Rxc4 31. Rd3 g5 32. Kd2 g4 33.
+Rc3 gxf3 34. gxf3 Rd4+ 35. Rd3 Rc4 36. Rc3 Rd4+ 37. Ke3 Rd1 38. Rc4 Rh1 39.
+Rxa4 Rxh2 40. Ra7+ Kf6 41. Rd7 Rxc2 42. Rxd6 Rc3+ 43. Rd3 Rc4 44. f4 Ra4 45.
+Kf3 h5 46. Rb3 Kg6 47. Re3 Kf6 48. Kg3 Kg6 49. Kh4 Kh6 50. Kh3 Kg6 51. Kg3 Kf6
+52. Kh4 Kg6 53. Rg3+ Kh6 54. Rg5 Rxe4 55. Rxh5+ Kg6 56. Rg5+ Kf6 57. Kg4 Ra4
+58. Rg8 Rxa3 59. Rf8+ Ke7 60. Rb8 Ra4 61. Rb7+ Kf6 62. Rc7 Rd4 63. Rc8 Rb4 64.
+Rf8+ Ke7 65. Rh8 Kf6 66. Rh6+ Kg7 67. Rh7+ Kxh7 68. Kg5 Kg7 69. Kh5 Rb5+ 70.
+Kg4 Kf6 71. Kh4 Rf5 72. Kg3 Kg6 73. Kg4 Kh6 74. Kh4 Kg6 75. Kg3 Kf6 76. Kg4 e5
+77. Kg3 exf4+ 78. Kf3 Ke5 79. Kf2 Ke4 80. Ke2 f3+ 81. Kd2 Rg5 82. Kc3 Rg2 83.
+Kc4 Re2 84. Kc5 f2 85. Kd6 f1=Q 86. Ke6 Qd1 87. Kf6 Rc2 88. Kg5 Kd3 89. Kf5 Re2
+90. Kf4 Qf1+ 91. Kg4 Rg2+ 92. Kh5 Qh1# 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "DirtyDiamondta"]
+[Black "Akylbekov_Nasir"]
+[Result "0-1"]
+[ECO "A20"]
+[WhiteElo "2355"]
+[BlackElo "2319"]
+[PlyCount "94"]
+[EventDate "2020.??.??"]
+
+1. c4 e5 2. Nf3 Nc6 3. g3 Bc5 4. Bg2 d6 5. d3 Nge7 6. O-O O-O 7. Nc3 a6 8. a3
+Be6 9. b4 Ba7 10. Bb2 h6 11. e3 Qd7 12. Qe2 Bh3 13. Rfd1 Bxg2 14. Kxg2 f5 15.
+d4 e4 16. Nd2 g5 17. d5 Ne5 18. Rac1 Nd3 19. Rc2 Nxb2 20. Rxb2 Ng6 21. Na2 Ne5
+22. Nb3 Rae8 23. Nd4 Bxd4 24. Rxd4 Ng6 25. Rc2 f4 26. exf4 gxf4 27. Qh5 f3+ 28.
+Kg1 Kg7 29. Nc3 e3 30. fxe3 Rxe3 31. Rg4 Rf6 32. Ne4 Rxe4 33. Rxe4 f2+ 34. Rxf2
+Rxf2 35. Kxf2 Qf7+ 36. Kg2 Nf4+ 37. Rxf4 Qxh5 38. Rf3 Qe5 39. Rf4 Qb2+ 40. Kh3
+Qxa3 41. Rg4+ Kh7 42. b5 axb5 43. cxb5 Qc5 44. Rf4 Qxd5 45. Kh4 Qxb5 46. Rf7+
+Kg6 47. Rxc7 Qh5# 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Aisen_Mestnikov"]
+[Black "alireza3700"]
+[Result "1-0"]
+[ECO "D02"]
+[WhiteElo "2388"]
+[BlackElo "2342"]
+[PlyCount "127"]
+[EventDate "2020.??.??"]
+
+1. d4 d5 2. Nf3 Nf6 3. g3 e6 4. Bg2 c5 5. O-O Nc6 6. b3 cxd4 7. Nxd4 Nxd4 8.
+Qxd4 Be7 9. Bb2 O-O 10. Nd2 b6 11. e4 dxe4 12. Nxe4 Qxd4 13. Bxd4 Ba6 14. Nxf6+
+Bxf6 15. Bxf6 gxf6 16. Bxa8 Bxf1 17. Kxf1 Rxa8 18. Rd1 Rc8 19. c4 Rc7 20. Rd8+
+Kg7 21. Ke2 f5 22. Ke3 Kf6 23. f4 a6 24. Kd4 b5 25. c5 h5 26. Rd6 Ke7 27. Rxa6
+Rb7 28. Kc3 Kd7 29. Kb4 Kc7 30. Ra8 Kc6 31. Rc8+ Kd5 32. c6 Rb6 33. c7 Kc6 34.
+Rf8 Kxc7 35. Rxf7+ Kd6 36. Rh7 Ra6 37. a3 Kd5 38. Rxh5 Ke4 39. Rh6 Kf3 40. Kxb5
+Rxa3 41. b4 Re3 42. Kc6 Re4 43. b5 Rc4+ 44. Kb7 Rb4 45. b6 e5 46. fxe5 Ke4 47.
+e6 Kd5 48. e7 Re4 49. Rh7 Kd6 50. Kc8 Kc6 51. b7 Rc4 52. e8=Q+ Kd5+ 53. Kb8 Rb4
+54. Rd7+ Kc4 55. Qe5 Kb3 56. Rd5 Rc4 57. Rd4 Kb4 58. Qe3 Rxd4 59. Qxd4+ Kb5 60.
+Qe4 Kb6 61. Qxf5 Kc6 62. g4 Kb6 63. g5 Ka6 64. g6 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "FedaMaster"]
+[Black "fusionpro"]
+[Result "0-1"]
+[ECO "B22"]
+[WhiteElo "2559"]
+[BlackElo "2441"]
+[PlyCount "98"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 c5 2. d4 cxd4 3. c3 Nf6 4. e5 Nd5 5. Nf3 d6 6. Qxd4 e6 7. Nbd2 Nc6 8. Bb5
+Qb6 9. Qxb6 Nxb6 10. exd6 Bxd6 11. Ne4 Be7 12. Bg5 Bd7 13. Bxe7 Kxe7 14. O-O-O
+a6 15. Bd3 Rhd8 16. Rhe1 h6 17. Nc5 Rab8 18. Be4 Be8 19. Rxd8 Nxd8 20. Nd4 Nd7
+21. Ncb3 Nf6 22. Bf3 Kf8 23. Na5 Nd7 24. Ndb3 Ke7 25. Nc4 Rc8 26. Ne3 Nc6 27.
+Nd5+ Kf8 28. Ne3 Nce5 29. Be2 Nc6 30. Rd1 Ke7 31. Nd4 Nxd4 32. Rxd4 e5 33. Rd2
+Nf6 34. Kc2 Bd7 35. Bf3 b6 36. Nd5+ Nxd5 37. Rxd5 f6 38. Rd2 Rc7 39. Bd5 a5 40.
+c4 Bf5+ 41. Kc3 Be6 42. b3 Bxd5 43. Rxd5 Ke6 44. a4 Rb7 45. Rb5 f5 46. c5 Kd5
+47. Rxb6 Rc7 48. Rb5 Rxc5+ 49. Rxc5+ Kxc5 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Yio05"]
+[Black "Adrian_DelaCruz"]
+[Result "0-1"]
+[ECO "E94"]
+[WhiteElo "2328"]
+[BlackElo "2355"]
+[PlyCount "80"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. Nf3 Nf6 2. d4 g6 3. c4 Bg7 4. Nc3 O-O 5. e4 d6 6. Be2 e5 7. O-O Na6 8. Be3
+Ng4 9. Bg5 f6 10. Bh4 exd4 11. Nxd4 Ne5 12. Rc1 Nc5 13. f4 Nc6 14. Nc2 a5 15.
+Bf3 g5 16. Bg3 gxf4 17. Bxf4 Ne5 18. Ne3 c6 19. Qd2 Be6 20. b3 Qe7 21. Rcd1
+Rfd8 22. Nf5 Bxf5 23. exf5 Bf8 24. Rfe1 Kh8 25. Qf2 Qg7 26. Ne4 Ncd3 27. Qe3 d5
+28. cxd5 cxd5 29. Bxe5 dxe4 30. Rxd3 exd3 31. Bd4 Re8 32. Qxe8 Rxe8 33. Rxe8
+Qf7 34. Re6 Bg7 35. Kf2 Qd7 36. Ke3 d2 37. Kd3 Kg8 38. Re4 Bh6 39. Re6 Qb5+ 40.
+Kc2 Qxf5+ 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "chesslismab"]
+[Black "hungzhao"]
+[Result "0-1"]
+[ECO "A46"]
+[WhiteElo "2444"]
+[BlackElo "2631"]
+[PlyCount "104"]
+[EventDate "2020.??.??"]
+
+1. d4 e6 2. Nf3 Nf6 3. e3 b6 4. Be2 Bb7 5. O-O c5 6. c4 Be7 7. Nc3 cxd4 8. Nxd4
+d5 9. cxd5 Nxd5 10. Nxd5 Bxd5 11. Bb5+ Nd7 12. Nc6 Bxc6 13. Bxc6 Rc8 14. Qa4
+Rc7 15. Rd1 Qc8 16. Bb5 Bf6 17. e4 Ke7 18. Bf4 e5 19. Bd2 a5 20. Be3 Rd8 21.
+Qa3+ Nc5 22. Rxd8 Qxd8 23. f3 Kf8 24. Kf2 Be7 25. Ke2 Ne6 26. Qd3 Nd4+ 27. Bxd4
+exd4 28. Rd1 Bc5 29. a3 Qh4 30. h3 g6 31. Kf1 Kg7 32. Kg1 Qf6 33. Kh1 Re7 34.
+Qd2 Bd6 35. Qf2 Be5 36. Bd3 Qf4 37. Qg1 Qg3 38. Rf1 f6 39. f4 Bxf4 40. Rf3 Qg5
+41. Qxd4 Be5 42. Qf2 Qc1+ 43. Qf1 Qc7 44. Qf2 Rd7 45. g3 Rd6 46. Kg2 Qd7 47. h4
+Rxd3 48. Rxd3 Qxd3 49. Qxb6 Qxe4+ 50. Kh3 Qf5+ 51. Kg2 h5 52. Qxf6+ Qxf6 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "BerserkAdopter"]
+[Black "estocastico"]
+[Result "1-0"]
+[ECO "B20"]
+[WhiteElo "2446"]
+[BlackElo "2581"]
+[PlyCount "71"]
+[EventDate "2020.??.??"]
+
+1. e4 c5 2. d3 d6 3. Nd2 Nc6 4. Ngf3 g6 5. g3 Bg7 6. Bg2 Nf6 7. O-O O-O 8. c3
+Rb8 9. Qe2 b5 10. h3 b4 11. c4 a5 12. Re1 a4 13. Rb1 Bb7 14. Nf1 Nd7 15. h4
+Nde5 16. N1h2 e6 17. h5 Qc7 18. h6 Bh8 19. Be3 Rfd8 20. Rbd1 d5 21. Bxc5 Nxf3+
+22. Nxf3 d4 23. a3 b3 24. Qd2 e5 25. Qg5 f6 26. Qg4 Bc8 27. Qh4 Be6 28. Nh2 Rf8
+29. Rf1 Rfe8 30. f4 Nd8 31. Bb4 Nf7 32. Bd2 Qd7 33. Bf3 Rbc8 34. Ng4 Bxc4 35.
+Nxf6+ Bxf6 36. Qxf6 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "taras05"]
+[Black "Betovsky"]
+[Result "1-0"]
+[ECO "B00"]
+[WhiteElo "2483"]
+[BlackElo "2630"]
+[PlyCount "47"]
+[EventDate "2020.??.??"]
+
+1. e4 a5 2. d4 b6 3. Bd3 Ba6 4. Qe2 Bxd3 5. Qxd3 c5 6. c3 cxd4 7. cxd4 Nc6 8.
+Nc3 Nb4 9. Qe2 d6 10. Nf3 Nf6 11. a3 Nc6 12. Qb5 Qd7 13. Qxb6 Rb8 14. Qa6 g6
+15. Qe2 Bg7 16. O-O O-O 17. Rd1 e6 18. e5 Ne8 19. Ne4 h6 20. h4 Rb3 21. Bf4 d5
+22. Nc5 Qb7 23. Nxb7 Rxb7 24. Rac1 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "redbullet64"]
+[Black "Molot_ua"]
+[Result "1-0"]
+[ECO "B12"]
+[WhiteElo "2405"]
+[BlackElo "2378"]
+[PlyCount "71"]
+[EventDate "2020.??.??"]
+
+1. e4 c6 2. d4 d6 3. Nc3 Nd7 4. f4 h6 5. Nf3 g5 6. fxg5 hxg5 7. Nxg5 Bg7 8. Bc4
+d5 9. Qf3 Ndf6 10. e5 dxc4 11. exf6 Nxf6 12. O-O Qxd4+ 13. Be3 Qd6 14. Bf4 Qc5+
+15. Kh1 Bg4 16. Qg3 Bh5 17. Rad1 Rd8 18. Rxd8+ Kxd8 19. h3 Qb6 20. Rd1+ Ke8 21.
+Bc7 Bxd1 22. Bxb6 axb6 23. Qb8+ Kd7 24. Qxb7+ Kd6 25. Nxf7+ Ke6 26. Nxh8 Bxc2
+27. Ng6 Bxg6 28. Qxc6+ Kf7 29. Qxb6 Ne4 30. Nxe4 Bxe4 31. Qb4 Bd3 32. b3 Be5
+33. bxc4 Bd6 34. Qc3 Bf5 35. c5 Be6 36. cxd6 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Filemon64"]
+[Black "Ridics"]
+[Result "1-0"]
+[ECO "A22"]
+[WhiteElo "2326"]
+[BlackElo "2300"]
+[PlyCount "109"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. c4 Nf6 2. Nc3 e5 3. g3 Bc5 4. Bg2 O-O 5. e3 Nc6 6. Nge2 Re8 7. O-O e4 8. b3
+d6 9. Bb2 Bg4 10. h3 Bh5 11. g4 Bg6 12. Nf4 Qd7 13. d4 exd3 14. Nxg6 hxg6 15.
+Qxd3 Ne5 16. Qe2 c6 17. Rad1 Rad8 18. Na4 Bb4 19. a3 Ba5 20. b4 Bc7 21. f4
+Nexg4 22. hxg4 Nxg4 23. e4 c5 24. Nxc5 Qc6 25. Nb3 Bb6+ 26. Nd4 Ne5 27. c5 dxc5
+28. Nxc6 cxb4+ 29. Kh1 Nxc6 30. e5 Rc8 31. axb4 Nxb4 32. Bxb7 Rc2 33. Qb5 Rb8
+34. Qxb4 Rxb7 35. f5 gxf5 36. Rd8+ Kh7 37. Qh4+ Kg6 38. Rd3 f6 39. exf6 Rxb2
+40. Rg3+ Kf7 41. Rxg7+ Ke6 42. Rxb7 Bf2 43. Rxf2 Rxb7 44. Re2+ Kf7 45. Qh7+
+Kxf6 46. Qxb7 a5 47. Qb6+ Kg5 48. Qxa5 Kg4 49. Rf2 f4 50. Qb4 Kh3 51. Rxf4 Kg3
+52. Rc4 Kf2 53. Qb3 Kf1 54. Rc2 Ke1 55. Qb1# 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Frogkiller"]
+[Black "Donald666Trump"]
+[Result "0-1"]
+[ECO "A42"]
+[WhiteElo "2384"]
+[BlackElo "2378"]
+[PlyCount "104"]
+[EventDate "2020.??.??"]
+
+1. e4 c5 2. Nf3 g6 3. d4 cxd4 4. Qxd4 Nf6 5. e5 Nc6 6. Qa4 Nd5 7. Qe4 Ndb4 8.
+Bb5 Qa5 9. Nc3 d5 10. exd6 Bf5 11. Qe5 f6 12. Bxc6+ Nxc6 13. Qxa5 Nxa5 14. dxe7
+Bxe7 15. O-O O-O-O 16. Re1 Rhe8 17. Bf4 Nc6 18. a3 Bxc2 19. Rac1 Bf5 20. Nb5 a6
+21. Na7+ Kd7 22. Red1+ Ke6 23. Nxc6 Rxd1+ 24. Rxd1 bxc6 25. Nd4+ Kf7 26. Nxc6
+Bf8 27. h3 Re2 28. g4 Bc8 29. Nd8+ Ke8 30. b3 Bxa3 31. Nc6 Bb7 32. Nd4 Ra2 33.
+Be3 Be7 34. Ne6 Ra3 35. Nc7+ Kf7 36. Nd5 Bxd5 37. Rxd5 Rxb3 38. Rd7 Ra3 39.
+Rxe7+ Kxe7 40. Bc5+ Ke6 41. Bxa3 f5 42. Kg2 fxg4 43. hxg4 h5 44. Kf3 hxg4+ 45.
+Kxg4 Kf6 46. f3 Kf7 47. Bb2 Kg8 48. Kg5 Kf7 49. f4 a5 50. Ba3 a4 51. Bb4 Ke6
+52. Kxg6 Kd5 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "mohsen448"]
+[Black "pmlmail"]
+[Result "1/2-1/2"]
+[ECO "A48"]
+[WhiteElo "2366"]
+[BlackElo "2472"]
+[PlyCount "135"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 Nf6 2. Nf3 g6 3. Bg5 Bg7 4. Nbd2 d5 5. e3 Bf5 6. c4 c6 7. Qb3 Qb6 8. c5
+Qxb3 9. axb3 a6 10. b4 O-O 11. b5 cxb5 12. Bxb5 Nbd7 13. Bxd7 Bxd7 14. b4 Bb5
+15. Nb3 e6 16. Na5 Rab8 17. Bf4 b6 18. Bxb8 bxa5 19. Bd6 axb4 20. Bxf8 Bxf8 21.
+Kd2 Ne4+ 22. Kc2 Nxf2 23. Rhb1 Bd3+ 24. Kb3 Bxb1 25. Rxb1 a5 26. Ra1 Ng4 27.
+Rxa5 Nxe3 28. Kxb4 Nxg2 29. Ra8 Kg7 30. Ka4 Ne3 31. c6 Nc4 32. Kb5 Nd6+ 33. Kb6
+Nc4+ 34. Kb7 Bd6 35. c7 Bxc7 36. Kxc7 h6 37. Ne5 Ne3 38. Kd6 Nf5+ 39. Kc5 h5
+40. Ra7 Nh6 41. Kd6 Kf6 42. h4 Nf5+ 43. Kc5 Nxh4 44. Rxf7+ Kg5 45. Kd6 Nf5+ 46.
+Kc5 h4 47. Rh7 Ng3 48. Nf7+ Kg4 49. Nd8 Nh5 50. Nxe6 h3 51. Ra7 h2 52. Ra1 Ng3
+53. Kxd5 h1=Q+ 54. Rxh1 Nxh1 55. Ke5 Ng3 56. d5 Nf5 57. d6 Nxd6 58. Kxd6 Kf5
+59. Kd5 Kf6 60. Nd4 g5 61. Nf3 g4 62. Ng1 Kf5 63. Kd4 Kf4 64. Kd3 Kg3 65. Ke2
+Kg2 66. Ke3 g3 67. Ne2 Kh2 68. Nxg3 1/2-1/2
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Lil_D"]
+[Black "Bulingot"]
+[Result "0-1"]
+[ECO "A01"]
+[WhiteElo "2305"]
+[BlackElo "2354"]
+[PlyCount "32"]
+[EventDate "2020.??.??"]
+
+1. b3 a5 2. Bb2 a4 3. bxa4 Nc6 4. Nc3 e5 5. e4 Bb4 6. Nf3 Nge7 7. Nd5 O-O 8.
+Nxb4 Nxb4 9. Bc4 d5 10. exd5 e4 11. Ng5 Bf5 12. O-O Nexd5 13. d3 Qxg5 14. dxe4
+Bxe4 15. f3 Ne3 16. Qd4 Qxg2# 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "InsaneTryhard"]
+[Black "Cazulo97"]
+[Result "0-1"]
+[ECO "C20"]
+[WhiteElo "2361"]
+[BlackElo "2377"]
+[PlyCount "66"]
+[EventDate "2020.??.??"]
+
+1. e4 e5 2. Qh5 Nc6 3. Bc4 g6 4. Qf3 Qf6 5. Ne2 Qxf3 6. gxf3 Bc5 7. d3 d6 8.
+Nbc3 Be6 9. Nd5 Nge7 10. Nxc7+ Kd7 11. Nxa8 Rxa8 12. c3 a6 13. f4 b5 14. Bb3
+Na5 15. Bc2 b4 16. fxe5 dxe5 17. f4 f6 18. fxe5 fxe5 19. h4 Bg4 20. Ng3 h5 21.
+Nf1 Rf8 22. Ne3 Rf3 23. d4 exd4 24. Nd5 Nxd5 25. exd5 dxc3 26. Bg5 Bf2+ 27. Kf1
+Bxh4+ 28. Kg1 Bxg5 29. bxc3 Be3+ 30. Kg2 Rf2+ 31. Kg3 Rxc2 32. cxb4 g5 33. bxa5
+Bf4# 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Maybach77"]
+[Black "Dynamovec"]
+[Result "1-0"]
+[ECO "B33"]
+[WhiteElo "2362"]
+[BlackElo "2411"]
+[PlyCount "63"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 c5 2. Nf3 Nc6 3. Nc3 Nf6 4. d4 cxd4 5. Nxd4 e5 6. Ndb5 d6 7. Bg5 a6 8.
+Na3 b5 9. Nd5 Be7 10. Bxf6 Bxf6 11. c3 Bg5 12. Nc2 Rb8 13. Bd3 O-O 14. O-O Ne7
+15. Ncb4 Bb7 16. a4 Nxd5 17. exd5 a5 18. Nc6 Bxc6 19. dxc6 bxa4 20. Qc2 Qb6 21.
+Bxh7+ Kh8 22. Be4 Qxb2 23. Qxb2 Rxb2 24. Rxa4 f5 25. Bd5 Rc2 26. c4 Bd8 27. g3
+f4 28. Rb1 fxg3 29. fxg3 e4 30. Bxe4 Re2 31. Bd5 Kh7 32. Rb8 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "metalkingGT"]
+[Black "joshuawaitzkin"]
+[Result "1-0"]
+[ECO "A05"]
+[WhiteElo "2453"]
+[BlackElo "2510"]
+[PlyCount "41"]
+[EventDate "2020.??.??"]
+
+1. Nf3 g6 2. g3 Bg7 3. Bg2 Nf6 4. O-O O-O 5. d3 d5 6. c3 c5 7. Nbd2 d4 8. e4
+dxc3 9. bxc3 Nc6 10. Nc4 Be6 11. Ne3 Qd7 12. Ng5 Rad8 13. Nxe6 Qxe6 14. Qe2 Ne5
+15. Rd1 Rd7 16. Bb2 Rfd8 17. d4 cxd4 18. cxd4 Neg4 19. d5 Qb6 20. Nxg4 Nxg4 21.
+Bxg7 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "ajedrez2021"]
+[Black "sutcunuri"]
+[Result "1-0"]
+[ECO "A10"]
+[WhiteElo "2596"]
+[BlackElo "2516"]
+[PlyCount "95"]
+[EventDate "2020.??.??"]
+
+1. c4 b6 2. Nf3 Bb7 3. Nc3 c5 4. e4 e6 5. d4 cxd4 6. Nxd4 a6 7. Be2 Nc6 8. O-O
+Nf6 9. Be3 Qc7 10. f4 Nxd4 11. Bxd4 Bc5 12. Bf3 e5 13. fxe5 Qxe5 14. Bxc5 bxc5
+15. Kh1 O-O 16. Qd2 Rfe8 17. Rad1 Rad8 18. Qd6 Nxe4 19. Nxe4 Bxe4 20. Bxe4 Qxe4
+21. Qxc5 d6 22. Qf2 Qxc4 23. b3 Qe6 24. Rde1 Qd7 25. h3 h6 26. Rd1 d5 27. Rd4
+Re4 28. Rc1 Qe6 29. Rcd1 Rxd4 30. Qxd4 Rd7 31. Qc5 h5 32. Qc8+ Kh7 33. Qc2+ g6
+34. Qd2 d4 35. Re1 Qf5 36. Qe2 d3 37. Qd2 h4 38. Re3 Rd4 39. Kh2 Qf4+ 40. Kg1
+Re4 41. Rxd3 Qe5 42. Rf3 Re1+ 43. Rf1 Re2 44. Qf4 Qc5+ 45. Kh1 Qh5 46. Qxf7+
+Kh6 47. Qf8+ Kg5 48. Qf4# 1-0
+
+[Event "Rated Blitz tournament hM7PUvgg"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "lama17"]
+[Black "balachess2006"]
+[Result "0-1"]
+[ECO "C11"]
+[WhiteElo "2338"]
+[BlackElo "2418"]
+[PlyCount "60"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 Nf6 2. Nc3 e6 3. e4 d5 4. Bg5 dxe4 5. Nxe4 Be7 6. Bxf6 Bxf6 7. Nf3 Nd7 8.
+c3 b6 9. Bd3 Bb7 10. Qc2 Be7 11. O-O-O Qc8 12. h4 Ba6 13. Neg5 h6 14. Ne4 Bxd3
+15. Rhe1 Bxc2 16. Kxc2 Qa6 17. a3 O-O-O 18. Kb1 Nf6 19. Ned2 Bd6 20. Ka2 Qd3
+21. Nb3 Qa6 22. Nfd2 c5 23. c4 cxd4 24. Nxd4 Bc5 25. Nb5 Rd7 26. Re2 Rhd8 27.
+b4 Bxb4 28. Kb3 Bxd2 29. a4 Rd3+ 30. Kc2 Qxa4+ 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "zpxocivubyntmraeswdq"]
+[Black "drdrunckenstein"]
+[Result "1-0"]
+[ECO "A10"]
+[WhiteElo "2689"]
+[BlackElo "2532"]
+[PlyCount "55"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. c4 g6 2. g3 d6 3. Bg2 Bg7 4. d3 Nf6 5. Qd2 O-O 6. Nc3 Nc6 7. b3 e5 8. Bb2 h6
+9. e3 Nd7 10. Nge2 f5 11. f4 Kh7 12. Nd5 Ne7 13. O-O c6 14. Ndc3 Nf6 15. b4 a5
+16. b5 c5 17. fxe5 dxe5 18. Na4 Qd6 19. Ba3 Nd7 20. Rad1 Re8 21. d4 exd4 22.
+exd4 Qe6 23. d5 Qd6 24. Nf4 b6 25. Ne6 Nf6 26. Rfe1 Bd7 27. Nxb6 Qxb6 28. Bxc5
+1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "hanysayed"]
+[Black "elRope"]
+[Result "0-1"]
+[ECO "D94"]
+[WhiteElo "2307"]
+[BlackElo "2362"]
+[PlyCount "36"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. Nf3 Nf6 2. d4 g6 3. e3 Bg7 4. c4 O-O 5. Nc3 c5 6. Be2 cxd4 7. exd4 d5 8. O-O
+Nc6 9. cxd5 Nxd5 10. Bc4 Be6 11. Bxd5 Bxd5 12. Be3 Bxf3 13. Qxf3 Nxd4 14. Bxd4
+Qxd4 15. Qxb7 Rab8 16. Qxe7 Rxb2 17. Rac1 Bh6 18. Rfd1 Qxf2+ 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "SuperDonald"]
+[Black "Alliced"]
+[Result "0-1"]
+[ECO "E70"]
+[WhiteElo "2329"]
+[BlackElo "2382"]
+[PlyCount "68"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 Nf6 2. c4 g6 3. Nc3 Bg7 4. e4 O-O 5. Be3 d6 6. h3 e5 7. d5 Na6 8. Nf3 Nh5
+9. g3 f5 10. exf5 gxf5 11. Nh4 Qe8 12. Be2 Nf6 13. Qc2 Nb4 14. Qb3 a5 15. a3 f4
+16. axb4 fxe3 17. fxe3 Bh6 18. Nb5 Qf7 19. Rxa5 Rxa5 20. bxa5 Ne4 21. Rf1 Qg7
+22. Rxf8+ Qxf8 23. Bf3 Nxg3 24. Qd1 e4 25. Bg2 Qf6 26. Nxc7 Qxh4 27. Ne6 Bxe3
+28. Qg4+ Qxg4 29. hxg4 Bxe6 30. dxe6 Bd4 31. b4 e3 32. Bf3 Bc3+ 33. Kd1 Bxb4
+34. Bd5 Kf8 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "hawth0rne"]
+[Black "ROBESPIERR"]
+[Result "0-1"]
+[ECO "C00"]
+[WhiteElo "2445"]
+[BlackElo "2559"]
+[PlyCount "36"]
+[EventDate "2020.??.??"]
+
+1. c4 e6 2. e4 Nf6 3. e5 Ng8 4. Qg4 d6 5. Nf3 Nc6 6. exd6 cxd6 7. a3 Nf6 8. Qg3
+d5 9. Nc3 d4 10. Nb5 e5 11. Nxe5 Qe7 12. Bd3 Qxe5+ 13. Qxe5+ Nxe5 14. Nc7+ Kd8
+15. Nxa8 Nxd3+ 16. Ke2 Bf5 17. h3 h5 18. g4 hxg4 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "murderoflegends"]
+[Black "Shahrisabz"]
+[Result "1-0"]
+[ECO "B32"]
+[WhiteElo "2410"]
+[BlackElo "2302"]
+[PlyCount "83"]
+[EventDate "2020.??.??"]
+
+1. e4 c5 2. Nf3 Nc6 3. d4 cxd4 4. Nxd4 e5 5. Nxc6 bxc6 6. Nc3 Be7 7. Bc4 Nf6 8.
+O-O O-O 9. Bg5 d6 10. Bb3 Be6 11. Qe2 Qd7 12. Rad1 Bg4 13. f3 Be6 14. h3 h6 15.
+Bxf6 Bxf6 16. Qd3 Be7 17. Rfe1 Qc7 18. Ne2 Rad8 19. Kh2 Qb6 20. Ng3 Bg5 21. Nf5
+Bxf5 22. exf5 Bf4+ 23. Kh1 d5 24. c3 Qf2 25. f6 Qg3 26. Kg1 Qh2+ 27. Kf1 Bg3
+28. Qe3 gxf6 29. Qxh6 Qh1+ 30. Ke2 Qxg2+ 31. Kd3 e4+ 32. fxe4 dxe4+ 33. Kc4
+Rxd1 34. Rxd1 Qe2+ 35. Kb4 Qb5+ 36. Ka3 Qa6+ 37. Ba4 c5 38. Rg1 Qd6 39. Rxg3+
+Qxg3 40. Qxf6 Qg6 41. Qf4 Rb8 42. Bb3 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Brocha"]
+[Black "Mia_Khaliffa"]
+[Result "1-0"]
+[ECO "A04"]
+[WhiteElo "2455"]
+[BlackElo "2439"]
+[PlyCount "105"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. Nf3 e6 2. g4 d5 3. Bg2 c5 4. h3 Nc6 5. e3 Bd6 6. b3 Nge7 7. Ba3 O-O 8. O-O
+b6 9. d4 Bb7 10. c4 Rc8 11. Nbd2 Qc7 12. Rc1 Qb8 13. dxc5 bxc5 14. cxd5 exd5
+15. Bxc5 Rfd8 16. Nd4 Bxc5 17. Rxc5 Nxd4 18. exd4 Ng6 19. Qf3 Rxc5 20. dxc5 Nh4
+21. Qg3 Nxg2 22. Qxb8 Rxb8 23. Kxg2 a5 24. Rc1 Bc6 25. Kg3 d4 26. Rc4 Rd8 27.
+Kf4 f6 28. Nf3 g5+ 29. Kg3 Bxf3 30. Kxf3 d3 31. Rc1 Kf7 32. Ke3 Ke6 33. Kd2 Ke5
+34. c6 Kd4 35. Rc3 Rc8 36. Rxd3+ Ke4 37. Rc3 Rc7 38. a3 Kf4 39. b4 axb4 40.
+axb4 Ke5 41. b5 Kd6 42. b6 Rxc6 43. Rxc6+ Kxc6 44. Kd3 Kxb6 45. Ke4 Kc6 46. Kf5
+Kd5 47. Kxf6 Ke4 48. Kxg5 Kf3 49. Kh6 Kxf2 50. Kxh7 Kg3 51. g5 Kxh3 52. g6 Kg4
+53. g7 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Evgen_88"]
+[Black "gmmitkov"]
+[Result "0-1"]
+[ECO "D00"]
+[WhiteElo "2532"]
+[BlackElo "2501"]
+[PlyCount "48"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 d5 2. g3 c6 3. Bg2 Bg4 4. h3 Bh5 5. Nf3 e6 6. O-O Nd7 7. c4 Bd6 8. Nc3
+Ngf6 9. g4 Bg6 10. Nh4 Be4 11. Nxe4 Nxe4 12. Nf3 h5 13. g5 h4 14. Qb3 Rb8 15.
+Nd2 Nxg5 16. e4 Nxe4 17. Nxe4 dxe4 18. Bxe4 Qf6 19. Rd1 Bf4 20. d5 Nc5 21. Qc2
+Bxc1 22. Raxc1 O-O 23. dxc6 bxc6 24. Bxc6 Rxb2 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Caochonewell"]
+[Black "RigelStar"]
+[Result "1-0"]
+[ECO "D13"]
+[WhiteElo "2424"]
+[BlackElo "2404"]
+[PlyCount "123"]
+[EventDate "2020.??.??"]
+
+1. d4 d5 2. Nf3 c6 3. c4 Nf6 4. cxd5 cxd5 5. Nc3 e6 6. a3 a6 7. Bg5 Nc6 8. e3
+h6 9. Bh4 Be7 10. Bd3 b5 11. O-O Na5 12. a4 b4 13. Nb1 Bd7 14. Qe2 Qb6 15. Nbd2
+O-O 16. Ne5 g5 17. Bg3 Rfc8 18. Rfc1 Rxc1+ 19. Rxc1 Rc8 20. Rxc8+ Bxc8 21. h4
+b3 22. hxg5 hxg5 23. f4 gxf4 24. Bxf4 Bb7 25. Ng4 Ne4 26. Nh6+ Kf8 27. Bxe4
+dxe4 28. Qh5 Ke8 29. Qxf7+ Kd8 30. Ng8 Qb4 31. Nf1 Nc6 32. Qg7 Ke8 33. Nxe7
+Nxe7 34. Bg5 Bd5 35. Bxe7 Qxe7 36. Qe5 Qd7 37. a5 Ke7 38. Qb8 Qb5 39. Qxb5 axb5
+40. a6 Kd6 41. Nd2 Kc6 42. a7 Kb6 43. Nxb3 Kxa7 44. Nc5 Kb6 45. g4 Ka5 46. b4+
+Kxb4 47. g5 e5 48. g6 exd4 49. exd4 Bg8 50. Nxe4 Kc4 51. Nf6 Be6 52. d5 b4 53.
+dxe6 b3 54. e7 b2 55. e8=Q b1=Q+ 56. Kf2 Qb2+ 57. Qe2+ Qxe2+ 58. Kxe2 Kd4 59.
+g7 Ke5 60. g8=Q Kxf6 61. Qg3 Kf5 62. Qc3 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Cebuanochessking"]
+[Black "ChanceTraveler"]
+[Result "1-0"]
+[ECO "B72"]
+[WhiteElo "2403"]
+[BlackElo "2389"]
+[PlyCount "91"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 g6 6. Be2 Bg7 7. g4 Nc6 8. g5
+Nd7 9. Be3 O-O 10. h4 Nxd4 11. Bxd4 Bxd4 12. Qxd4 Qb6 13. O-O-O Qxd4 14. Rxd4
+Nb6 15. f4 Be6 16. h5 Rfc8 17. Rf1 Bc4 18. Bxc4 Rxc4 19. Rxc4 Nxc4 20. b3 Nb6
+21. h6 f6 22. gxf6 exf6 23. Nb5 d5 24. e5 Kf7 25. a4 a6 26. Nd4 Re8 27. e6+ Ke7
+28. f5 Rg8 29. Re1 g5 30. c4 dxc4 31. a5 Nc8 32. bxc4 Nd6 33. c5 Rc8 34. Nb3
+Nxf5 35. Kb2 Nxh6 36. Nd4 Rd8 37. Kc3 Rxd4 38. Kxd4 Nf5+ 39. Kc4 h5 40. Rb1
+Kxe6 41. Rxb7 h4 42. Rh7 g4 43. c6 h3 44. c7 Nd6+ 45. Kd4 Nc8 46. Ke4 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "burpcow"]
+[Black "MiguelKni"]
+[Result "1-0"]
+[ECO "B31"]
+[WhiteElo "2302"]
+[BlackElo "2305"]
+[PlyCount "43"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 c5 2. Nf3 Nc6 3. Bb5 g6 4. Bxc6 bxc6 5. O-O Bg7 6. c3 Nf6 7. Re1 O-O 8.
+d4 cxd4 9. cxd4 d5 10. e5 Ne4 11. Nbd2 Nxd2 12. Bxd2 Rb8 13. b3 Qb6 14. Rc1 Bg4
+15. Be3 Rfc8 16. h3 Bd7 17. Qd2 a5 18. Bh6 Bh8 19. Ng5 e6 20. Qf4 Be8 21. Nxe6
+fxe6 22. Qf8# 1-0
+
+[Event "Rated Blitz tournament hM7PUvgg"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "GlennTipton"]
+[Black "AGG2020"]
+[Result "1-0"]
+[ECO "A48"]
+[WhiteElo "2455"]
+[BlackElo "2483"]
+[PlyCount "115"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 Nf6 2. Nf3 g6 3. Bf4 Bg7 4. e3 O-O 5. h3 d6 6. Be2 c5 7. c3 Nc6 8. O-O
+Qb6 9. Qb3 Be6 10. Qxb6 axb6 11. a3 h6 12. Nbd2 Bf5 13. g4 Be6 14. e4 cxd4 15.
+Nxd4 Bd7 16. Be3 h5 17. g5 Nh7 18. h4 f6 19. Bc4+ Kh8 20. Ne6 Bxe6 21. Bxe6
+fxg5 22. hxg5 Ne5 23. f4 Nd3 24. Rab1 Nc5 25. Bh3 e6 26. Bxc5 dxc5 27. Bxe6
+Rad8 28. Bd5 Rfe8 29. Nf3 Re7 30. c4 Rf8 31. Nh4 Bd4+ 32. Kg2 Kg7 33. b3 Rfe8
+34. a4 Nf8 35. Nf3 Rxe4 36. Bxe4 Rxe4 37. Nxd4 Rxd4 38. Rbd1 Ne6 39. Rxd4 Nxd4
+40. Rb1 Kf7 41. Kf2 Ke6 42. Ke3 Kf5 43. Rb2 h4 44. b4 Kg4 45. bxc5 bxc5 46.
+Rxb7 h3 47. Rb2 Kg3 48. a5 h2 49. Rxh2 Kxh2 50. a6 Nc6 51. f5 gxf5 52. g6 Kg3
+53. g7 f4+ 54. Kd3 Ne7 55. a7 f3 56. a8=Q f2 57. Qf8 Kg2 58. g8=Q+ 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Realblindmuddy"]
+[Black "Elhlwagy11"]
+[Result "0-1"]
+[ECO "D02"]
+[WhiteElo "2404"]
+[BlackElo "2304"]
+[PlyCount "110"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. Nf3 d5 2. d4 Nc6 3. c4 Nf6 4. Nc3 e6 5. e3 Bd6 6. Bd3 dxc4 7. Bxc4 a6 8. O-O
+O-O 9. b3 e5 10. dxe5 Nxe5 11. Be2 Qe7 12. Bb2 Bg4 13. h3 Bh5 14. Nd4 Bxe2 15.
+Qxe2 g6 16. Rad1 Rfe8 17. Nf3 Rad8 18. Nxe5 Qxe5 19. g3 Qf5 20. Kg2 h5 21. Qf3
+Qxf3+ 22. Kxf3 b5 23. Nxb5 axb5 24. Bxf6 Ra8 25. Rd2 Ra6 26. Rc1 Ba3 27. Rcc2
+Rxf6+ 28. Kg2 Bd6 29. Re2 b4 30. f4 Rfe6 31. Kf3 f5 32. Rc4 c5 33. e4 fxe4+ 34.
+Rcxe4 Rxe4 35. Rxe4 Re7 36. Rxe7 Bxe7 37. Ke4 Kf7 38. Kd5 Kf6 39. g4 h4 40. Ke4
+Bd6 41. f5 gxf5+ 42. gxf5 Bg3 43. Kd5 Bf2 44. Ke4 Bd4 45. Kf4 Bb2 46. Kg4 Bc1
+47. Kxh4 Kxf5 48. Kg3 Ke4 49. Kf2 Kd3 50. Ke1 Kc2 51. Ke2 Kb2 52. Kd1 Bh6 53.
+h4 Kxa2 54. Kc2 Bf4 55. h5 Bh6 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Betovsky"]
+[Black "taras05"]
+[Result "0-1"]
+[ECO "A80"]
+[WhiteElo "2622"]
+[BlackElo "2491"]
+[PlyCount "34"]
+[EventDate "2020.??.??"]
+
+1. d4 f5 2. Bg5 g6 3. e4 fxe4 4. Nc3 Nf6 5. Bxf6 exf6 6. Nxe4 d5 7. Ng3 Kf7 8.
+Bd3 Bg7 9. Nf3 c6 10. O-O Be6 11. c4 Re8 12. cxd5 Bxd5 13. Re1 Nd7 14. Be4 Nb6
+15. a4 a5 16. Bxd5+ Qxd5 17. Qb3 Qxb3 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Gambitopy"]
+[Black "Training88"]
+[Result "1-0"]
+[ECO "B00"]
+[WhiteElo "2303"]
+[BlackElo "2326"]
+[PlyCount "69"]
+[EventDate "2020.??.??"]
+
+1. e4 a6 2. d4 b5 3. Bd3 Bb7 4. Nf3 Nf6 5. Qe2 e6 6. O-O c5 7. dxc5 Bxc5 8. Bg5
+Qb6 9. a3 Ng4 10. b4 Bd4 11. Nxd4 Qxd4 12. Nd2 h5 13. Nf3 Qb6 14. e5 Nc6 15.
+Be4 Ne7 16. Bxe7 Kxe7 17. Bxb7 Qxb7 18. h3 Nh6 19. Rad1 Nf5 20. c4 Rhc8 21. c5
+g6 22. Qd2 Rc6 23. Qg5+ Kf8 24. Rd3 Kg7 25. Rfd1 Rc7 26. Qf6+ Kg8 27. Ng5 Rf8
+28. Rd6 Ng7 29. c6 Ne8 30. cxb7 Nxf6 31. exf6 Rxb7 32. Rxd7 Rb6 33. Rd8 e5 34.
+Rxf8+ Kxf8 35. Rd8# 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "vassiukov"]
+[Black "lewisbort"]
+[Result "1/2-1/2"]
+[ECO "A41"]
+[WhiteElo "2347"]
+[BlackElo "2367"]
+[PlyCount "164"]
+[EventDate "2020.??.??"]
+
+1. d4 d6 2. Nf3 g6 3. Bf4 Bg7 4. e3 Nd7 5. h3 e5 6. Nbd2 exf4 7. exf4 Ne7 8.
+Be2 Kf8 9. O-O Kg8 10. Re1 h6 11. g4 Nf6 12. Bd3 h5 13. g5 Nfd5 14. f5 Nxf5 15.
+Ne4 Nf4 16. Bf1 Bd7 17. Qd2 Kh7 18. Qxf4 d5 19. Nc5 b6 20. Nxd7 Qxd7 21. c3
+Rhe8 22. Bd3 Rxe1+ 23. Rxe1 Nd6 24. Kg2 Re8 25. Ne5 Re7 26. Re3 Qe8 27. h4 c5
+28. Qf3 Kg8 29. Qxd5 cxd4 30. cxd4 Nb7 31. Bb5 Qd8 32. Qxd8+ Nxd8 33. Bc4 Ne6
+34. Nxg6 Bxd4 35. Nxe7+ Kf8 36. Re4 Kxe7 37. Bxe6 Bxb2 38. Bg4+ Kd6 39. Bxh5 f5
+40. gxf6 Bxf6 41. Bg4 Kd5 42. Ra4 b5 43. Rxa7 Bd4 44. Rb7 Kc6 45. Rxb5 Kxb5 46.
+Kf3 Kc6 47. Ke4 Bg7 48. f4 Kd6 49. Kf5 Ke7 50. Kg6 Bf6 51. f5 Bd4 52. h5 Bf6
+53. h6 Be5 54. Bh5 Bd4 55. Kh7 Bf6 56. Kg8 Be5 57. h7 Bf6 58. h8=Q Bxh8 59.
+Kxh8 Kf6 60. Kh7 Kxf5 61. Bg6+ Ke5 62. a4 Kd5 63. a5 Kc5 64. a6 Kb6 65. Bd3 Ka7
+66. Kg6 Kb6 67. Kf6 Kc6 68. Ke6 Kb6 69. Kd7 Ka7 70. Kc8 Ka8 71. Kc7 Ka7 72. Kc6
+Ka8 73. Kb6 Kb8 74. Bb5 Kc8 75. Bc6 Kd8 76. a7 Ke7 77. a8=Q Kf6 78. Qb7 Kf5 79.
+Qd7+ Ke5 80. Kc5 Kf6 81. Qd5 Kg6 82. Qe4+ Kf6 1/2-1/2
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "camilomunoz0107"]
+[Black "Glig"]
+[Result "1-0"]
+[ECO "D02"]
+[WhiteElo "2356"]
+[BlackElo "2460"]
+[PlyCount "83"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 d5 2. Nf3 e6 3. c4 Nf6 4. g3 dxc4 5. Qa4+ Qd7 6. Qxc4 Qc6 7. Nbd2 Qxc4 8.
+Nxc4 Nc6 9. Bg2 Bd7 10. O-O O-O-O 11. a3 Be8 12. e3 Be7 13. b4 a6 14. Bb2 Nd5
+15. Rfc1 Kb8 16. Ne1 g5 17. Nd3 h5 18. e4 Nb6 19. Nxb6 cxb6 20. d5 exd5 21.
+Bxh8 dxe4 22. Bxe4 f6 23. Bg7 Bf7 24. Bh7 Nd4 25. Rd1 Ne6 26. Ne5 Be8 27. Rxd8+
+Bxd8 28. Rd1 fxe5 29. Bxe5+ Bc7 30. Bxc7+ Kxc7 31. Bf5 Ng7 32. g4 hxg4 33. Bxg4
+Bc6 34. Re1 Kd6 35. h4 gxh4 36. f4 Bd5 37. Kh2 a5 38. Kh3 axb4 39. axb4 Bc6 40.
+Kxh4 Ne8 41. Kg5 Kd5 42. Bf3+ 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "metalkingGT"]
+[Black "shinji_no_baka"]
+[Result "1-0"]
+[ECO "A05"]
+[WhiteElo "2460"]
+[BlackElo "2361"]
+[PlyCount "65"]
+[EventDate "2020.??.??"]
+
+1. Nf3 Nf6 2. g3 g6 3. Bg2 Bg7 4. O-O O-O 5. d3 d5 6. c3 c5 7. Nbd2 Nc6 8. e4
+Re8 9. e5 Ng4 10. d4 cxd4 11. cxd4 e6 12. h3 Nh6 13. Re1 Nf5 14. Nf1 Qb6 15.
+Be3 Nxe3 16. Nxe3 Qxb2 17. Rb1 Qxa2 18. Ng4 h5 19. Nf6+ Bxf6 20. exf6 Qa5 21.
+g4 hxg4 22. hxg4 e5 23. Nxe5 Qd8 24. g5 Bf5 25. Rxb7 Nxe5 26. dxe5 Rb8 27. Qxd5
+Rxb7 28. Qxb7 Qd2 29. Re3 Be6 30. Qxa7 Rc8 31. Rg3 Rc1+ 32. Kh2 Qd4 33. Qxd4
+1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Akylbekov_Nasir"]
+[Black "Chesscoach46"]
+[Result "1/2-1/2"]
+[ECO "C46"]
+[WhiteElo "2325"]
+[BlackElo "2322"]
+[PlyCount "124"]
+[EventDate "2020.??.??"]
+
+1. e4 e5 2. Nf3 Nc6 3. Nc3 Bc5 4. Nxe5 Bxf2+ 5. Kxf2 Nxe5 6. d4 Ng6 7. Bd3 Nf6
+8. Re1 d6 9. Kg1 Bg4 10. Qd2 c5 11. dxc5 dxc5 12. h3 Be6 13. Qf2 O-O 14. Qxc5
+Rc8 15. Qf2 a6 16. Bg5 b5 17. Bxf6 Qxf6 18. Qxf6 gxf6 19. a3 Rfd8 20. Rad1 Bc4
+21. Bxc4 Rxd1 22. Bxf7+ Kxf7 23. Rxd1 a5 24. Rd7+ Ke6 25. Rb7 b4 26. axb4 axb4
+27. Rxb4 Nf4 28. Kf2 Rg8 29. Rb6+ Ke5 30. Rb5+ Ke6 31. Nd5 Nxd5 32. Rxd5 Rb8
+33. b3 Ra8 34. Rd2 Ra2 35. Ke3 Ke5 36. c4 Ra1 37. Rd5+ Ke6 38. c5 Ra2 39. Kd4
+Rxg2 40. Rd6+ Ke7 41. Kd5 Rc2 42. b4 Rd2+ 43. Kc6 Rb2 44. b5 f5 45. b6 fxe4 46.
+Rd5 Ke6 47. Rd8 e3 48. Re8+ Kf7 49. Rxe3 Rc2 50. Re4 Rc3 51. Rb4 Ke7 52. b7 Re3
+53. b8=Q Re6+ 54. Qd6+ Kf6 55. Qxe6+ Kxe6 56. Rh4 Kf6 57. Rxh7 Kg6 58. Rd7 Kf6
+59. Rd6+ Ke5 60. Kb5 Ke4 61. c6 Kf4 62. c7 Kg3 1/2-1/2
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Mondesespoir2700"]
+[Black "jcpoza1971"]
+[Result "1-0"]
+[ECO "B01"]
+[WhiteElo "2421"]
+[BlackElo "2314"]
+[PlyCount "111"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 d5 2. exd5 Nf6 3. d4 Nxd5 4. c4 Nf6 5. Nc3 Bf5 6. Bf4 e6 7. Nf3 Bb4 8.
+Qb3 Bxc3+ 9. bxc3 b6 10. Be2 O-O 11. O-O Nc6 12. Ne5 Na5 13. Qb4 Rc8 14. Rfd1
+Qd6 15. c5 Qd8 16. Ba6 Nd5 17. Qb2 Nxf4 18. Bxc8 Qxc8 19. Qd2 Ng6 20. Nxg6 Bxg6
+21. Qg5 Qa6 22. Qe7 Qc4 23. Qxc7 Qxc3 24. Qxa7 bxc5 25. Rac1 Qa3 26. Qxc5 Qxc5
+27. Rxc5 Nb7 28. Rc7 Nd6 29. d5 exd5 30. Rxd5 Rb8 31. h4 Ne8 32. Re7 Nf6 33.
+Rd2 h5 34. a4 Ng4 35. g3 Rb1+ 36. Kg2 Nf6 37. Ra2 Be4+ 38. f3 Bd5 39. Rc2 Bb3
+40. Rc8+ Kh7 41. Ra7 Ra1 42. a5 Nd5 43. g4 Nf6 44. Kg3 hxg4 45. fxg4 Rg1+ 46.
+Kf2 Rxg4 47. Raa8 Ra4 48. a6 Rxh4 49. a7 Ra4 50. Rd8 Bd5 51. Rab8 Rxa7 52. Rb2
+Ra4 53. Rd2 Rf4+ 54. Ke3 Rf5 55. Rd6 Ne4 56. Rh2+ 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Bulingot"]
+[Black "Lil_D"]
+[Result "1-0"]
+[ECO "A10"]
+[WhiteElo "2359"]
+[BlackElo "2300"]
+[PlyCount "51"]
+[EventDate "2020.??.??"]
+
+1. c4 g6 2. h4 h6 3. h5 g5 4. d4 d6 5. Nc3 Bg7 6. e4 e6 7. Nge2 Ne7 8. g3 f5 9.
+Bg2 O-O 10. f4 fxe4 11. fxg5 d5 12. gxh6 Bf6 13. Be3 Nbc6 14. g4 dxc4 15. Nxe4
+Nd5 16. Qd2 Nxe3 17. Qxe3 Bxd4 18. Qd2 Bf2+ 19. Nxf2 Qe7 20. Ne4 Kh8 21. Qg5
+Qb4+ 22. N2c3 Qe7 23. Qxe7 Nxe7 24. O-O-O e5 25. Ng5 Bxg4 26. Be4 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Abouyahya1983"]
+[Black "Kelevra90"]
+[Result "1/2-1/2"]
+[ECO "A37"]
+[WhiteElo "2563"]
+[BlackElo "2459"]
+[PlyCount "68"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. c4 c5 2. Nc3 g6 3. Nf3 Nc6 4. g3 Bg7 5. Bg2 d6 6. O-O e6 7. e3 Nge7 8. d4
+O-O 9. b3 cxd4 10. exd4 Nf5 11. Be3 e5 12. dxe5 Nxe3 13. fxe3 Nxe5 14. Nd4 a6
+15. h3 h6 16. Nd5 Kh7 17. Qe2 Rb8 18. Kh2 Bd7 19. Rad1 b5 20. cxb5 axb5 21. Nb4
+Qb6 22. Nd5 Qd8 23. Nf3 f5 24. Nd4 b4 25. e4 fxe4 26. Bxe4 Qa5 27. Ne7 Qc5 28.
+Qh5 Rxf1 29. Nxg6 Rf2+ 30. Kh1 Kg8 31. Ne7+ Kh8 32. Ng6+ Kg8 33. Ne7+ Kh8 34.
+Ng6+ Kg8 1/2-1/2
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Kidefence"]
+[Black "BlueGreensun"]
+[Result "1-0"]
+[ECO "C41"]
+[WhiteElo "2709"]
+[BlackElo "2757"]
+[PlyCount "57"]
+[EventDate "2020.??.??"]
+
+1. e4 d6 2. d4 Nf6 3. Nc3 e5 4. Nf3 Nbd7 5. Bc4 Be7 6. dxe5 dxe5 7. Be3 O-O 8.
+h4 Ng4 9. Qe2 Nxe3 10. Qxe3 c6 11. O-O-O Qa5 12. Kb1 Nb6 13. Bb3 Bc5 14. Qe2
+Bg4 15. h5 h6 16. Rh4 Bxf3 17. gxf3 Rad8 18. Rg1 Be7 19. Rhg4 Bg5 20. a3 Rd2
+21. Qf1 Rfd8 22. Qg2 Qc5 23. Rxg5 hxg5 24. Qxg5 Qf8 25. h6 R8d6 26. hxg7 Qd8
+27. Bxf7+ Kxf7 28. g8=Q+ Qxg8 29. Qxg8+ 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Rookdom"]
+[Black "yaguigor"]
+[Result "1/2-1/2"]
+[ECO "D10"]
+[WhiteElo "2432"]
+[BlackElo "2452"]
+[PlyCount "73"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. c4 c6 2. Nc3 d5 3. d4 Nf6 4. e3 e6 5. cxd5 exd5 6. h3 Bf5 7. g4 Bg6 8. Bg2
+Nbd7 9. f3 h5 10. g5 Nh7 11. h4 Bd6 12. Nge2 Nhf8 13. e4 Ne6 14. e5 Bb4 15. f4
+Bf5 16. Ng3 Bg4 17. Qd3 g6 18. a3 Ba5 19. b4 Bb6 20. Be3 Ng7 21. Bh3 Bxh3 22.
+Rxh3 Qe7 23. f5 gxf5 24. Nxf5 Nxf5 25. Qxf5 Qe6 26. Rf3 Nf8 27. Kd2 Qxf5 28.
+Rxf5 Ne6 29. Kd3 Ke7 30. Raf1 Raf8 31. Ne2 a6 32. Nf4 Ng7 33. Rf6 Ne8 34. Rf5
+Ng7 35. Rf6 Ne8 36. Rh6 Ng7 37. Rf6 1/2-1/2
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "nakarian10"]
+[Black "DirtyDiamondta"]
+[Result "1-0"]
+[ECO "A04"]
+[WhiteElo "2361"]
+[BlackElo "2348"]
+[PlyCount "91"]
+[EventDate "2020.??.??"]
+
+1. Nf3 c5 2. g3 g6 3. Bg2 Bg7 4. O-O d6 5. c4 Nc6 6. Nc3 Nf6 7. e3 O-O 8. d4
+cxd4 9. Nxd4 Nxd4 10. exd4 a6 11. b3 Be6 12. d5 Bd7 13. Bb2 Rc8 14. Rc1 b5 15.
+cxb5 axb5 16. Re1 Re8 17. Qd2 Qa5 18. Ne4 Qxd2 19. Nxd2 Ng4 20. Bxg7 Kxg7 21.
+h3 Ne5 22. Red1 Nd3 23. Rxc8 Rxc8 24. Ne4 Nc5 25. Nxc5 Rxc5 26. Rd2 Rc1+ 27.
+Kh2 h5 28. Be4 f5 29. Bd3 Kf6 30. Kg2 Rc3 31. f4 g5 32. fxg5+ Kxg5 33. Kf3 Kf6
+34. Kf4 Be8 35. Bxf5 Bf7 36. Be4 Rc1 37. g4 Rf1+ 38. Kg3 hxg4 39. hxg4 Ke5 40.
+Re2 Rg1+ 41. Bg2+ Kf6 42. Kf2 Ra1 43. g5+ Kg7 44. Rxe7 Rxa2+ 45. Re2 Rb2 46.
+Rxb2 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "JiangoFett"]
+[Black "profaVa"]
+[Result "0-1"]
+[ECO "D08"]
+[WhiteElo "2388"]
+[BlackElo "2376"]
+[PlyCount "138"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 d5 2. c4 e5 3. dxe5 d4 4. Nf3 Nc6 5. a3 Nge7 6. g3 Ng6 7. Bg2 Ngxe5 8.
+Nxe5 Nxe5 9. O-O Be7 10. b3 O-O 11. Bb2 c5 12. e3 Nc6 13. Bxc6 bxc6 14. exd4
+cxd4 15. Qxd4 Qxd4 16. Bxd4 Bf5 17. Nc3 Rfd8 18. Be3 Bf6 19. Rac1 Rd3 20. Ne2
+Rxb3 21. Nd4 Bxd4 22. Bxd4 Rxa3 23. Rfe1 Rd3 24. Bxa7 h5 25. Be3 Ra2 26. h4 Kh7
+27. Red1 Rxd1+ 28. Rxd1 Rc2 29. c5 Be4 30. Kh2 Bd5 31. Kg1 Kg6 32. Kf1 Kf5 33.
+Rd4 Ra2 34. Ke1 Ke6 35. Rf4 f5 36. Rb4 Bf3 37. Rb7 Re2+ 38. Kf1 Rc2 39. Ke1
+Re2+ 40. Kf1 Ra2 41. Ke1 Ra1+ 42. Kd2 Rd1+ 43. Kc3 g6 44. Rg7 Kf6 45. Rc7 Bd5
+46. Bg5+ Ke5 47. Re7+ Be6 48. Bf4+ Kd5 49. Rg7 Kxc5 50. Rxg6 Bd5 51. Rg5 Be4
+52. f3 Rd3+ 53. Kb2 Rxf3 54. Rxh5 Kc4 55. Rh6 Rf2+ 56. Kc1 Kc3 57. Be5+ Kb3 58.
+Kd1 c5 59. h5 c4 60. Bf4 c3 61. Rb6+ Kc4 62. Rb8 Bf3+ 63. Ke1 Re2+ 64. Kf1 Rh2
+65. h6 c2 66. Rc8+ Kd3 67. h7 Rh1+ 68. Kf2 Rh2+ 69. Kxf3 Rf2+ 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "vava05"]
+[Black "Kralj56"]
+[Result "1-0"]
+[ECO "B06"]
+[WhiteElo "2396"]
+[BlackElo "2458"]
+[PlyCount "121"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 g6 2. d4 Bg7 3. c3 d6 4. h4 h5 5. Be2 Nc6 6. Nf3 a6 7. Bg5 Bg4 8. Qb3 Qc8
+9. Nbd2 e6 10. d5 exd5 11. exd5 Nce7 12. O-O-O Nf6 13. Bd3 O-O 14. Bxf6 Bxf6
+15. Ne4 Bg7 16. Neg5 c6 17. dxc6 bxc6 18. Rhe1 Qc7 19. Rxe7 Qxe7 20. Bxg6 d5
+21. Re1 Qd6 22. Bh7+ Kh8 23. Bc2 Rab8 24. Qa4 c5 25. Nh7 Rfd8 26. Nhg5 Rf8 27.
+Nh7 Rfd8 28. Nfg5 Qd7 29. Qf4 f6 30. f3 fxg5 31. Qxg5 Qd6 32. Kb1 Qh6 33. fxg4
+Qxg5 34. Nxg5 Re8 35. Rd1 hxg4 36. Rxd5 Bxc3 37. b3 Bd4 38. Bd1 Re1 39. Kc2 Rf8
+40. Bxg4 Rf2+ 41. Kd3 Rxg2 42. Rd8+ Kg7 43. Bf3 Re3+ 44. Kc4 Rg3 45. Bb7 Rc3+
+46. Kd5 Be3 47. Ne6+ Kf6 48. Re8 a5 49. Kc6 a4 50. bxa4 c4 51. Nc7 Ra3 52. Nd5+
+Kf7 53. Re7+ Kf8 54. Bc8 c3 55. Be6 c2 56. Rf7+ Ke8 57. Nc7+ Kd8 58. Rd7+ Kc8
+59. Rd5+ Kb8 60. Rb5+ Ka7 61. Rb7# 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "hawth0rne"]
+[Black "WildBreath"]
+[Result "1-0"]
+[ECO "E06"]
+[WhiteElo "2441"]
+[BlackElo "2414"]
+[PlyCount "133"]
+[EventDate "2020.??.??"]
+
+1. d4 Nf6 2. Nf3 e6 3. c4 d5 4. g3 Be7 5. Bg2 O-O 6. O-O dxc4 7. Ne5 Nc6 8.
+Nxc6 bxc6 9. Na3 Bxa3 10. bxa3 Rb8 11. Qa4 c3 12. Rd1 Nd5 13. e4 Nb6 14. Qc2
+Ba6 15. Be3 Nc4 16. Qxc3 Nxe3 17. fxe3 Qd6 18. e5 Qe7 19. Bxc6 Rb6 20. Be4 Rfb8
+21. Rdc1 g6 22. Rab1 Rxb1 23. Rxb1 Rxb1+ 24. Bxb1 Qd7 25. Be4 Qb5 26. Bg2 Qe2
+27. h3 Qxa2 28. Qxc7 Qxa3 29. Qb8+ Kg7 30. Qxa7 Qxe3+ 31. Kh2 Bd3 32. Qe7 Qf2
+33. Qf6+ Qxf6 34. exf6+ Kxf6 35. Bf3 Bc4 36. Kg2 Bd5 37. Kf2 Bxf3 38. Kxf3 g5
+39. Kg4 h6 40. Kf3 Kg6 41. Ke4 f5+ 42. Ke5 Kf7 43. d5 exd5 44. Kxf5 Kg7 45. Ke5
+Kg6 46. g4 h5 47. Kxd5 hxg4 48. hxg4 Kf6 49. Kd6 Kf7 50. Ke5 Kg6 51. Ke6 Kg7
+52. Kf5 Kf7 53. Kxg5 Kg7 54. Kf5 Kh7 55. g5 Kg7 56. Kg4 Kf7 57. Kh4 Kg7 58. Kh5
+Kh7 59. Kg4 Kg7 60. Kf4 Kf7 61. Kf5 Kg7 62. g6 Kg8 63. Kf6 Kf8 64. Kg5 Kg8 65.
+Kh5 Kg7 66. Kg5 Kg8 67. Kh6 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Rooko64"]
+[Black "alchemical1969"]
+[Result "1-0"]
+[ECO "B40"]
+[WhiteElo "2365"]
+[BlackElo "2351"]
+[PlyCount "67"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 c5 2. Nf3 e6 3. b3 a6 4. Bb2 Nc6 5. g3 d5 6. e5 Nge7 7. Bg2 Nf5 8. O-O h5
+9. h4 Qd7 10. Nc3 b6 11. Na4 Qc7 12. d4 cxd4 13. c4 dxc4 14. Nxd4 Nfxd4 15.
+Bxd4 Rb8 16. Bb2 b5 17. Nc3 Nxe5 18. Ne4 Nd3 19. Bd4 e5 20. Be3 Be7 21. bxc4
+bxc4 22. Rb1 Rxb1 23. Qxb1 O-O 24. Qc2 f5 25. Ng5 f4 26. Bd5+ Kh8 27. Bxc4 Bxg5
+28. hxg5 Nb4 29. Qg6 Qxc4 30. Qxh5+ Kg8 31. g6 Rf6 32. Qh7+ Kf8 33. Qh8+ Qg8
+34. Bc5+ 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "ROBESPIERR"]
+[Black "Betovsky"]
+[Result "1-0"]
+[ECO "A40"]
+[WhiteElo "2563"]
+[BlackElo "2614"]
+[PlyCount "39"]
+[EventDate "2020.??.??"]
+
+1. d4 e5 2. dxe5 d6 3. exd6 Bxd6 4. g3 Nf6 5. Bg2 Nc6 6. Nf3 Qe7 7. Bg5 Bg4 8.
+Nc3 O-O-O 9. Qc1 Bb4 10. O-O Bxc3 11. bxc3 Qxe2 12. Re1 Qb5 13. Rb1 Qa5 14. Nd4
+Bd7 15. Qb2 Qb6 16. Qa3 Qa5 17. Qb3 b6 18. Bxf6 gxf6 19. Nxc6 Bxc6 20. Bxc6 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Yoseqpuedo"]
+[Black "Molot_ua"]
+[Result "0-1"]
+[ECO "A00"]
+[WhiteElo "2404"]
+[BlackElo "2372"]
+[PlyCount "52"]
+[EventDate "2020.??.??"]
+
+1. e3 c6 2. f4 d6 3. Nf3 Nd7 4. Be2 h6 5. O-O g5 6. d3 Bg7 7. e4 gxf4 8. Bxf4
+Bxb2 9. Nbd2 Bxa1 10. Qxa1 Ngf6 11. Kh1 h5 12. e5 dxe5 13. Nxe5 Rg8 14. Ne4
+Nxe4 15. dxe4 Nxe5 16. Bxe5 Be6 17. Bxh5 Qa5 18. Bf3 O-O-O 19. Qb2 Bg4 20. Bg3
+Bxf3 21. gxf3 Qh5 22. Qa3 Rxg3 23. Qxe7 Rxf3 24. Rg1 Rf2 25. Rg3 Rd1+ 26. Rg1
+Qf3# 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "rebelzky"]
+[Black "CarlosMontenegro"]
+[Result "0-1"]
+[ECO "A41"]
+[WhiteElo "2361"]
+[BlackElo "2401"]
+[PlyCount "68"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 g6 2. c4 Bg7 3. e4 d6 4. Nc3 c6 5. Nf3 Bg4 6. Be2 Qb6 7. Na4 Qa5+ 8. Bd2
+Qc7 9. Be3 Nf6 10. Nc3 e5 11. O-O O-O 12. d5 cxd5 13. cxd5 a6 14. a4 Nbd7 15.
+Nd2 Bxe2 16. Qxe2 Rfc8 17. Rfc1 Qd8 18. h3 Nh5 19. Nc4 Nc5 20. Bxc5 Rxc5 21. b4
+Rc7 22. Na5 Rac8 23. Na2 Nf4 24. Qf3 Rxc1+ 25. Rxc1 Rxc1+ 26. Nxc1 Qb6 27. Qc3
+Bh6 28. Kf1 Kg7 29. h4 Nh5 30. Nd3 Qd8 31. g3 Qd7 32. Ne1 Qxa4 33. Nxb7 Qb5+
+34. Kg2 Qxb7 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "estocastico"]
+[Black "hungzhao"]
+[Result "0-1"]
+[ECO "B50"]
+[WhiteElo "2574"]
+[BlackElo "2634"]
+[PlyCount "56"]
+[EventDate "2020.??.??"]
+
+1. e4 c5 2. Nf3 d6 3. Nc3 Nf6 4. e5 dxe5 5. Nxe5 Nbd7 6. Bb5 e6 7. b3 Be7 8.
+Bb2 O-O 9. Bxd7 Nxd7 10. Qe2 Nxe5 11. Qxe5 b6 12. Nd5 f6 13. Nxe7+ Qxe7 14. Qg3
+e5 15. d3 e4 16. O-O-O exd3 17. Rhe1 Qf7 18. Rxd3 Bf5 19. Rde3 Rfe8 20. Qf3 Bg6
+21. g4 Rad8 22. h4 Rxe3 23. Qxe3 h5 24. g5 fxg5 25. Qxg5 Re8 26. Rg1 Re6 27. a4
+Qxf2 28. Qg2 Re1+ 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "RaylessStarfish"]
+[Black "redbullet64"]
+[Result "1-0"]
+[ECO "E67"]
+[WhiteElo "2387"]
+[BlackElo "2410"]
+[PlyCount "51"]
+[EventDate "2020.??.??"]
+
+1. c4 Nf6 2. g3 g6 3. Bg2 Bg7 4. Nf3 d6 5. O-O O-O 6. d4 Nbd7 7. Nc3 e5 8. e3
+Re8 9. b3 c6 10. Bb2 Qc7 11. Rc1 Qb8 12. Qc2 a6 13. Rfd1 b5 14. cxb5 axb5 15.
+dxe5 dxe5 16. Nd2 Bb7 17. Qb1 Qa7 18. Nce4 Nxe4 19. Nxe4 Nb6 20. Nd6 Re7 21.
+Nxb7 Qxb7 22. Bxc6 Qa7 23. Bxa8 Qxa8 24. Rd6 Nc8 25. Rd8+ Bf8 26. Rcxc8 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "taras05"]
+[Black "awisepawn"]
+[Result "0-1"]
+[ECO "B40"]
+[WhiteElo "2498"]
+[BlackElo "2391"]
+[PlyCount "66"]
+[EventDate "2020.??.??"]
+
+1. e4 c5 2. Nf3 e6 3. c4 Nc6 4. d4 cxd4 5. Nxd4 Nf6 6. Nxc6 bxc6 7. Bd3 d5 8.
+exd5 cxd5 9. O-O Be7 10. Qe2 O-O 11. Nc3 Bb7 12. Rd1 Qc7 13. cxd5 Nxd5 14. Ne4
+Nf6 15. Nxf6+ Bxf6 16. Be3 Rac8 17. Rac1 Qa5 18. Rxc8 Rxc8 19. b3 h6 20. f3 Be7
+21. Bf2 Bc5 22. Be4 Bxf2+ 23. Kxf2 Qb6+ 24. Kg3 Qc7+ 25. Kh3 Bxe4 26. Qxe4 Qc2
+27. Qxc2 Rxc2 28. a4 Rb2 29. Rd3 Kh7 30. g3 Kg6 31. Kg4 f5+ 32. Kf4 Kf6 33. Re3
+g5# 0-1
+
+[Event "Rated Blitz tournament hM7PUvgg"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "balachess2006"]
+[Black "juancruzariasTDF"]
+[Result "0-1"]
+[ECO "A06"]
+[WhiteElo "2422"]
+[BlackElo "2408"]
+[PlyCount "124"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. Nf3 d5 2. d3 Nc6 3. Nbd2 Bg4 4. g3 e5 5. Bg2 f5 6. h3 Bh5 7. g4 fxg4 8. hxg4
+Bxg4 9. e4 Nf6 10. exd5 Nxd5 11. Ne4 Bb4+ 12. c3 Be7 13. Rg1 O-O 14. Bh1 Bh5
+15. Bh6 Rf7 16. Bxg7 Rxg7 17. Rxg7+ Kxg7 18. Qd2 Nf4 19. O-O-O a5 20. Rg1+ Kh8
+21. d4 a4 22. Nxe5 Nxe5 23. dxe5 Qxd2+ 24. Kxd2 Rd8+ 25. Ke3 Nd5+ 26. Kd4 Nf6+
+27. Ke3 Nxe4 28. Bxe4 Bc5+ 29. Kf4 Rf8+ 30. Kg5 Bf3 31. Bxf3 Rxf3 32. e6 Be7+
+33. Kg4 Rf6 34. Re1 Kg7 35. f4 Kf8 36. f5 Rh6 37. Re2 Rh4+ 38. Kg3 Rc4 39. Kf3
+a3 40. b3 Rxc3+ 41. Ke4 Rc5 42. Rh2 Kg7 43. Rg2+ Kf6 44. Rh2 Re5+ 45. Kd4 Rxf5
+46. Rxh7 Kxe6 47. Rh6+ Rf6 48. Rh2 Bd6 49. Re2+ Kd7 50. Kc4 Rf4+ 51. Kd3 b5 52.
+Kc3 b4+ 53. Kd3 Rf3+ 54. Kc4 Rc3+ 55. Kb5 Rc5+ 56. Kxb4 Rc2+ 57. Ka4 Rxe2 58.
+b4 Rxa2 59. b5 Rb2 60. Ka5 a2 61. Ka6 a1=Q+ 62. Kb7 Rxb5# 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "alireza3700"]
+[Black "Aisen_Mestnikov"]
+[Result "0-1"]
+[ECO "B06"]
+[WhiteElo "2337"]
+[BlackElo "2393"]
+[PlyCount "50"]
+[EventDate "2020.??.??"]
+
+1. d4 d6 2. Nc3 g6 3. e4 Bg7 4. Be3 Nf6 5. f3 c6 6. Qd2 O-O 7. O-O-O b5 8. Bh6
+b4 9. Nce2 a5 10. h4 Ba6 11. h5 Nbd7 12. hxg6 fxg6 13. Bxg7 Kxg7 14. Qh6+ Kg8
+15. e5 Nh5 16. g4 dxe5 17. gxh5 Qe8 18. hxg6 Qxg6 19. Qxg6+ hxg6 20. d5 cxd5
+21. Rxd5 Nf6 22. Rxe5 Rad8 23. Rxe7 Nd5 24. Ra7 Ne3 25. Rxa6 Rd1# 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "drop_stone"]
+[Black "C9C9C9C9C9"]
+[Result "1-0"]
+[ECO "C45"]
+[WhiteElo "2895"]
+[BlackElo "3014"]
+[PlyCount "75"]
+[EventDate "2020.??.??"]
+
+1. e4 Nc6 2. Nf3 e5 3. d4 exd4 4. Nxd4 Bc5 5. Nb3 Bb6 6. Nc3 Nf6 7. Qe2 d6 8.
+Bg5 h6 9. Bh4 g5 10. Bg3 Qe7 11. O-O-O Bg4 12. f3 Bh5 13. Qb5 a6 14. Qa4 O-O
+15. h4 Bg6 16. hxg5 hxg5 17. Bd3 Kg7 18. f4 Be3+ 19. Kb1 gxf4 20. Bh4 Qe5 21.
+Nd2 Nd4 22. Nc4 b5 23. Nxe5 bxa4 24. Bxf6+ Kxf6 25. Nd7+ Ke7 26. Nxf8 Rxf8 27.
+Nd5+ Kd7 28. Bxa6 c5 29. Rhe1 Bxe4 30. Nf6+ Ke6 31. Nxe4 Rg8 32. g3 f5 33. gxf4
+fxe4 34. Rxe3 d5 35. c4 Rf8 36. cxd5+ Kxd5 37. Bb7+ Kd6 38. Rxe4 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "jesus_guillen02"]
+[Black "BerserkAdopter"]
+[Result "1/2-1/2"]
+[ECO "B01"]
+[WhiteElo "2372"]
+[BlackElo "2454"]
+[PlyCount "103"]
+[EventDate "2020.??.??"]
+
+1. e4 d5 2. exd5 Qxd5 3. c4 Qd8 4. d4 Bf5 5. Nf3 e6 6. Nc3 c6 7. Bf4 Nf6 8. Bd3
+Bxd3 9. Qxd3 Bd6 10. Ne5 Qc7 11. c5 Bxe5 12. Bxe5 Qe7 13. Qg3 Na6 14. Qxg7 Rg8
+15. Qxf6 Qxf6 16. Bxf6 Rxg2 17. Be5 Rg4 18. O-O-O O-O-O 19. a3 Nc7 20. Bxc7
+Kxc7 21. Ne2 b6 22. Rhg1 Re4 23. cxb6+ axb6 24. Nc3 Rexd4 25. Rxd4 Rxd4 26. Rg7
+Rh4 27. Rxf7+ Kd6 28. Rf3 Rxh2 29. Kd2 h5 30. Ke3 Ke5 31. Ne4 Rh1 32. Nd2 Re1+
+33. Kd3 c5 34. Rh3 Rd1 35. Rxh5+ Kd6 36. Kc2 Ra1 37. Nc4+ Kc6 38. Ne5+ Kb5 39.
+Nd3 Rf1 40. b3 Kc6 41. b4 c4 42. Ne5+ Kd5 43. Nf3+ Ke4 44. Nd2+ Kd4 45. Nxf1 e5
+46. Rh4+ e4 47. f3 Kd5 48. Rxe4 Kc6 49. Rxc4+ Kb5 50. Rc3 Ka4 51. Rd3 b5 52. f4
+1/2-1/2
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "elRope"]
+[Black "hanysayed"]
+[Result "0-1"]
+[ECO "A15"]
+[WhiteElo "2367"]
+[BlackElo "2302"]
+[PlyCount "102"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. c4 Nf6 2. g3 g6 3. Bg2 Bg7 4. Nf3 O-O 5. O-O d6 6. Nc3 c6 7. d3 Nbd7 8. Rb1
+e5 9. e3 Re8 10. d4 e4 11. Nd2 d5 12. b4 Nf8 13. b5 Bg4 14. Qa4 Qc8 15. Ba3 Bh3
+16. Rfc1 Bxg2 17. Kxg2 Qd7 18. Nb3 dxc4 19. bxc6 bxc6 20. Nc5 Qg4 21. Qd1 Qf5
+22. Qe2 h5 23. h3 g5 24. Rb7 g4 25. h4 Qf3+ 26. Kg1 Nd5 27. Qxf3 exf3 28. N3a4
+Nxe3 29. fxe3 Rxe3 30. Bb2 Re2 31. Bc3 Rg2+ 32. Kh1 Rxg3 33. Nb2 Rh3+ 34. Kg1
+Ng6 35. Nxc4 g3 36. Ne5 Bxe5 37. dxe5 Nxh4 38. Rcb1 f2+ 39. Kf1 g2+ 40. Kxf2
+Rxc3 41. Ne4 Rf3+ 42. Kg1 Rh3 43. Ng5 Rh1+ 44. Kf2 Rxb1 45. Rxb1 Rd8 46. Kg3
+Rd4 47. e6 Rg4+ 48. Kf2 Rxg5 49. Rb8+ Kh7 50. e7 g1=Q+ 51. Ke2 Re5+ 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "mixo23"]
+[Black "Marohzevich"]
+[Result "1-0"]
+[ECO "A40"]
+[WhiteElo "2415"]
+[BlackElo "2488"]
+[PlyCount "83"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 e6 2. Nf3 d5 3. c4 a6 4. cxd5 exd5 5. Nc3 Nf6 6. Bg5 Be7 7. e3 O-O 8. Bd3
+Be6 9. O-O Nbd7 10. Qc2 h6 11. Bh4 c5 12. dxc5 Nxc5 13. Rad1 Rc8 14. Nd4 Nfe4
+15. Bxe7 Qxe7 16. Bxe4 Nxe4 17. Qb3 Nxc3 18. bxc3 b5 19. a4 bxa4 20. Qxa4 Rxc3
+21. Qxa6 Rfc8 22. Rb1 h5 23. Rb7 Qf6 24. Ra7 h4 25. Ra8 Rxa8 26. Qxa8+ Kh7 27.
+Qa1 Rc8 28. Nf3 Qxa1 29. Rxa1 h3 30. gxh3 Kg6 31. Kg2 Rh8 32. h4 Bf5 33. Kg3 f6
+34. Ra5 Be4 35. Nd4 Rd8 36. f3 Bd3 37. Ne6 Re8 38. Nf4+ Kh6 39. Nxd3 Rxe3 40.
+Rxd5 Re2 41. Nf4 Ra2 42. Rh5# 1-0
+
+[Event "Rated Blitz tournament OxRShNHO"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "AttackSparrow"]
+[Black "Alfilparanoico"]
+[Result "0-1"]
+[ECO "B14"]
+[WhiteElo "2462"]
+[BlackElo "2469"]
+[PlyCount "144"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 c6 2. d4 d5 3. exd5 cxd5 4. c4 Nf6 5. Nc3 g6 6. cxd5 Nxd5 7. Qb3 Nb6 8.
+Bb5+ Bd7 9. Nf3 Bg7 10. a4 O-O 11. Bxd7 N8xd7 12. a5 Nc8 13. Qxb7 Rb8 14. Qa6
+Nd6 15. O-O Qc8 16. Qxc8 Rfxc8 17. Nd5 Kf8 18. a6 Rb5 19. Nc3 Rb4 20. Re1 Nb6
+21. h3 Ndc4 22. Re2 e6 23. Ne4 Nd5 24. Nc5 Ke8 25. Nb7 Kd7 26. Nc5+ Kc6 27. Nd3
+Rb3 28. Nde5+ Nxe5 29. Nxe5+ Bxe5 30. dxe5 Kb6 31. Bg5 Rb5 32. Bd2 Rc6 33. Be1
+Kc7 34. Ra4 Kd7 35. Rh4 h5 36. Ra4 Rbb6 37. g4 hxg4 38. hxg4 Rxa6 39. Rxa6 Rxa6
+40. Re4 Ra1 41. Kg2 Rb1 42. Re2 Kc6 43. Kf3 a5 44. Bxa5 Ra1 45. Rc2+ Kd7 46.
+Bc3 Ra4 47. Kg3 Rc4 48. Rd2 Kc6 49. Bd4 Kb5 50. Be3 Re4 51. Rd4 Rxe5 52. Rd3
+Nxe3 53. fxe3 Re4 54. Kf3 Rb4 55. b3 Kc6 56. Rc3+ Kd5 57. Kg3 Ke5 58. Kf3 f5
+59. Rc5+ Kf6 60. gxf5 gxf5 61. Rc3 Ke5 62. Rd3 Rb7 63. Rc3 Rb8 64. Rc5+ Kf6 65.
+Rc3 Rh8 66. e4 Rh3+ 67. Kf4 Rxc3 68. e5+ Ke7 69. b4 Rb3 70. Kg5 Rxb4 71. Kg6
+Rg4+ 72. Kh5 Kf7 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "sutcunuri"]
+[Black "ajedrez2021"]
+[Result "0-1"]
+[ECO "B35"]
+[WhiteElo "2512"]
+[BlackElo "2601"]
+[PlyCount "50"]
+[EventDate "2020.??.??"]
+
+1. e4 g6 2. Nf3 Bg7 3. d4 c5 4. Nc3 cxd4 5. Nxd4 Nc6 6. Be3 Nf6 7. Bc4 O-O 8.
+Bb3 a5 9. a3 d6 10. f3 a4 11. Ba2 Qa5 12. Qd2 Bd7 13. h4 Rfc8 14. O-O-O Ne5 15.
+Bh6 Bxh6 16. Qxh6 Rxc3 17. bxc3 Qxc3 18. Kb1 Qxa3 19. h5 Qb4+ 20. Kc1 Qa3+ 21.
+Kb1 Ra6 22. hxg6 Rb6+ 23. Bb3 Nxg6 24. Nf5 Bxf5 25. exf5 axb3 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "iCe_eNerGyTeaM"]
+[Black "Cazulo97"]
+[Result "1-0"]
+[ECO "B08"]
+[WhiteElo "2541"]
+[BlackElo "2382"]
+[PlyCount "83"]
+[EventDate "2020.??.??"]
+
+1. d4 Nf6 2. Nf3 g6 3. Nc3 Bg7 4. e4 d6 5. Be2 O-O 6. O-O c5 7. d5 a6 8. a4 e5
+9. Nd2 Ne8 10. Nc4 f5 11. f4 Nd7 12. exf5 gxf5 13. fxe5 Nxe5 14. Bf4 Nxc4 15.
+Bxc4 Nf6 16. Qd3 Rf7 17. Rae1 Ne4 18. Nxe4 fxe4 19. Qxe4 Bf5 20. Qf3 Bxc2 21.
+Qg3 b5 22. axb5 axb5 23. Bxb5 Rb8 24. Re8+ Qxe8 25. Bxe8 Rxe8 26. Bh6 Rxf1+ 27.
+Kxf1 Bg6 28. Bxg7 Kxg7 29. Qxd6 Rf8+ 30. Ke1 c4 31. Qe5+ Kg8 32. Kd2 Rf2+ 33.
+Kc3 Rc2+ 34. Kb4 Kf7 35. d6 Rd2 36. Qf4+ Ke6 37. Qxd2 Kd7 38. Kc5 Bf5 39. Qe3
+Be6 40. Qh6 Bf5 41. Qg7+ Ke6 42. Qe7# 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Rusticous"]
+[Black "Lopez09"]
+[Result "0-1"]
+[ECO "A41"]
+[WhiteElo "2346"]
+[BlackElo "2385"]
+[PlyCount "80"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. c4 g6 2. Nc3 Bg7 3. d4 d6 4. Nf3 Bg4 5. Qb3 Bxf3 6. exf3 b6 7. Be3 Nf6 8.
+Be2 O-O 9. O-O c5 10. Rfe1 Nc6 11. d5 Na5 12. Qc2 a6 13. Bg5 Qc7 14. Bd3 Rfe8
+15. Re3 Rab8 16. Rae1 Qd7 17. Qe2 Kf8 18. Ne4 Nxe4 19. Rxe4 Bf6 20. Bxf6 exf6
+21. b3 f5 22. Re3 Rxe3 23. fxe3 b5 24. Qb2 Kg8 25. cxb5 axb5 26. Qf6 c4 27. Bc2
+Re8 28. b4 Nb7 29. h4 Qe7 30. Qd4 Qe5 31. Qb6 Qc3 32. Re2 Nd8 33. Qxb5 Kf8 34.
+a4 Rxe3 35. Rxe3 Qxe3+ 36. Kh2 Qf4+ 37. Kh3 f6 38. Qd7 Nf7 39. a5 g5 40. Qxf5
+Qxh4# 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Tigerscot"]
+[Black "WhoozitWarriors"]
+[Result "1-0"]
+[ECO "A45"]
+[WhiteElo "2459"]
+[BlackElo "2604"]
+[PlyCount "137"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 Nf6 2. Nc3 e6 3. Bf4 a6 4. e3 b5 5. Nf3 b4 6. Ne2 Bb7 7. Ng3 c5 8. dxc5
+Bxc5 9. Bd6 Bxd6 10. Qxd6 Qe7 11. Qxe7+ Kxe7 12. a3 Nc6 13. Nd4 Nxd4 14. exd4
+a5 15. Kd2 h5 16. f3 h4 17. Ne2 h3 18. Nf4 g5 19. Nxh3 Nd5 20. Nxg5 Rag8 21.
+Ne4 Nf4 22. g3 f5 23. gxf4 fxe4 24. axb4 exf3 25. Bd3 axb4 26. Ra7 Bc6 27. Ke3
+Rg2 28. Rf1 Rhxh2 29. Rxf3 Bxf3 30. Kxf3 Rd2 31. Ke3 Rxc2 32. Bxc2 Rxc2 33. d5
+exd5 34. Kd4 Rxb2 35. Kxd5 Rf2 36. Ke4 b3 37. Rb7 b2 38. Ke3 Rh2 39. Rb6 d6 40.
+f5 Rg2 41. Kf3 Rc2 42. Kf4 Rf2+ 43. Ke4 Kd7 44. Rb7+ Kc6 45. Rb3 Kc5 46. Ke3
+Kc4 47. Rb6 Rh2 48. Rc6+ Kd5 49. Rb6 Ke5 50. Kf3 Kxf5 51. Kg3 Rc2 52. Kf3 Ke5
+53. Ke3 d5 54. Kd3 Rh2 55. Kc3 d4+ 56. Kd3 Rh3+ 57. Kd2 Ke4 58. Re6+ Kd5 59.
+Rb6 Kc4 60. Rc6+ Kb3 61. Ra6 Rh2+ 62. Kd3 Rh3+ 63. Kxd4 Rh2 64. Rb6+ Kc2 65.
+Rc6+ Kb1 66. Rc5 Rh3 67. Rb5 Rh4+ 68. Kd5 Rh5+ 69. Kd6 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Donald666Trump"]
+[Black "Frogkiller"]
+[Result "0-1"]
+[ECO "B90"]
+[WhiteElo "2384"]
+[BlackElo "2378"]
+[PlyCount "86"]
+[EventDate "2020.??.??"]
+
+1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Be3 e5 7. Nb3 Nbd7 8. f4
+b5 9. f5 Bb7 10. Qf3 Rc8 11. O-O-O Qc7 12. Bd3 Nb6 13. g4 b4 14. Bxb6 Qxb6 15.
+Nd5 Nxd5 16. exd5 a5 17. Kb1 a4 18. Nd2 a3 19. b3 Ba6 20. Bxa6 Qxa6 21. Qd3 Qb6
+22. Nc4 Qc5 23. c3 bxc3 24. Qxc3 Be7 25. Qa5 Qxa5 26. Nxa5 h5 27. h3 Bg5 28.
+Nc6 Be3 29. Kc2 Kd7 30. Kd3 Bc5 31. Rc1 Ra8 32. Nxe5+ dxe5 33. Rxc5 hxg4 34. h4
+Rh5 35. Ke4 f6 36. Rhc1 Ra7 37. d6 Kxd6 38. Rc6+ Kd7 39. Kd5 Rxf5 40. h5 Rxh5
+41. Rb6 Rh2 42. Rcc6 Rd2+ 43. Ke4 Rxa2 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "BlueGreensun"]
+[Black "Kidefence"]
+[Result "1-0"]
+[ECO "B02"]
+[WhiteElo "2751"]
+[BlackElo "2716"]
+[PlyCount "127"]
+[EventDate "2020.??.??"]
+
+1. e4 Nf6 2. e5 Nd5 3. Nc3 Nxc3 4. dxc3 d6 5. Nf3 Nc6 6. Bf4 g6 7. Bb5 Bg7 8.
+Nd4 Bd7 9. Qf3 Nxe5 10. Bxd7+ Nxd7 11. Qxb7 Qb8 12. Qe4 O-O 13. Nc6 Qxb2 14.
+O-O e6 15. Rab1 Qxc3 16. Rb7 d5 17. Ne7+ Kh8 18. Qe2 Qc5 19. Bg5 Rab8 20. Rxb8
+Rxb8 21. Qa6 h6 22. Bh4 g5 23. Qa4 Nb6 24. Qxa7 Ra8 25. Qb7 Qxe7 26. Bg3 Rxa2
+27. Bxc7 Nc4 28. Qb8+ Kh7 29. c3 Rb2 30. Qc8 Qf6 31. Bg3 Nd2 32. Rd1 Ne4 33.
+Rf1 Nxg3 34. hxg3 Qxc3 35. Qd7 Qf6 36. Qc7 Rd2 37. Qc1 Rd4 38. Qb1+ Re4 39. f3
+Qd4+ 40. Kh1 f5 41. fxe4 dxe4 42. Qb3 Qf6 43. Qc4 Kg6 44. Qe2 h5 45. Kg1 Qe5
+46. Rd1 Bf6 47. Qf1 f4 48. Kh1 e3 49. Qe2 fxg3 50. Qd3+ Qf5 51. Qe2 h4 52. Rf1
+h3 53. Rxf5 hxg2+ 54. Kxg2 exf5 55. Qf3 f4 56. Qe2 Kf5 57. Qd3+ Ke6 58. Qc4+
+Ke7 59. Qb5 Kf8 60. Qb4+ Kg7 61. Qc4 Kg6 62. Qc7 g4 63. Qc6 f3+ 64. Kxg3 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Odirovski"]
+[Black "tigra522"]
+[Result "1-0"]
+[ECO "A48"]
+[WhiteElo "2459"]
+[BlackElo "2377"]
+[PlyCount "77"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. Nf3 Nf6 2. d4 g6 3. Bf4 Bg7 4. e3 O-O 5. h3 d6 6. Bc4 Nbd7 7. O-O Qe8 8. Bh2
+e5 9. c3 Qe7 10. a4 c6 11. Qb3 h6 12. Rd1 Kh7 13. Qa3 Re8 14. a5 Ne4 15. Nfd2
+Nxd2 16. Nxd2 f5 17. Bf1 d5 18. Nf3 Qxa3 19. Rxa3 e4 20. Nd2 c5 21. Bb5 c4 22.
+b3 cxb3 23. Rxb3 a6 24. Ba4 Re7 25. c4 Nf6 26. Rdb1 dxc4 27. Nxc4 Be6 28. Nb6
+Rd8 29. Rc3 Nd5 30. Nxd5 Bxd5 31. Rb6 g5 32. Bd6 Re6 33. Bc7 Rc8 34. Rc5 Rxb6
+35. axb6 Be6 36. d5 Bf8 37. Ra5 Bb4 38. dxe6 Bxa5 39. e7 1-0
+
+[Event "Rated Blitz tournament 32Y8CIiO"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Patonotucupi"]
+[Black "Darop"]
+[Result "1-0"]
+[ECO "B22"]
+[WhiteElo "2417"]
+[BlackElo "2341"]
+[PlyCount "115"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 c5 2. c3 Nc6 3. d4 cxd4 4. cxd4 d5 5. exd5 Qxd5 6. Nf3 Bg4 7. Nc3 Qd8 8.
+d5 Nb8 9. Bb5+ Nd7 10. h3 Bxf3 11. Qxf3 Ngf6 12. O-O a6 13. Ba4 b5 14. Bc2 g6
+15. Re1 Bg7 16. d6 e6 17. Bg5 O-O 18. Qf4 Rc8 19. Rac1 Rc4 20. Qe3 Qb6 21. Qxb6
+Nxb6 22. Bb3 Rd4 23. Be3 Rxd6 24. Bc5 Rfd8 25. Bxd6 Rxd6 26. Rcd1 Ne8 27. Ne4
+Rxd1 28. Rxd1 Kf8 29. Rd8 Ke7 30. Rb8 Nd7 31. Ra8 Nc7 32. Ra7 Kd8 33. a4 Bd4
+34. Rb7 Bxb2 35. axb5 axb5 36. Nd6 Nc5 37. Rb8+ Kd7 38. Nxb5 Nxb3 39. Nxc7 Kxc7
+40. Rxb3 Bd4 41. Rd3 e5 42. Kf1 f5 43. Rb3 Kd6 44. Ke2 g5 45. Rb7 h5 46. Rg7 g4
+47. Rg5 gxh3 48. gxh3 Ke6 49. Rxh5 Kf6 50. Rh8 Kg5 51. Ra8 f4 52. Kf3 Kh4 53.
+Rh8+ Kg5 54. h4+ Kf5 55. Rf8+ Kg6 56. Ke4 Bxf2 57. Kxe5 Bg3 58. Ke4 1-0
+
+[Event "Rated Blitz tournament 32Y8CIiO"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "bagoysuragoy"]
+[Black "Mjolnir1980"]
+[Result "1-0"]
+[ECO "A04"]
+[WhiteElo "2317"]
+[BlackElo "2322"]
+[PlyCount "97"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. Nf3 b6 2. g3 Bb7 3. Bg2 e6 4. O-O f5 5. c4 Nf6 6. Nc3 Bb4 7. Nb5 a6 8. Nbd4
+O-O 9. a3 Bc5 10. b4 Bxd4 11. Nxd4 Bxg2 12. Kxg2 c5 13. Nb3 cxb4 14. axb4 Nc6
+15. Ba3 b5 16. d3 d6 17. Qd2 Qd7 18. Rfc1 Qb7 19. Kg1 Ne5 20. Na5 Qb6 21. Bb2
+Neg4 22. c5 Qd8 23. Nb7 Qc7 24. Nxd6 Qc6 25. f3 Nh6 26. Qe3 Qd7 27. Ra5 Nd5 28.
+Qd4 f4 29. c6 Qe7 30. Ne4 Nf5 31. Qe5 Nxb4 32. gxf4 Nd5 33. Kh1 Qh4 34. Rg1 Qe7
+35. Ba3 Qh4 36. Bxf8 Rxf8 37. Rxa6 Nxf4 38. Ra7 g6 39. Ng3 Nxg3+ 40. Rxg3 Qh6
+41. e3 Nh5 42. Qxe6+ Kh8 43. Qe5+ Nf6 44. Ra8 Qg7 45. Rxf8+ Qxf8 46. c7 Kg7 47.
+Qe6 Qc5 48. c8=Q Qc1+ 49. Qxc1 1-0
+
+[Event "Rated Bullet tournament H3UwNQec"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "RhenzRheann_Auza98"]
+[Black "Zuritadas"]
+[Result "1-0"]
+[ECO "A07"]
+[WhiteElo "2379"]
+[BlackElo "2388"]
+[PlyCount "41"]
+[EventDate "2020.??.??"]
+
+1. Nf3 d5 2. g3 Nd7 3. Bg2 e5 4. O-O Ngf6 5. d3 Bc5 6. c4 e4 7. dxe4 dxe4 8.
+Nd4 O-O 9. Nc3 Re8 10. Nb3 Bf8 11. Bg5 h6 12. Bxf6 Nxf6 13. Qxd8 Rxd8 14. Nxe4
+Nxe4 15. Bxe4 c6 16. Rfd1 Be6 17. Rxd8 Rxd8 18. Bd3 b5 19. cxb5 cxb5 20. Bxb5
+Rd2 21. Nxd2 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "redbullet64"]
+[Black "metalkingGT"]
+[Result "0-1"]
+[ECO "C01"]
+[WhiteElo "2404"]
+[BlackElo "2464"]
+[PlyCount "68"]
+[EventDate "2020.??.??"]
+
+1. e4 e6 2. d4 d5 3. exd5 exd5 4. Nf3 Nf6 5. c4 Bd6 6. c5 Be7 7. Bd3 O-O 8. O-O
+Bg4 9. Re1 h6 10. h3 Bh5 11. g4 Bg6 12. Bxg6 fxg6 13. Qd3 Ne4 14. Ne5 Nd7 15.
+Nxg6 Nxf2 16. Qc2 Nxh3+ 17. Kh1 Bh4 18. Nxf8 Bxe1 19. Ng6 Nf6 20. Qe2 Bg3 21.
+Nc3 Qe8 22. Qg2 Qxg6 23. Qxg3 Nxg4 24. Be3 Qh5 25. Kg2 Nxe3+ 26. Qxe3 Qg4+ 27.
+Qg3 Nf4+ 28. Kh2 Qh5+ 29. Kg1 Rf8 30. Rf1 g5 31. Qf3 Qh4 32. Qf2 Nh3+ 33. Kg2
+Nxf2 34. Rxf2 Qxf2+ 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Training88"]
+[Black "RaylessStarfish"]
+[Result "0-1"]
+[ECO "A00"]
+[WhiteElo "2320"]
+[BlackElo "2393"]
+[PlyCount "82"]
+[EventDate "2020.??.??"]
+
+1. b4 e6 2. Bb2 Nf6 3. b5 c5 4. a4 d5 5. e3 Bd6 6. Nf3 Nbd7 7. c4 b6 8. cxd5
+Nxd5 9. Be2 Bb7 10. O-O Rc8 11. Bxg7 Rg8 12. Bb2 Bb8 13. Nc3 Qc7 14. a5 Nxc3
+15. Bxc3 Bxf3 16. g3 Bxe2 17. Qxe2 Ne5 18. axb6 axb6 19. f4 Ng4 20. Ra6 Qd7 21.
+Rfa1 h5 22. Rxb6 h4 23. Ra8 Bc7 24. Ra7 hxg3 25. hxg3 Nh6 26. Kg2 Nf5 27. g4
+Qd5+ 28. Qf3 Qxf3+ 29. Kxf3 Bxb6 30. Ra6 Nh4+ 31. Kg3 Nf5+ 32. Kf3 Nxe3 33.
+Rxb6 Nd5 34. Rb7 Nxc3 35. dxc3 f6 36. c4 Rf8 37. f5 Rf7 38. Rb6 e5 39. Re6+ Kf8
+40. Ke4 Rd8 41. Rd6 Rxd6 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "AbdAlQadir"]
+[Black "shinji_no_baka"]
+[Result "1-0"]
+[ECO "A43"]
+[WhiteElo "2328"]
+[BlackElo "2357"]
+[PlyCount "61"]
+[EventDate "2020.??.??"]
+
+1. e4 e6 2. d4 c5 3. d5 Nf6 4. Nc3 exd5 5. exd5 d6 6. Nf3 Be7 7. Bb5+ Bd7 8.
+O-O O-O 9. Bxd7 Nbxd7 10. a4 Re8 11. Qd3 Nf8 12. Bf4 Ng6 13. Bg3 Nh5 14. Rfe1
+Qd7 15. Qb5 a6 16. Qxd7 Rad8 17. Qxb7 Nxg3 18. hxg3 Kf8 19. Qxa6 h6 20. Nb5 Ra8
+21. Qb7 Reb8 22. Qd7 Rd8 23. Qf5 Bf6 24. c3 Ne7 25. Qf4 Nxd5 26. Qd2 Nb6 27. a5
+Nc4 28. Qe2 Nxa5 29. Nc7 Ra7 30. Qe8+ Rxe8 31. Rxe8# 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Aisen_Mestnikov"]
+[Black "alireza3700"]
+[Result "1-0"]
+[ECO "C02"]
+[WhiteElo "2398"]
+[BlackElo "2333"]
+[PlyCount "101"]
+[EventDate "2020.??.??"]
+
+1. e4 e6 2. d4 d5 3. e5 c5 4. c3 Bd7 5. Nf3 cxd4 6. cxd4 Qb6 7. Nc3 Bb4 8. Bd3
+Bb5 9. O-O Bxd3 10. Qxd3 Ne7 11. Be3 Nec6 12. a3 Bxc3 13. bxc3 Nd7 14. c4 dxc4
+15. Qxc4 O-O 16. Rfb1 Qa6 17. Qxa6 bxa6 18. Nd2 Nb6 19. Ne4 Rfd8 20. Nd6 f6 21.
+f4 fxe5 22. dxe5 Nd5 23. Kf2 Nxe3 24. Kxe3 g5 25. g3 Na5 26. Ra2 Rab8 27. Rab2
+Rxb2 28. Rxb2 Kg7 29. Rb4 Nc6 30. Rb7+ Kg6 31. h4 gxh4 32. gxh4 Rg8 33. h5+
+Kxh5 34. Rxh7+ Kg6 35. Rc7 Na5 36. Nf7 Rb8 37. Ng5 Rb3+ 38. Ke4 Rxa3 39. Nxe6
+Ra4+ 40. Kd5 Nc4 41. f5+ Kh5 42. Rh7+ Kg4 43. Nc5 Kf3 44. Nxa4 Ne3+ 45. Ke6 Ng4
+46. f6 Ne3 47. Rg7 Nc4 48. f7 Nd6 49. f8=Q+ Nf7 50. Qd6 Ke4 51. Kxf7 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Chesscoach46"]
+[Black "Akylbekov_Nasir"]
+[Result "1/2-1/2"]
+[ECO "C44"]
+[WhiteElo "2322"]
+[BlackElo "2325"]
+[PlyCount "129"]
+[EventDate "2020.??.??"]
+
+1. e4 e5 2. d4 Nc6 3. Nf3 exd4 4. Bc4 d6 5. c3 Be6 6. Bxe6 fxe6 7. Qb3 Qd7 8.
+Qxb7 Rb8 9. Qa6 dxc3 10. Nxc3 Nf6 11. Bg5 Be7 12. O-O-O h6 13. Bh4 g5 14. Bg3
+Rb6 15. Qa4 Ne5 16. Bxe5 Qxa4 17. Nxa4 dxe5 18. Nxb6 axb6 19. Rhe1 Bd6 20. Nd2
+Ke7 21. Nc4 b5 22. Nxd6 cxd6 23. Kc2 Rc8+ 24. Kb3 Rc4 25. f3 g4 26. Rc1 Rd4 27.
+Red1 gxf3 28. gxf3 d5 29. Rxd4 exd4 30. e5 Nh5 31. Kb4 Nf4 32. Kxb5 Nd3 33. Rb1
+Nxe5 34. a4 Nxf3 35. a5 d3 36. a6 Nd4+ 37. Kc5 Nb3+ 38. Kb4 Nd4 39. Kc5 Nb3+
+40. Kb6 d2 41. a7 Nc1 42. a8=Q d1=Q 43. Qb7+ Kf6 44. Qc6 Qd4+ 45. Qc5 Qxc5+ 46.
+Kxc5 Nb3+ 47. Kb4 Nd2 48. Rf1+ Nxf1 49. Kc3 Ne3 50. Kd3 Nd1 51. Ke2 Nxb2 52. h4
+e5 53. Kf3 Kf5 54. Kg3 e4 55. Kh3 Kf4 56. Kh2 Kg4 57. h5 Kxh5 58. Kg2 Kg5 59.
+Kf2 h5 60. Ke2 h4 61. Ke1 h3 62. Kd2 h2 63. Kc2 h1=Q 64. Kc3 Qf3+ 65. Kb4
+1/2-1/2
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "murderoflegends"]
+[Black "nakarian10"]
+[Result "1-0"]
+[ECO "B35"]
+[WhiteElo "2414"]
+[BlackElo "2366"]
+[PlyCount "27"]
+[EventDate "2020.??.??"]
+
+1. e4 c5 2. Nf3 g6 3. d4 cxd4 4. Nxd4 Nc6 5. Nc3 Bg7 6. Be3 Nf6 7. Bc4 Qa5 8.
+f3 Qb4 9. Bb3 Nxe4 10. Nxc6 Qxc3+ 11. bxc3 Bxc3+ 12. Kf1 Bxa1 13. Qxa1 O-O 14.
+Nxe7# 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "RigelStar"]
+[Black "Caochonewell"]
+[Result "0-1"]
+[ECO "A45"]
+[WhiteElo "2399"]
+[BlackElo "2429"]
+[PlyCount "58"]
+[EventDate "2020.??.??"]
+
+1. d4 Nf6 2. e3 c5 3. Nf3 cxd4 4. exd4 d5 5. c3 Nc6 6. h3 Bf5 7. Bd3 Bg6 8.
+Bxg6 hxg6 9. Bg5 Rc8 10. Nbd2 e6 11. O-O Be7 12. b4 O-O 13. a4 a5 14. b5 Nb8
+15. Qb3 Nbd7 16. Rac1 Nb6 17. c4 dxc4 18. Nxc4 Nxc4 19. Rxc4 Qd5 20. Rfc1 Bb4
+21. Bxf6 gxf6 22. Qc2 Rcd8 23. Rc7 Bd6 24. Rc4 Kg7 25. Qc3 Bf4 26. Rc2 Ra8 27.
+b6 Bd6 28. Qb3 Bb4 29. Rc7 Qxb3 0-1
+
+[Event "Rated Blitz tournament te4AhseI"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Stormart"]
+[Black "Fantasma94"]
+[Result "0-1"]
+[WhiteElo "2365"]
+[BlackElo "2379"]
+[PlyCount "0"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+ 0-1
+
+[Event "Rated Blitz tournament te4AhseI"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "chesslismab"]
+[Black "LeninGuerra"]
+[Result "0-1"]
+[ECO "A40"]
+[WhiteElo "2431"]
+[BlackElo "2439"]
+[PlyCount "104"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 e6 2. Nf3 c5 3. c4 cxd4 4. Nxd4 b6 5. Nc3 Bb7 6. e4 a6 7. f3 d6 8. Be2
+Nf6 9. O-O Be7 10. Be3 O-O 11. Rc1 Nbd7 12. Qd2 Rc8 13. Rfd1 Qc7 14. Bf1 Qb8
+15. Bf2 Bd8 16. g4 Bc7 17. Bg3 Rfd8 18. b4 Ne5 19. b5 axb5 20. Ncxb5 Nxf3+ 21.
+Nxf3 Nxe4 22. Qg2 Qa8 23. Nxc7 Rxc7 24. Bh4 Rdc8 25. Qh3 d5 26. Bd3 Qxa2 27.
+Bg3 Nxg3 28. Qxh7+ Kf8 29. Qh8+ Ke7 30. Qh4+ f6 31. Qxg3 dxc4 32. Bf1 Qa3 33.
+Nd4 Qxg3+ 34. hxg3 Bd5 35. Nb5 Rc5 36. Nc3 b5 37. Rb1 Bf3 38. Rdc1 Rb8 39. Kf2
+Bxg4 40. Rb4 Bf5 41. Ne2 Bd3 42. Nd4 Rd8 43. Nxb5 Bxf1 44. Kxf1 Rb8 45. Rcb1 c3
+46. Na3 Rxb4 47. Rxb4 c2 48. Rb7+ Kf8 49. Rb8+ Kf7 50. Rb7+ Kg6 51. Nxc2 Rxc2
+52. Rb4 e5 0-1
+
+[Event "Rated Blitz tournament te4AhseI"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "emejachasu"]
+[Black "LuisGaiborGallardo"]
+[Result "0-1"]
+[ECO "B12"]
+[WhiteElo "2328"]
+[BlackElo "2334"]
+[PlyCount "52"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 c6 2. d4 d5 3. e5 Bf5 4. Nf3 e6 5. Be2 Nd7 6. O-O c5 7. c4 Ne7 8. Nc3
+dxc4 9. Bxc4 a6 10. d5 Nb6 11. Bb3 c4 12. d6 cxb3 13. dxe7 Bxe7 14. Qxb3 O-O
+15. Rd1 Qc7 16. Be3 Nc4 17. Bd4 Na5 18. Qb6 Qxb6 19. Bxb6 Nc4 20. Bd4 Nxb2 21.
+Nh4 Bxh4 22. g3 Be7 23. f3 h5 24. Kf2 Rfd8 25. Ke3 Nc4+ 26. Kf4 g5# 0-1
+
+[Event "Rated Blitz tournament te4AhseI"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Chang90"]
+[Black "joseag1303"]
+[Result "1-0"]
+[ECO "B23"]
+[WhiteElo "2327"]
+[BlackElo "2331"]
+[PlyCount "63"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 c5 2. Nc3 d6 3. g3 g6 4. Bg2 Bg7 5. h4 Nf6 6. Nh3 O-O 7. d3 Nc6 8. O-O
+Nd4 9. f3 Rb8 10. Be3 b5 11. Qd2 Nh5 12. Kh2 b4 13. Nd1 f5 14. c3 Nc6 15. Bh6
+bxc3 16. bxc3 Ne5 17. Bxg7 Nxg7 18. Ne3 fxe4 19. dxe4 Bd7 20. Ng5 h6 21. Nh3
+Kh7 22. Nf4 Qc8 23. Ned5 Qe8 24. Rab1 Rxb1 25. Rxb1 Nh5 26. Nxh5 gxh5 27. Nf4
+Rg8 28. Rf1 Qf7 29. Qf2 Bc8 30. Bh3 Bxh3 31. Nxh3 Qg6 32. Nf4 1-0
+
+[Event "Rated Blitz tournament te4AhseI"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Mr-Anonymous-Killer"]
+[Black "MiracleEcu"]
+[Result "1-0"]
+[ECO "A00"]
+[WhiteElo "2342"]
+[BlackElo "2358"]
+[PlyCount "133"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. Nh3 d5 2. g3 h5 3. Bg2 h4 4. c4 dxc4 5. Qa4+ Bd7 6. Qxc4 Bc6 7. Bxc6+ Nxc6
+8. Nc3 Nf6 9. d3 e6 10. Bg5 hxg3 11. hxg3 Be7 12. O-O-O Qd4 13. Nf4 O-O-O 14.
+Qxd4 Nxd4 15. f3 Nf5 16. g4 Nd4 17. Rdg1 c6 18. a3 a5 19. Kb1 b5 20. Rc1 Kb7
+21. Bxf6 Bxf6 22. Ne4 Be7 23. g5 e5 24. Nh5 g6 25. Nhg3 Kb6 26. Rce1 a4 27. Kc1
+c5 28. Nf6 Bxf6 29. gxf6 b4 30. Kd2 Kb5 31. Ne4 Rb8 32. Rxh8 Rxh8 33. Nd6+ Kc6
+34. Nxf7 Rh5 35. Rg1 Rh2 36. Rxg6 Rxe2+ 37. Kd1 Rxb2 38. Nxe5+ Kd6 39. f7+ Ke7
+40. Rg8 Ne6 41. Re8+ Kd6 42. Rxe6+ Kxe6 43. f8=Q Rb1+ 44. Ke2 bxa3 45. Qxc5
+Rb2+ 46. Ke3 a2 47. Qc6+ Kxe5 48. f4+ Kf5 49. Qd5+ Kg6 50. Qg5+ Kf7 51. Qf5+
+Ke8 52. Qe5+ Kd7 53. Qxb2 a3 54. Qxa2 Kd6 55. Qxa3+ Kd7 56. Qb4 Ke8 57. Qe4+
+Kf7 58. f5 Kf8 59. Qe6 Kg7 60. d4 Kf8 61. d5 Kg7 62. d6 Kf8 63. d7 Kg7 64. Qd6
+Kh7 65. d8=Q Kg7 66. Q8d7+ Kg8 67. Qb8# 1-0
+
+[Event "Rated Blitz tournament te4AhseI"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Alberto_Santos"]
+[Black "PetroffLRS"]
+[Result "1-0"]
+[ECO "D14"]
+[WhiteElo "2315"]
+[BlackElo "2300"]
+[PlyCount "93"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 Nf6 2. Nf3 c6 3. c4 d5 4. cxd5 cxd5 5. Nc3 Nc6 6. Bf4 Bf5 7. e3 a6 8. Ne5
+e6 9. Rc1 Nxe5 10. Bxe5 Bd6 11. Bxd6 Qxd6 12. Be2 O-O 13. O-O b5 14. a4 b4 15.
+Nb1 a5 16. Nd2 Ne4 17. Nb3 f6 18. f3 Ng5 19. Qd2 Bg6 20. Rc5 e5 21. dxe5 fxe5
+22. Rxd5 Qf6 23. Rxa5 Rac8 24. Rc5 Rcd8 25. Qxb4 e4 26. f4 Ne6 27. Rc6 Rfe8 28.
+Bc4 Bf5 29. Nd4 Rxd4 30. exd4 Qxd4+ 31. Kh1 Qd7 32. Rd6 Qe7 33. Rfd1 h6 34. Qb3
+Kh7 35. Qe3 Qh4 36. g3 Qf6 37. Qc3 Qg6 38. Be2 Bg4 39. Bxg4 Qxg4 40. Qe3 Qf5
+41. R6d5 Qg6 42. a5 Nc7 43. Rd6 Qf5 44. a6 Nb5 45. Rd7 Rc8 46. a7 Qg4 47. R7d2
+1-0
+
+[Event "Rated Blitz tournament te4AhseI"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Cloud_ec"]
+[Black "mux77"]
+[Result "1-0"]
+[ECO "A48"]
+[WhiteElo "2437"]
+[BlackElo "2445"]
+[PlyCount "119"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 Nf6 2. Nf3 g6 3. Bf4 Bg7 4. e3 d6 5. h3 Nbd7 6. Be2 O-O 7. O-O e6 8. Bh2
+Qe7 9. c3 b6 10. a4 a6 11. Nbd2 Bb7 12. Re1 Ne4 13. Nxe4 Bxe4 14. Nd2 Bb7 15.
+Bf3 Bxf3 16. Qxf3 c5 17. Qc6 e5 18. Nc4 Rfc8 19. Qxd6 Qxd6 20. Nxd6 Rc6 21.
+dxe5 Bxe5 22. Nc4 Bxh2+ 23. Kxh2 Rb8 24. Red1 Nf6 25. Rd2 b5 26. axb5 axb5 27.
+Ne5 Re6 28. Nd7 Rc8 29. Nxf6+ Rxf6 30. Ra7 b4 31. c4 Rcc6 32. Kg3 h5 33. h4
+Rce6 34. Rd5 Re4 35. f3 Rxc4 36. Rc7 Rc2 37. Rdxc5 Rxb2 38. Rb5 Rb3 39. e4 Rc3
+40. Rxc3 bxc3 41. Rc5 Kg7 42. Rxc3 Ra6 43. Rc7 Ra1 44. e5 Kg8 45. e6 fxe6 46.
+Re7 Ra6 47. Kf4 Kf8 48. Rb7 Ra5 49. Rc7 Ke8 50. Rg7 Rf5+ 51. Kg3 Rf6 52. Ra7
+Kf8 53. Kf2 Rf5 54. Ke3 Rb5 55. Kf4 Rc5 56. Rb7 Rf5+ 57. Ke4 Rc5 58. Rb4 Kf7
+59. Kd4 Kf6 60. Kxc5 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "drdrunckenstein"]
+[Black "zpxocivubyntmraeswdq"]
+[Result "0-1"]
+[ECO "A00"]
+[WhiteElo "2529"]
+[BlackElo "2692"]
+[PlyCount "100"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. g3 g6 2. Bg2 Bg7 3. d3 d6 4. Nf3 c5 5. O-O Nc6 6. Nc3 Rb8 7. e4 b5 8. a4 b4
+9. Ne2 e6 10. Rb1 Nge7 11. b3 O-O 12. Nd2 e5 13. f4 f5 14. exf5 Bxf5 15. fxe5
+Nxe5 16. Ne4 Bg4 17. h3 Bd7 18. Nf4 Qc7 19. Ng5 h6 20. Nge6 Bxe6 21. Nxe6 Rxf1+
+22. Qxf1 Qd7 23. Nxg7 Kxg7 24. g4 Rf8 25. Qe2 g5 26. Bb2 N7g6 27. Re1 Qf7 28.
+Rf1 Qe7 29. Rxf8 Qxf8 30. Be4 Nf4 31. Qf1 Qf6 32. Ba1 a5 33. Bf5 Qe7 34. Kh2
+Kf7 35. Qf2 Qf6 36. Kh1 Ke7 37. Qf1 Kd8 38. Qf2 Kc7 39. Qf1 Qe7 40. Be4 Nd7 41.
+Kh2 d5 42. Bf3 Qd6 43. Kh1 Ne5 44. Bg2 Nc6 45. Qf3 Nd4 46. Bxd4 cxd4 47. Qf2
+Qe5 48. Kg1 Kd6 49. Kf1 Kc5 50. Qf3 Qe3 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "KingoFish"]
+[Black "alphonsea"]
+[Result "1-0"]
+[ECO "B22"]
+[WhiteElo "2393"]
+[BlackElo "2317"]
+[PlyCount "53"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 c5 2. c3 Nf6 3. e5 Nd5 4. d4 cxd4 5. cxd4 Nc6 6. Nc3 Nxc3 7. bxc3 d6 8.
+f4 d5 9. Bd3 g6 10. Nf3 Bg7 11. O-O Bg4 12. h3 Bxf3 13. Qxf3 e6 14. g4 h5 15.
+Rb1 Rb8 16. f5 hxg4 17. hxg4 Qh4 18. Qg2 gxf5 19. gxf5 Nxe5 20. Bg5 Qh1+ 21.
+Qxh1 Rxh1+ 22. Kxh1 Nxd3 23. Rf3 f6 24. Bd2 e5 25. Rxd3 e4 26. Rh3 Kf7 27. Bf4
+1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "UptownExpress"]
+[Black "Xychael27"]
+[Result "0-1"]
+[ECO "B22"]
+[WhiteElo "2303"]
+[BlackElo "2300"]
+[PlyCount "132"]
+[EventDate "2020.??.??"]
+
+1. e4 c5 2. d4 cxd4 3. c3 Nf6 4. e5 Nd5 5. cxd4 Nc6 6. Nc3 Nxc3 7. bxc3 d5 8.
+f4 Bf5 9. Nf3 e6 10. Bd3 Bxd3 11. Qxd3 Be7 12. O-O O-O 13. f5 Na5 14. fxe6 fxe6
+15. Bd2 Rc8 16. Rac1 Nc4 17. Qe2 Nxd2 18. Qxd2 a6 19. Qe2 Qa5 20. Qe3 Rc4 21.
+h3 Rfc8 22. Ng5 Bxg5 23. Qxg5 Rxc3 24. Rce1 Qd8 25. Qg4 Qe7 26. Rf4 Rc1 27.
+Rxc1 Rxc1+ 28. Kh2 Rc8 29. Qf3 Rf8 30. Rxf8+ Qxf8 31. Qg4 Qf5 32. Qg3 g5 33.
+Kh1 Qf4 34. Qc3 Qf7 35. Qc8+ Kg7 36. Qc1 h6 37. Qe3 b5 38. Kg1 Kg6 39. Qd3+ Qf5
+40. Qd2 Qb1+ 41. Kh2 Qf5 42. Qc3 Qf4+ 43. Kg1 Qf7 44. Qc2+ Qf5 45. Qc3 Qb1+ 46.
+Kh2 Qf5 47. Qg3 Qf4 48. h4 Kf5 49. hxg5 hxg5 50. Qxf4+ gxf4 51. Kg1 Ke4 52. Kf2
+Kxd4 53. Ke2 Kxe5 54. g4 Kf6 55. g5+ Kxg5 56. Kf3 e5 57. Kg2 Kf5 58. Kf2 e4 59.
+Ke2 d4 60. Kf2 d3 61. Ke1 Ke5 62. Kd1 Kd4 63. Ke1 e3 64. Kd1 f3 65. a3 f2 66.
+a4 f1=Q# 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "C9C9C9C9C9"]
+[Black "drop_stone"]
+[Result "0-1"]
+[ECO "D41"]
+[WhiteElo "3006"]
+[BlackElo "2903"]
+[PlyCount "82"]
+[EventDate "2020.??.??"]
+
+1. Nf3 d5 2. d4 Nf6 3. c4 e6 4. Nc3 c5 5. cxd5 cxd4 6. Qxd4 exd5 7. Bg5 Be7 8.
+Rd1 Nc6 9. Qa4 O-O 10. e3 Be6 11. Bb5 Qb6 12. O-O Rac8 13. Rd2 h6 14. Bh4 Ne4
+15. Nxe4 dxe4 16. Bxe7 Nxe7 17. Nd4 Rfd8 18. Rfd1 Bg4 19. Be2 Bxe2 20. Rxe2 Nc6
+21. Red2 Nxd4 22. exd4 Rd5 23. h3 a6 24. Qa3 Rcd8 25. Qe3 f5 26. g4 Qg6 27. Kh1
+fxg4 28. Rg1 Rh5 29. Rg3 Qf5 30. Kh2 Rxh3+ 31. Rxh3 gxh3 32. Qg3 Rd5 33. Rd1 g5
+34. Rc1 Kh7 35. Rc7+ Rd7 36. Rxd7+ Qxd7 37. Qe5 g4 38. d5 Qf7 39. Qxe4+ Kh8 40.
+Qd4+ Kh7 41. d6 Qf3 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "troisi"]
+[Black "imdejong"]
+[Result "1-0"]
+[ECO "A00"]
+[WhiteElo "2381"]
+[BlackElo "2351"]
+[PlyCount "89"]
+[EventDate "2020.??.??"]
+
+1. g3 e6 2. Bg2 d5 3. c4 Nf6 4. cxd5 exd5 5. d4 Bd6 6. Nf3 h6 7. Nc3 O-O 8. O-O
+c6 9. Bf4 Re8 10. Bxd6 Qxd6 11. Ne5 Nbd7 12. f4 Nb6 13. e3 Nfd7 14. Bf3 Nf8 15.
+Bh5 g6 16. Bf3 f6 17. Nd3 Rxe3 18. Nc5 Kg7 19. Qd2 Re7 20. Rae1 Bh3 21. Rxe7+
+Qxe7 22. Re1 Qf7 23. g4 Re8 24. Kf2 f5 25. g5 hxg5 26. fxg5 Ne6 27. Nxe6+ Rxe6
+28. b3 Rxe1 29. Qxe1 Bg4 30. Qe5+ Kh7 31. Kg3 Bxf3 32. Kxf3 Nd7 33. Qd6 Kg7 34.
+Ne2 Nf8 35. Nf4 Kh7 36. h4 Nd7 37. h5 Nf8 38. hxg6+ Nxg6 39. Nd3 f4 40. Ne5
+Nxe5+ 41. dxe5 Qh5+ 42. Kxf4 Qh4+ 43. Kf5 Qh3+ 44. Kf6 Qf3+ 45. Ke7 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "azolot"]
+[Black "Bulingot"]
+[Result "1-0"]
+[ECO "A00"]
+[WhiteElo "2301"]
+[BlackElo "2364"]
+[PlyCount "61"]
+[EventDate "2020.??.??"]
+
+1. e3 c5 2. c4 Nf6 3. Nf3 g6 4. d4 Bg7 5. Nc3 O-O 6. d5 d6 7. h3 e6 8. Be2 exd5
+9. cxd5 a6 10. a4 Nbd7 11. O-O Re8 12. Nd2 Ne5 13. f4 Ned7 14. Nc4 b6 15. Nxd6
+Qc7 16. Nxe8 Nxe8 17. e4 c4 18. Kh1 Rb8 19. Bf3 b5 20. axb5 axb5 21. Ne2 Nc5
+22. e5 Nb3 23. Rb1 Bb7 24. d6 Qd7 25. Bxb7 Qxb7 26. Be3 Rd8 27. Nd4 Nxd6 28.
+Nxb3 cxb3 29. exd6 Qe4 30. Qf3 Qc2 31. Rfc1 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Betovsky"]
+[Black "Akali666"]
+[Result "1-0"]
+[ECO "A45"]
+[WhiteElo "2608"]
+[BlackElo "2459"]
+[PlyCount "35"]
+[EventDate "2020.??.??"]
+
+1. d4 Nf6 2. Bg5 e6 3. e4 d5 4. exd5 Qxd5 5. Bxf6 gxf6 6. Nf3 Nc6 7. c4 Bb4+ 8.
+Nc3 Qa5 9. Qb3 Bxc3+ 10. bxc3 Bd7 11. Be2 O-O-O 12. O-O b6 13. c5 Ne7 14. Rab1
+Qa4 15. Qb2 Nd5 16. c4 Nf4 17. Bd1 Bc6 18. Bxa4 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "starkspieler"]
+[Black "Atomrod"]
+[Result "0-1"]
+[ECO "B12"]
+[WhiteElo "2423"]
+[BlackElo "2497"]
+[PlyCount "148"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 c6 2. d4 d5 3. e5 c5 4. dxc5 Nc6 5. a3 a5 6. Bb5 Bd7 7. Qxd5 e6 8. Qe4
+Bxc5 9. Nf3 Qb6 10. Bd3 Nge7 11. O-O Ng6 12. Nbd2 Qc7 13. Re1 Nce7 14. Qg4 h5
+15. Qg5 Bc6 16. Ne4 Qb6 17. Nxc5 Qxc5 18. Be3 Qd5 19. Rad1 Rd8 20. Be2 Qe4 21.
+Rxd8+ Kxd8 22. Bd3 Qg4 23. Bb6+ Ke8 24. h3 Qxg5 25. Nxg5 a4 26. Bc5 Nd5 27. Ne4
+f6 28. Nd6+ Kd7 29. Bxg6 Nf4 30. Be4 fxe5 31. Bxc6+ Kxc6 32. Bb4 Rh6 33. Nc4
+Kd5 34. Nxe5 h4 35. c4+ Kd4 36. Bc3+ Kc5 37. Re4 g5 38. Bd2 b5 39. Bxf4 gxf4
+40. cxb5 Kxb5 41. Rxf4 Rh5 42. Nf3 e5 43. Rb4+ Ka5 44. Rxh4 Rf5 45. Re4 Rf8 46.
+Rxe5+ Kb6 47. g4 Rxf3 48. Kg2 Rb3 49. Re2 Rb5 50. f3 Kc6 51. Kg3 Kd6 52. h4 Rc5
+53. h5 Rc1 54. Kh4 Rh1+ 55. Kg5 Rf1 56. f4 Rh1 57. f5 Kd5 58. f6 Rf1 59. Kg6
+Kd4 60. g5 Kd3 61. Re7 Rf2 62. f7 Kd4 63. Kg7 Rf5 64. g6 Rg5 65. f8=Q Rxh5 66.
+Qf4+ Kd5 67. Re3 Rh1 68. Rd3+ Kc5 69. Qe5+ Kc6 70. Qe4+ Kc7 71. Qe6 Rc1 72.
+Rd7+ Kb8 73. Qe8+ Rc8 74. Rd8 Kc7 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "WildBreath"]
+[Black "estocastico"]
+[Result "0-1"]
+[ECO "B23"]
+[WhiteElo "2409"]
+[BlackElo "2569"]
+[PlyCount "33"]
+[EventDate "2020.??.??"]
+
+1. e4 c5 2. Nc3 d6 3. Bb5+ Nd7 4. Bxd7+ Bxd7 5. d3 g6 6. f4 Bg7 7. Nf3 Nf6 8.
+O-O O-O 9. Qe1 b5 10. Qh4 b4 11. Ne2 e6 12. f5 exf5 13. Bh6 Ng4 14. Qh3 Nxh6
+15. exf5 Bxf5 16. Qg3 Bd7 17. Nf4 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "taras05"]
+[Black "nakarian10"]
+[Result "1-0"]
+[ECO "B36"]
+[WhiteElo "2491"]
+[BlackElo "2361"]
+[PlyCount "131"]
+[EventDate "2020.??.??"]
+
+1. e4 c5 2. Nf3 g6 3. d4 cxd4 4. Nxd4 Nc6 5. c4 Nf6 6. Nc3 Nxd4 7. Qxd4 d6 8.
+Be3 Bg7 9. f3 O-O 10. Qd2 a5 11. Be2 a4 12. O-O Qa5 13. Rfd1 Be6 14. Rab1 Rfc8
+15. b4 axb3 16. axb3 Qb4 17. Nb5 Qxd2 18. Rxd2 Bd7 19. Nd4 Ne8 20. b4 Nc7 21.
+Kf2 Ne6 22. Nxe6 Bxe6 23. c5 dxc5 24. Bxc5 Bf8 25. Rbd1 Ra2 26. Rxa2 Bxa2 27.
+Rd7 b6 28. Bxb6 Rc2 29. Ke3 e6 30. Rd8 Kg7 31. Bd4+ f6 32. Bxf6+ Kxf6 33. Rxf8+
+Ke7 34. Rb8 Rb2 35. b5 h5 36. Rb7+ Kd6 37. Rb6+ Kc5 38. Rc6+ Kb4 39. Rd6 Ka5
+40. Rd2 Rb4 41. Rxa2+ Kb6 42. Ra6+ Kb7 43. Rc6 Rb3+ 44. Rc3 Rxc3+ 45. Bd3 Rb3
+46. g3 Kb6 47. f4 Kc5 48. h4 Rb2 49. e5 Rg2 50. Kf3 Rd2 51. Bxg6 Rd4 52. Bxh5
+Rb4 53. Kg4 Rb3 54. Bf7 Rb4 55. Bxe6 Kb6 56. Bf5 Kc7 57. h5 Rb3 58. h6 Rb4 59.
+h7 Rxb5 60. h8=Q Rxe5 61. Qg7+ Re7 62. Qxe7+ Kc6 63. Qe5 Kb6 64. Be4 Ka6 65.
+Kf3 Kb6 66. f5 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "ajedrez2021"]
+[Black "sutcunuri"]
+[Result "0-1"]
+[ECO "A15"]
+[WhiteElo "2605"]
+[BlackElo "2508"]
+[PlyCount "92"]
+[EventDate "2020.??.??"]
+
+1. c4 Nf6 2. Nf3 Nc6 3. g3 e5 4. Bg2 d5 5. O-O Be7 6. cxd5 Nxd5 7. d3 O-O 8.
+Nc3 Nb6 9. Be3 Re8 10. Rc1 Bf8 11. Re1 Nd4 12. Na4 Nxa4 13. Qxa4 Nxf3+ 14. Bxf3
+c6 15. b4 Bd7 16. Qb3 a5 17. a3 axb4 18. axb4 Be6 19. Qb2 Ra2 20. Qb1 Bd5 21.
+b5 cxb5 22. Bb6 Qd6 23. Bc5 Qd7 24. Bxf8 Rxf8 25. Qb4 Bxf3 26. exf3 Qxd3 27.
+Rf1 Qd5 28. Qe7 Raa8 29. Qb4 Qxf3 30. Qb2 Qd5 31. Rc3 Qe6 32. Rb3 f6 33. Rxb5
+b6 34. Rxb6 Qf7 35. Rb3 Qg6 36. Rb6 Rae8 37. h4 Kh8 38. h5 Qxh5 39. Rb7 Qg6 40.
+Rb5 e4 41. Rb8 e3 42. Rb6 exf2+ 43. Rxf2 Qxg3+ 44. Rg2 Qe3+ 45. Kh2 Qxb6 46.
+Rg6 Qxb2+ 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "hungzhao"]
+[Black "hawth0rne"]
+[Result "0-1"]
+[ECO "B43"]
+[WhiteElo "2639"]
+[BlackElo "2446"]
+[PlyCount "78"]
+[EventDate "2020.??.??"]
+
+1. e4 c5 2. Nf3 e6 3. Nc3 a6 4. d4 cxd4 5. Nxd4 Qc7 6. Bd3 b5 7. O-O Bb7 8. a3
+Nf6 9. Qe2 Be7 10. e5 Nd5 11. Nxd5 Bxd5 12. Bf4 Nc6 13. Nxc6 Bxc6 14. Qg4 g5
+15. Bxg5 Rg8 16. h4 h6 17. Qh5 hxg5 18. Qh7 O-O-O 19. h5 Qxe5 20. Rae1 Qd5 21.
+Be4 Qd6 22. Bxc6 Qxc6 23. Qxf7 Bc5 24. b4 Bb6 25. c4 bxc4 26. Rc1 Rdf8 27. Qh7
+g4 28. Qc2 g3 29. Qxc4 Bxf2+ 30. Kh1 Qxc4 31. Rxc4+ Kb7 32. Rh4 Rh8 33. Rd1 Kc7
+34. Rc4+ Kd8 35. Rh4 Rf5 36. h6 Rf6 37. h7 Rf7 38. Rd5 exd5 39. Rh6 Rfxh7 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "emiliofelixramirez"]
+[Black "Guanabana12"]
+[Result "0-1"]
+[ECO "C00"]
+[WhiteElo "2399"]
+[BlackElo "2436"]
+[PlyCount "118"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 e6 2. d4 b6 3. Nc3 Bb7 4. Nf3 Nf6 5. Bd3 c5 6. d5 exd5 7. exd5 Nxd5 8.
+Nxd5 Bxd5 9. O-O Be7 10. Re1 Be6 11. Ne5 Nc6 12. Nxc6 dxc6 13. Qh5 Qd5 14. Qe2
+O-O 15. Bf4 Bf6 16. c3 Rad8 17. Be4 Qc4 18. Qc2 g6 19. Bh6 Bg7 20. Bxg7 Kxg7
+21. Bxc6 Rd6 22. Bf3 Rfd8 23. b3 Qd3 24. Qxd3 Rxd3 25. c4 Rd2 26. Red1 Kf6 27.
+Kf1 Bf5 28. Ke1 Rxd1+ 29. Rxd1 Rxd1+ 30. Kxd1 Ke5 31. Kd2 Kd4 32. Bc6 g5 33.
+Be8 f6 34. Bc6 h6 35. Be8 Bb1 36. a3 a5 37. Bc6 Bf5 38. Be8 Be4 39. f3 Bb7 40.
+Bd7 f5 41. Bxf5 a4 42. Bc2 axb3 43. Bxb3 Ba6 44. g3 Bxc4 45. Bxc4 Kxc4 46. Ke3
+b5 47. f4 gxf4+ 48. gxf4 Kd5 49. Kd3 h5 50. h4 b4 51. axb4 cxb4 52. f5 Ke5 53.
+Kc4 Kxf5 54. Kxb4 Kg4 55. Kc3 Kxh4 56. Kd2 Kg3 57. Ke1 Kg2 58. Ke2 h4 59. Ke3
+h3 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "kingcobra23"]
+[Black "jesus_guillen02"]
+[Result "1-0"]
+[ECO "B21"]
+[WhiteElo "2315"]
+[BlackElo "2373"]
+[PlyCount "29"]
+[EventDate "2020.??.??"]
+
+1. e4 c5 2. d4 cxd4 3. c3 dxc3 4. Nxc3 Nf6 5. Nf3 d6 6. e5 dxe5 7. Qxd8+ Kxd8
+8. Nxe5 Be6 9. Bf4 g6 10. O-O-O+ Ke8 11. Nb5 Na6 12. Nd4 Bxa2 13. Bb5+ Kd8 14.
+Ne6+ Kc8 15. Rd8# 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "nightfox"]
+[Black "Molot_ua"]
+[Result "1-0"]
+[ECO "B12"]
+[WhiteElo "2424"]
+[BlackElo "2379"]
+[PlyCount "77"]
+[EventDate "2020.??.??"]
+
+1. e4 c6 2. d4 d6 3. Nc3 Nd7 4. Nf3 h6 5. Bc4 g5 6. h4 g4 7. Nh2 h5 8. Bg5 Bg7
+9. Nf1 b5 10. Bb3 a5 11. a4 b4 12. Ne2 Ba6 13. Nfg3 Nf8 14. Be3 Qb6 15. Nf5 Bh6
+16. Nxh6 Nxh6 17. d5 c5 18. Ng3 Ng8 19. Nf5 Ng6 20. Qd2 Ne5 21. Ng7+ Kf8 22.
+Nf5 Qc7 23. O-O-O c4 24. Ba2 b3 25. Bb1 bxc2 26. Bxc2 Nd3+ 27. Kb1 Rb8 28. Bxd3
+cxd3 29. Bd4 Nf6 30. Rc1 Qb7 31. Bxf6 exf6 32. Nxd6 Qb3 33. Rc7 Rh7 34. Rhc1
+Qxa4 35. Nf5 Qb3 36. R1c3 Qb4 37. d6 a4 38. d7 a3 39. Rc8+ 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "isralino"]
+[Black "Yoseqpuedo"]
+[Result "1-0"]
+[ECO "A40"]
+[WhiteElo "2300"]
+[BlackElo "2398"]
+[PlyCount "135"]
+[EventDate "2020.??.??"]
+
+1. d4 e6 2. Nc3 f5 3. e4 Nf6 4. exf5 exf5 5. Bd3 d5 6. Qf3 Bd6 7. Bxf5 Bxf5 8.
+Qxf5 O-O 9. Nf3 c6 10. Qd3 Qc7 11. Be3 b5 12. h3 a5 13. O-O Nbd7 14. Rae1 Rae8
+15. Bg5 b4 16. Ne2 Ne4 17. Be3 Ndf6 18. Ng5 h6 19. Nxe4 Nxe4 20. c3 Qf7 21. Nc1
+Qh5 22. Qc2 bxc3 23. bxc3 Rb8 24. Nd3 Qg6 25. f4 Nf6 26. Rf2 Nh5 27. Ne5 Qe8
+28. Bc1 Qd8 29. f5 Nf6 30. Ng6 Re8 31. Rfe2 Qd7 32. Re6 Ne4 33. R1xe4 dxe4 34.
+Qxe4 Rxe6 35. fxe6 Qe8 36. Bf4 Bxf4 37. Nxf4 Rb7 38. d5 cxd5 39. Qxd5 Rc7 40.
+e7+ Kh8 41. Qf5 Rxe7 42. Ng6+ Kg8 43. Nxe7+ Qxe7 44. Qc8+ Qf8 45. Qc4+ Qf7 46.
+Qxf7+ Kxf7 47. Kf2 Ke7 48. Ke3 Kd6 49. Kd4 Kc6 50. Kc4 a4 51. Kb4 Kb6 52. Kxa4
+g5 53. Kb4 h5 54. c4 Kc6 55. c5 Kb7 56. a4 Kc7 57. c6 Kb8 58. Kc4 Ka7 59. Kb5
+g4 60. Kc5 Kb8 61. hxg4 Kc8 62. g3 h4 63. gxh4 Kc7 64. h5 Kc8 65. h6 Kc7 66. h7
+Kb8 67. h8=Q+ Kc7 68. Qf6 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Caochonewell"]
+[Black "RigelStar"]
+[Result "1-0"]
+[ECO "D13"]
+[WhiteElo "2435"]
+[BlackElo "2394"]
+[PlyCount "97"]
+[EventDate "2020.??.??"]
+
+1. d4 d5 2. Nf3 c6 3. c4 Nf6 4. cxd5 cxd5 5. Nc3 e6 6. a3 a6 7. Bg5 b5 8. e3
+Bb7 9. Bd3 Be7 10. O-O h6 11. Bh4 Nbd7 12. a4 b4 13. Nb1 a5 14. Qe2 O-O 15.
+Nbd2 Nb6 16. Nb3 Nfd7 17. Bxe7 Qxe7 18. Rfc1 Rfc8 19. Rxc8+ Bxc8 20. Bb5 Qd6
+21. Rc1 Bb7 22. Qc2 f6 23. Nc5 Rc8 24. Qd1 Bc6 25. Nxd7 Qxd7 26. Bxc6 Rxc6 27.
+b3 Rc3 28. Rxc3 bxc3 29. Qc2 Qc6 30. Kf1 Nc8 31. Ng1 Nd6 32. f3 e5 33. Ne2 exd4
+34. exd4 Nf5 35. Qxf5 c2 36. Nc1 Qc3 37. Qd3 Qb2 38. Qd2 Kf7 39. Ke2 Ke6 40.
+Kd3 Qb1 41. Qxc2 Qa1 42. Kd2 Qxd4+ 43. Qd3 Qg1 44. Qe2+ Kf7 45. h3 Qh2 46. Nd3
+Qc7 47. Qe3 Qb8 48. Nc5 Qb7 49. Nxb7 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "WildBreath"]
+[Black "iCe_eNerGyTeaM"]
+[Result "0-1"]
+[ECO "A00"]
+[WhiteElo "2406"]
+[BlackElo "2544"]
+[PlyCount "24"]
+[EventDate "2020.??.??"]
+
+1. h4 Nc6 2. h5 e5 3. d3 Nh6 4. a4 d5 5. a5 a6 6. Bxh6 gxh6 7. Nd2 Be6 8. e4
+dxe4 9. dxe4 Qd4 10. c3 Qc5 11. Qb3 Bxb3 12. Nxb3 Qd6 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Betovsky"]
+[Black "estocastico"]
+[Result "1-0"]
+[ECO "A45"]
+[WhiteElo "2611"]
+[BlackElo "2572"]
+[PlyCount "73"]
+[EventDate "2020.??.??"]
+
+1. d4 Nf6 2. Bg5 g6 3. Bxf6 exf6 4. g3 f5 5. Bg2 h5 6. e3 h4 7. Ne2 h3 8. Bf1
+Bg7 9. c4 c5 10. Nbc3 Nc6 11. d5 Ne5 12. Nf4 g5 13. Nh5 Bf8 14. Be2 d6 15. Qc2
+f6 16. O-O-O Qe7 17. Kb1 Qf7 18. g4 fxg4 19. Ng3 f5 20. Ka1 a6 21. Na4 f4 22.
+Ne4 Bf5 23. exf4 gxf4 24. Nb6 Rd8 25. Rhe1 Bg7 26. Bf1 O-O 27. Qd2 Nf3 28. Qa5
+Nxe1 29. Rxe1 Rfe8 30. a3 Bxe4 31. Rc1 Qf6 32. Qd2 Bf3 33. Na4 b5 34. cxb5 axb5
+35. Bxb5 Re4 36. Bc4 Ra8 37. Qxf4 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "shinji_no_baka"]
+[Black "AbdAlQadir"]
+[Result "0-1"]
+[ECO "D20"]
+[WhiteElo "2351"]
+[BlackElo "2334"]
+[PlyCount "52"]
+[EventDate "2020.??.??"]
+
+1. d4 d5 2. c4 dxc4 3. Nc3 a6 4. a4 Nc6 5. d5 Na5 6. e4 e5 7. Nf3 Bd6 8. h3 Ne7
+9. Be2 Ng6 10. O-O O-O 11. Bg5 f6 12. Be3 Nf4 13. Bxf4 exf4 14. Nd2 Re8 15.
+Nxc4 Nxc4 16. Bxc4 Qe7 17. f3 Qe5 18. Kh1 Qh5 19. Rf2 Bc5 20. Rd2 Re5 21. Bf1
+Rg5 22. a5 Qh4 23. Qe1 Rg3 24. Ne2 Bxh3 25. gxh3 Rxh3+ 26. Kg2 Rh2# 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "aminmohamad64"]
+[Black "Derrotado"]
+[Result "1-0"]
+[ECO "A00"]
+[WhiteElo "2393"]
+[BlackElo "2405"]
+[PlyCount "101"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. g3 a5 2. Bg2 g6 3. e4 Bg7 4. d4 d6 5. c3 Nd7 6. h3 e5 7. Be3 Ngf6 8. Ne2 O-O
+9. O-O b6 10. f4 Bb7 11. fxe5 Nxe4 12. Qd3 d5 13. Nd2 f5 14. exf6 Ndxf6 15. g4
+Ba6 16. c4 Nd6 17. b3 Nfe4 18. Nxe4 dxe4 19. Qc2 c5 20. Rxf8+ Qxf8 21. Rf1 Qc8
+22. dxc5 bxc5 23. Nc3 Qe6 24. Nxe4 Nxe4 25. Bxe4 Rd8 26. Bxc5 Kh8 27. Bd5 Qe8
+28. Qf2 Rxd5 29. cxd5 Bxf1 30. Kxf1 Qe5 31. Qd2 h5 32. Be3 Qf6+ 33. Kg2 hxg4
+34. hxg4 Kg8 35. d6 Qe6 36. d7 Qxg4+ 37. Kf1 Qh3+ 38. Ke1 Qh4+ 39. Kd1 Bf6 40.
+Qd5+ Kh7 41. Qf7+ Bg7 42. Ke2 Qg4+ 43. Kd3 Qd1+ 44. Ke4 Qc2+ 45. Kf3 Qd1+ 46.
+Kg2 Qg4+ 47. Kf2 Qh4+ 48. Ke2 Qg4+ 49. Kd2 Qg2+ 50. Kd3 Qd5+ 51. Qxd5 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "BerserkAdopter"]
+[Black "Akali666"]
+[Result "0-1"]
+[ECO "C20"]
+[WhiteElo "2452"]
+[BlackElo "2456"]
+[PlyCount "88"]
+[EventDate "2020.??.??"]
+
+1. e4 e5 2. d3 Nc6 3. Nd2 Bc5 4. Ngf3 Nge7 5. g3 h5 6. Bg2 Ng6 7. h4 d6 8. c3
+Bg4 9. Qe2 a6 10. Nc4 Qe7 11. Ne3 O-O-O 12. Nxg4 hxg4 13. Nd2 Nf8 14. Qxg4+ Ne6
+15. Nc4 Kb8 16. Be3 Bxe3 17. Nxe3 g6 18. O-O-O Na5 19. Kb1 Qd7 20. Nd5 Qa4 21.
+Qe2 c6 22. Ne3 b5 23. Qc2 Ka7 24. Rdf1 Rb8 25. Bh3 Nc5 26. f4 b4 27. Qxa4 Nxa4
+28. c4 b3 29. a3 Rb7 30. fxe5 dxe5 31. Rf6 Nc5 32. Bf1 Rd8 33. Be2 Nxd3 34.
+Rhf1 Nc5 35. Rxf7 Nxe4 36. Rxb7+ Nxb7 37. Kc1 Nd2 38. Rf7 Kb6 39. c5+ Nxc5 40.
+Nd1 Nde4 41. Nc3 Nxc3 42. bxc3 Na4 43. Bc4 b2+ 44. Kb1 Rd2 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Kidefence"]
+[Black "BlueGreensun"]
+[Result "0-1"]
+[ECO "D00"]
+[WhiteElo "2711"]
+[BlackElo "2756"]
+[PlyCount "98"]
+[EventDate "2020.??.??"]
+
+1. e4 d5 2. d4 dxe4 3. Nc3 Nf6 4. f3 c5 5. Be3 cxd4 6. Bxd4 exf3 7. Nxf3 Nc6 8.
+Bb5 Bd7 9. Be3 a6 10. Ba4 b5 11. Bb3 e6 12. Qe2 Ng4 13. O-O-O Nxe3 14. Qxe3 Qc7
+15. Rhf1 Be7 16. Ng5 Qe5 17. Qxe5 Nxe5 18. Nxf7 Nxf7 19. Rxd7 Kxd7 20. Rxf7
+Rhg8 21. Ne4 Raf8 22. Nc5+ Kd6 23. Rxf8 Rxf8 24. Nxe6 Rf1+ 25. Kd2 Rf2+ 26. Ke3
+Rxg2 27. h3 Rh2 28. Nxg7 Rxh3+ 29. Kf4 Bf6 30. Nf5+ Kd7 31. c3 Rh2 32. Ne3 Rxb2
+33. Nd5 Bg7 34. c4 bxc4 35. Bxc4 a5 36. Ke4 Kd6 37. Ne3 Kc5 38. Bg8 Rb4+ 39.
+Kd3 h6 40. Nc2 Rb8 41. Bb3 Rd8+ 42. Ke2 h5 43. Ne1 h4 44. Kf3 Bf6 45. Kg4 Rd4+
+46. Kh3 Bd8 47. Nf3 Rd3 48. Kg4 h3 49. Ng1 h2 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "NEKI_NOVI_KLINAC"]
+[Black "Parwis"]
+[Result "1-0"]
+[ECO "C47"]
+[WhiteElo "2443"]
+[BlackElo "2475"]
+[PlyCount "129"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 e5 2. Nf3 Nf6 3. Nc3 Nc6 4. d4 Bb4 5. dxe5 Nxe4 6. Bd2 Bxc3 7. Bxc3 Nxc3
+8. bxc3 Qe7 9. Be2 Nxe5 10. O-O d6 11. Nxe5 dxe5 12. Bf3 O-O 13. Re1 Qc5 14.
+Rb1 Rb8 15. Qd5 Qxd5 16. Bxd5 Bf5 17. Rxe5 Bxc2 18. Rxb7 Rxb7 19. Bxb7 Rb8 20.
+Re7 c5 21. h3 Kf8 22. Rc7 c4 23. Bd5 Rb1+ 24. Kh2 Bg6 25. Bxc4 Rb2 26. Rxa7
+Rxf2 27. Bd5 f5 28. c4 f4 29. c5 Rd2 30. Bf3 Rc2 31. c6 Be8 32. c7 g6 33. a4
+Bd7 34. a5 Ke7 35. a6 Kd6 36. Rb7 Ra2 37. a7 Bc8 38. Rb8 Rxa7 39. Rxc8 Rxc7 40.
+Rxc7 Kxc7 41. h4 Kd6 42. Kh3 h5 43. Be4 Ke5 44. Bxg6 f3 45. gxf3 Kf4 46. Bxh5
+Kf5 47. Bg4+ Kf6 48. Kg3 Kg6 49. Bc8 Kh6 50. Ba6 Kg7 51. Bf1 Kh6 52. Kg4 Kg7
+53. f4 Kh6 54. h5 Kg7 55. Kg5 Kf7 56. f5 Kg7 57. h6+ Kg8 58. Kg6 Kh8 59. f6 Kg8
+60. h7+ Kh8 61. Kf7 Kxh7 62. Ke7 Kg6 63. f7 Kf5 64. f8=Q+ Ke5 65. Qf6+ 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "gmmitkov"]
+[Black "Evgen_88"]
+[Result "1-0"]
+[ECO "C11"]
+[WhiteElo "2508"]
+[BlackElo "2525"]
+[PlyCount "79"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 e6 2. Nc3 d5 3. d4 Nf6 4. e5 Nfd7 5. f4 c5 6. Nf3 Nc6 7. Be3 Qb6 8. a3
+cxd4 9. Nxd4 Bc5 10. Ncb5 a6 11. b4 axb5 12. bxc5 Qa5+ 13. Bd2 Qd8 14. Nxb5 O-O
+15. Be3 f6 16. exf6 Nxf6 17. Be2 e5 18. fxe5 Ne4 19. Bf3 Qa5+ 20. c3 Nxc3 21.
+Qd2 Qxb5 22. Qxc3 d4 23. Bxd4 Nxd4 24. Qxd4 Be6 25. a4 Qa5+ 26. Kf2 Rad8 27.
+Qe3 Rd2+ 28. Kg3 Rc2 29. Rhc1 Rxc1 30. Rxc1 Qxa4 31. h3 Qb4 32. Kh2 h6 33. Qc3
+Qxc3 34. Rxc3 Rf7 35. Rd3 Rc7 36. Rd6 Bc4 37. e6 Rxc5 38. Rd8+ Kh7 39. e7 Bf7
+40. Rf8 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "lord_barre"]
+[Black "MrMania"]
+[Result "1-0"]
+[ECO "B52"]
+[WhiteElo "2408"]
+[BlackElo "2386"]
+[PlyCount "107"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 c5 2. Nf3 d6 3. Bb5+ Bd7 4. Bxd7+ Nxd7 5. c4 Ngf6 6. Nc3 g6 7. O-O Bg7 8.
+d3 O-O 9. Ng5 h6 10. Nh3 Rb8 11. f4 a6 12. a4 e6 13. Nf2 d5 14. e5 Ne8 15. Qf3
+dxc4 16. dxc4 Qc7 17. Be3 Rd8 18. Rad1 Nb8 19. Nce4 b6 20. a5 Rxd1 21. Rxd1
+bxa5 22. Bxc5 Nc6 23. Bxf8 Bxf8 24. c5 Nb4 25. Qe3 Nd5 26. Qc1 a4 27. Nd6 Ng7
+28. Nfe4 Nf5 29. Rxd5 exd5 30. Nf6+ Kh8 31. Nxd5 Qa5 32. Nxf7+ Kg8 33. Nd6 Nd4
+34. Nf6+ Kg7 35. Qd1 Qxc5 36. Kh1 Bxd6 37. Ne8+ Kf7 38. Nxd6+ Ke6 39. Ne4 Qb5
+40. Qg4+ Kd5 41. Nc3+ Kc4 42. Nxb5 axb5 43. e6 b4 44. e7 a3 45. bxa3 bxa3 46.
+e8=Q a2 47. Qa4+ Kd3 48. Qgd1+ Ke4 49. Qdxd4+ Kf5 50. Qe5+ Kg4 51. Qd1+ Kh4 52.
+g3+ Kh3 53. Qeh5+ gxh5 54. Qxh5# 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "iCe_eNerGyTeaM"]
+[Black "metalkingGT"]
+[Result "1-0"]
+[ECO "B06"]
+[WhiteElo "2548"]
+[BlackElo "2469"]
+[PlyCount "57"]
+[EventDate "2020.??.??"]
+
+1. Nf3 g6 2. d4 Bg7 3. Nc3 d6 4. e4 Nd7 5. Be2 e5 6. dxe5 Nxe5 7. Nxe5 Bxe5 8.
+Be3 Bg7 9. Bd4 Nf6 10. Qd2 O-O 11. O-O-O Qe7 12. f3 Be6 13. Rhe1 Nd7 14. Bb5
+Ne5 15. Ba4 a6 16. Bb3 Nc4 17. Bxc4 Bxc4 18. Bxg7 Kxg7 19. Qd4+ Kg8 20. Qxc4
+Qg5+ 21. Kb1 Qxg2 22. Nd5 Qxf3 23. Rf1 Qh3 24. Nf6+ Kh8 25. Qd4 c5 26. Qxd6
+Rad8 27. Qxc5 Rxd1+ 28. Rxd1 Qf3 29. Qxf8# 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "RaylessStarfish"]
+[Black "redbullet64"]
+[Result "1-0"]
+[ECO "E09"]
+[WhiteElo "2398"]
+[BlackElo "2399"]
+[PlyCount "49"]
+[EventDate "2020.??.??"]
+
+1. c4 Nf6 2. g3 e6 3. Bg2 d5 4. Nf3 c6 5. O-O Be7 6. Qc2 O-O 7. d4 Nbd7 8. Nbd2
+b6 9. b3 Bb7 10. Bb2 Rc8 11. Rac1 c5 12. Qb1 cxd4 13. Nxd4 e5 14. Nf5 Bb4 15.
+Rfd1 e4 16. a3 Bxd2 17. Rxd2 g6 18. Nd6 e3 19. fxe3 Ba8 20. Nxc8 Qxc8 21. cxd5
+Qa6 22. Rc6 Bxc6 23. dxc6 Ng4 24. cxd7 Nxe3 25. d8=Q 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "El-Camino12"]
+[Black "corwinifred"]
+[Result "0-1"]
+[ECO "B40"]
+[WhiteElo "2405"]
+[BlackElo "2300"]
+[PlyCount "54"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 c5 2. Nf3 e6 3. b3 d6 4. Bb2 Nc6 5. Bd3 Nf6 6. O-O Be7 7. Re1 O-O 8. e5
+dxe5 9. Nxe5 Nxe5 10. Bxe5 b6 11. Nc3 Bb7 12. Qe2 Nd7 13. Bxh7+ Kxh7 14. Qh5+
+Kg8 15. Bxg7 Kxg7 16. Re3 Bg5 17. Rg3 f6 18. h4 Rh8 19. Qg4 Ne5 20. Qxe6 Rxh4
+21. Re1 Nf7 22. Qf5 Qh8 23. f3 Rh1+ 24. Kf2 Rxe1 25. Kxe1 Qh4 26. Kf2 Rd8 27.
+d3 Qd4+ 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Maybach77"]
+[Black "Dynamovec"]
+[Result "1-0"]
+[ECO "B32"]
+[WhiteElo "2369"]
+[BlackElo "2405"]
+[PlyCount "49"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 c5 2. Nf3 Nc6 3. d4 cxd4 4. Nxd4 e5 5. Nb5 Nf6 6. N1c3 d6 7. Bg5 a6 8.
+Bxf6 gxf6 9. Na3 f5 10. Bd3 f4 11. Qh5 b5 12. Naxb5 axb5 13. Bxb5 Bd7 14. O-O-O
+Nd4 15. Bc4 Be6 16. Rxd4 exd4 17. Bxe6 Qc7 18. Nd5 Qa7 19. Bxf7+ Kd8 20. Qg5+
+Be7 21. Qg7 Rf8 22. Rd1 Qxa2 23. Be6 Qa1+ 24. Kd2 Qa7 25. Ra1 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "drop_stone"]
+[Black "C9C9C9C9C9"]
+[Result "1-0"]
+[ECO "A40"]
+[WhiteElo "2911"]
+[BlackElo "2999"]
+[PlyCount "41"]
+[EventDate "2020.??.??"]
+
+1. d4 b6 2. e4 Bb7 3. Nc3 e6 4. Bd3 Nf6 5. a3 c5 6. d5 exd5 7. exd5 Nxd5 8. Qf3
+Qf6 9. Be4 Nc6 10. Nxd5 Qe5 11. Bf4 Qxb2 12. Rd1 O-O-O 13. Ne2 Re8 14. O-O g6
+15. Nec3 f5 16. Bd3 Nd4 17. Qg3 Bg7 18. Bb8 Ne6 19. Rfe1 Bxc3 20. Rxe6 Bxd5 21.
+Qc7# 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Training88"]
+[Black "azolot"]
+[Result "1/2-1/2"]
+[ECO "A00"]
+[WhiteElo "2316"]
+[BlackElo "2308"]
+[PlyCount "81"]
+[EventDate "2020.??.??"]
+
+1. b4 d6 2. Bb2 Nf6 3. b5 e5 4. a4 Nbd7 5. e3 Be7 6. Nf3 O-O 7. Be2 c6 8. O-O
+cxb5 9. axb5 a5 10. d4 e4 11. Nfd2 d5 12. c4 dxc4 13. Nc3 b6 14. Ndxe4 Bb7 15.
+Nxf6+ Nxf6 16. Bxc4 Rc8 17. Bd3 Nd5 18. Nxd5 Qxd5 19. f3 Bf6 20. Be4 Qd7 21.
+Bxb7 Qxb7 22. Qb3 Rfd8 23. Rac1 Rxc1 24. Rxc1 Qe7 25. Rc6 h6 26. Ba3 Qb7 27.
+Bd6 Qa7 28. Rc7 Qa8 29. Qxf7+ Kh8 30. Be7 Bxe7 31. Rxe7 Rg8 32. Rb7 a4 33. Ra7
+Qc8 34. Qa2 Qc1+ 35. Kf2 Re8 36. Rxa4 Qxe3+ 37. Kg3 Qg5+ 38. Kf2 Qe3+ 39. Kg3
+Qg5+ 40. Kh3 Qe3 41. Kg3 1/2-1/2
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "vassiukov"]
+[Black "Lil_D"]
+[Result "0-1"]
+[ECO "A40"]
+[WhiteElo "2341"]
+[BlackElo "2306"]
+[PlyCount "58"]
+[EventDate "2020.??.??"]
+
+1. d4 g6 2. Nf3 Bg7 3. Bf4 d6 4. e3 Nf6 5. h3 O-O 6. Nbd2 Nc6 7. c3 Nd7 8. Be2
+e5 9. dxe5 dxe5 10. Bh2 a5 11. a4 Qe7 12. O-O Nc5 13. Qc2 Bf5 14. e4 Be6 15.
+Nc4 Bc8 16. Rfe1 b6 17. Ne3 Bb7 18. Nd5 Qd8 19. Rad1 Qc8 20. Bb5 Kh8 21. Bxc6
+Bxc6 22. Nxe5 Bxa4 23. Qe2 Bxd1 24. Rxd1 a4 25. Qf3 a3 26. Nxf7+ Rxf7 27. Qxf7
+axb2 28. Nf6 Ra1 29. Qd5 Bxf6 0-1
+
+[Event "Rated Blitz tournament OxRShNHO"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Lioni26"]
+[Black "FanDeGranda"]
+[Result "0-1"]
+[ECO "B30"]
+[WhiteElo "2392"]
+[BlackElo "2360"]
+[PlyCount "74"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 c5 2. Nf3 Nc6 3. b4 Nxb4 4. c3 Nc6 5. d4 cxd4 6. cxd4 g6 7. Bc4 Bg7 8.
+Bb2 d6 9. Qb3 e6 10. d5 Na5 11. Bb5+ Kf8 12. Bxg7+ Kxg7 13. Qc3+ e5 14. O-O a6
+15. Bd3 Nf6 16. Nbd2 b5 17. a4 Bd7 18. axb5 axb5 19. Qb4 Qb6 20. Rfb1 Rhb8 21.
+h3 Nh5 22. Bf1 Nf4 23. Rc1 Ra7 24. Nb1 Rba8 25. Nc3 Nb7 26. Rxa7 Rxa7 27. Bxb5
+Nc5 28. Rb1 Rb7 29. Qa3 Qc7 30. Bxd7 Rxb1+ 31. Nxb1 Qxd7 32. Nc3 Qb7 33. Nxe5
+Nxe4 34. Nxe4 dxe5 35. Qd6 Qxd5 36. Qf6+ Kg8 37. Nd6 Qxg2# 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "troisi"]
+[Black "BreatEastonEllis"]
+[Result "1-0"]
+[ECO "E90"]
+[WhiteElo "2387"]
+[BlackElo "2507"]
+[PlyCount "51"]
+[EventDate "2020.??.??"]
+
+1. d4 Nf6 2. c4 g6 3. Nc3 Bg7 4. Nf3 d6 5. e4 O-O 6. Bd3 e5 7. h3 Nc6 8. d5 Ne7
+9. O-O Nh5 10. Be3 Nf4 11. Bxf4 exf4 12. Re1 f5 13. e5 dxe5 14. Nxe5 g5 15. Qh5
+Bf6 16. g4 fxg3 17. fxg3 Qd6 18. Ng4 Qxg3+ 19. Kh1 Qxd3 20. Nxf6+ Rxf6 21. Rxe7
+f4 22. Qxg5+ Rg6 23. Re8+ Kg7 24. Qe5+ Kh6 25. Qxf4+ Kg7 26. Qf8# 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Glig"]
+[Black "camilomunoz0107"]
+[Result "1/2-1/2"]
+[ECO "C43"]
+[WhiteElo "2453"]
+[BlackElo "2363"]
+[PlyCount "145"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 e5 2. Nf3 Nf6 3. d4 Nxe4 4. Bd3 d5 5. Nxe5 Nd7 6. Nd2 Nxe5 7. dxe5 Nc5 8.
+Be2 Be7 9. O-O O-O 10. h3 f5 11. Nf3 Ne6 12. c3 c6 13. Re1 b6 14. Bd3 c5 15.
+Bc2 Bb7 16. Bb3 Kh8 17. Bd2 Qd7 18. a4 a5 19. Qe2 Rad8 20. Rad1 Qc7 21. Bc1 Bc6
+22. h4 h6 23. h5 Qb7 24. Nh2 Bg5 25. Nf3 Bxc1 26. Rxc1 Qe7 27. g3 Be8 28. Nh4
+Ng5 29. Rcd1 c4 30. Bc2 Ne4 31. Bxe4 fxe4 32. Qg4 Qxe5 33. Ng6+ Bxg6 34. Qxg6
+Rf6 35. Qg4 Rdf8 36. Re2 Rf5 37. Qg6 Rg5 38. Qxb6 Rxh5 39. Qd4 Qg5 40. Qe3 Qg4
+41. f4 exf3 42. Rg2 Rh3 43. Rf1 Rf6 44. Qe8+ Kh7 45. Rxf3 Qxf3 46. Qe1 Rxg3 47.
+Rxg3 Qf4 48. Kg2 Qf5 49. Kg1 Rg6 50. Rxg6 Qxg6+ 51. Kf2 Qe4 52. Qd2 Qf5+ 53.
+Kg1 h5 54. Qd4 Qg4+ 55. Qxg4 hxg4 56. Kg2 Kg6 57. Kf2 Kf5 58. Kg3 g5 59. Kg2
+Kf4 60. Kf2 Ke4 61. Kg3 Kd3 62. Kxg4 Kc2 63. Kxg5 Kxb2 64. Kf4 Kxc3 65. Ke5 Kb3
+66. Kxd5 Kxa4 67. Kxc4 Ka3 68. Kc3 a4 69. Kc2 Ka2 70. Kc1 Ka1 71. Kc2 a3 72.
+Kc1 a2 73. Kc2 1/2-1/2
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "hawth0rne"]
+[Black "hungzhao"]
+[Result "0-1"]
+[ECO "A40"]
+[WhiteElo "2455"]
+[BlackElo "2631"]
+[PlyCount "42"]
+[EventDate "2020.??.??"]
+
+1. d4 e6 2. Bg5 Qxg5 3. Nf3 Qd8 4. e3 Nf6 5. Bd3 b6 6. O-O Bb7 7. Nbd2 d6 8. e4
+Nbd7 9. e5 dxe5 10. dxe5 Nd5 11. Qe2 Nf4 12. Qe3 Nxd3 13. cxd3 Bc5 14. d4 Be7
+15. Qf4 Nf8 16. h4 Ng6 17. Qg4 Bxh4 18. Rac1 Be7 19. g3 h5 20. Qh3 Qd5 21. Rc3
+c5 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "pmlmail"]
+[Black "murderoflegends"]
+[Result "0-1"]
+[ECO "D13"]
+[WhiteElo "2411"]
+[BlackElo "2419"]
+[PlyCount "52"]
+[EventDate "2020.??.??"]
+
+1. d4 d5 2. Nf3 c6 3. c4 Nf6 4. cxd5 cxd5 5. Nc3 Bf5 6. Nh4 Bg6 7. Nxg6 hxg6 8.
+Bf4 e6 9. e3 Bd6 10. Bb5+ Nc6 11. Qa4 O-O 12. Bxc6 bxc6 13. Qxc6 Bxf4 14. exf4
+Rb8 15. Rb1 Qa5 16. O-O Rfc8 17. Qa4 Qxa4 18. Nxa4 Rc4 19. b3 Rxd4 20. g3 Ne4
+21. Rbc1 Rd2 22. Ra1 Rc8 23. Kg2 Rcc2 24. a3 Nxf2 25. Rxf2 Rxf2+ 26. Kg1 Rxh2
+0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "CheKarloz"]
+[Black "Pirocanac91"]
+[Result "0-1"]
+[ECO "B18"]
+[WhiteElo "2340"]
+[BlackElo "2324"]
+[PlyCount "82"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 c6 2. d4 d5 3. Nc3 dxe4 4. Nxe4 Bf5 5. Ng3 Bg6 6. f4 e6 7. Nf3 Nd7 8. Bd3
+Ngf6 9. O-O Be7 10. Be3 O-O 11. Ne5 Nxe5 12. fxe5 Nd5 13. Bxg6 Nxe3 14. Qd3
+hxg6 15. Qxe3 c5 16. dxc5 Qa5 17. Ne4 Rac8 18. Kh1 Bxc5 19. Qh3 Be7 20. c3 Qxe5
+21. Rae1 Qh5 22. Qe3 b6 23. Rf3 Bc5 24. Qf4 e5 25. Qc1 f5 26. Ng3 Qh6 27. Qxh6
+gxh6 28. Rxe5 Rce8 29. Rxe8 Rxe8 30. Rf1 h5 31. Rd1 h4 32. Nf1 Re2 33. Rb1 Kf7
+34. h3 g5 35. b4 Bd6 36. a4 g4 37. c4 gxh3 38. gxh3 Re4 39. Nd2 Re3 40. Rg1
+Rxh3+ 41. Kg2 Rg3+ 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "alireza3700"]
+[Black "Gambitopy"]
+[Result "0-1"]
+[ECO "B07"]
+[WhiteElo "2328"]
+[BlackElo "2309"]
+[PlyCount "70"]
+[EventDate "2020.??.??"]
+
+1. d4 d6 2. Nc3 Nf6 3. e4 g6 4. Be3 Bg7 5. f3 O-O 6. Qd2 Nc6 7. O-O-O e5 8. d5
+Nd4 9. Nge2 Nxe2+ 10. Bxe2 h5 11. Bh6 Bd7 12. Bxg7 Kxg7 13. g4 h4 14. f4 exf4
+15. Qxf4 Qe7 16. g5 Nh7 17. Qxh4 Qxg5+ 18. Qxg5 Nxg5 19. h4 Nh3 20. Rdf1 Rh8
+21. h5 g5 22. Rf2 Nxf2 23. Rf1 Ng4 24. Rg1 Ne5 25. Rxg5+ Kf6 26. Rg1 Rag8 27.
+Rf1+ Ke7 28. a4 Rg2 29. Bb5 Bxb5 30. Nxb5 Rxh5 31. Nxc7 Rhh2 32. Kb1 Rxc2 33.
+Nb5 Rxb2+ 34. Kc1 Nd3+ 35. Kd1 Rhd2# 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "RyanX4FleteChavale"]
+[Black "Jupiter435"]
+[Result "0-1"]
+[ECO "A04"]
+[WhiteElo "2382"]
+[BlackElo "2469"]
+[PlyCount "12"]
+[EventDate "2020.??.??"]
+
+1. Nf3 c5 2. c3 d6 3. Ne5 dxe5 4. e4 Nc6 5. Bc4 Nf6 6. Qh5 Nxh5 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "taras05"]
+[Black "lewisbort"]
+[Result "1-0"]
+[ECO "B06"]
+[WhiteElo "2495"]
+[BlackElo "2370"]
+[PlyCount "95"]
+[EventDate "2020.??.??"]
+
+1. e4 d6 2. d4 g6 3. Nc3 Bg7 4. g3 Nd7 5. Bg2 e5 6. Nge2 Ne7 7. Be3 O-O 8. O-O
+exd4 9. Nxd4 Ne5 10. b3 N5c6 11. f4 Nxd4 12. Bxd4 Nc6 13. Bxg7 Kxg7 14. Nd5 Re8
+15. f5 Ne5 16. Qd2 Rf8 17. f6+ Kh8 18. Qh6 Rg8 19. Ne7 Ng4 20. Qd2 Re8 21. h3
+Nxf6 22. Rxf6 Qxe7 23. Qc3 Qe5 24. Qxe5 Rxe5 25. Rxf7 Be6 26. Rxc7 b6 27. Rf1
+Rc5 28. c4 Rxc7 29. Re1 Re7 30. e5 d5 31. cxd5 Bf5 32. d6 Ree8 33. Bxa8 Rxa8
+34. g4 Be6 35. Kf2 Rd8 36. Ke3 Rd7 37. Rf1 Kg8 38. Rf6 Rxd6 39. exd6 Bd7 40.
+Kd4 Kg7 41. Ke5 g5 42. Re6 h6 43. Re7+ Kf8 44. Rxd7 Ke8 45. Re7+ Kd8 46. Ke6 b5
+47. Rf7 b4 48. Rf8# 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "sutcunuri"]
+[Black "ajedrez2021"]
+[Result "1/2-1/2"]
+[ECO "B06"]
+[WhiteElo "2515"]
+[BlackElo "2598"]
+[PlyCount "96"]
+[EventDate "2020.??.??"]
+
+1. e4 g6 2. h4 Bg7 3. h5 c5 4. Nc3 Nc6 5. Bc4 e6 6. d3 Nge7 7. h6 Bxc3+ 8. bxc3
+O-O 9. Bg5 d5 10. Bb3 f6 11. Be3 b6 12. Nf3 Kh8 13. exd5 exd5 14. O-O Bg4 15.
+Re1 Qd7 16. a4 Rae8 17. a5 Nf5 18. axb6 axb6 19. Ba4 g5 20. Bd2 Nxh6 21. Rxe8
+Rxe8 22. Bxc6 Qxc6 23. Ra7 Qe6 24. Qe1 Bxf3 25. Qxe6 Rxe6 26. gxf3 Kg8 27. Be3
+Nf5 28. Rb7 Nxe3 29. fxe3 Rxe3 30. Rxb6 Rxf3 31. Rc6 Rf4 32. Rxc5 h5 33. Rxd5
+h4 34. Rd4 Kg7 35. Rxf4 gxf4 36. c4 Kf7 37. c5 Ke7 38. d4 Kd7 39. c4 f5 40. Kg2
+Kc6 41. d5+ Kxc5 42. Kf3 Kd6 43. Kf2 Kc5 44. Kf3 h3 45. Kf2 Kd6 46. Kf3 Kc5 47.
+Kf2 Kd6 48. Kf3 Kc5 1/2-1/2
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Molot_ua"]
+[Black "metalkingGT"]
+[Result "1-0"]
+[ECO "A00"]
+[WhiteElo "2374"]
+[BlackElo "2465"]
+[PlyCount "77"]
+[EventDate "2020.??.??"]
+
+1. d3 g6 2. c3 Bg7 3. Nd2 c5 4. h3 Nc6 5. g4 e5 6. Bg2 Nge7 7. Nf1 d5 8. Ng3
+O-O 9. Nf3 f5 10. gxf5 gxf5 11. Nh5 f4 12. Rg1 Nf5 13. Qb3 Kh8 14. Nxg7 Nxg7
+15. e4 fxe3 16. Bxe3 b6 17. Bh6 Be6 18. Ng5 Qf6 19. Bxg7+ Kxg7 20. Nxe6+ Kh8
+21. Nxf8 Rxf8 22. O-O-O Qf4+ 23. Kb1 c4 24. dxc4 dxc4 25. Qc2 Na5 26. Qe2 Rg8
+27. Be4 Nb3 28. Rxg8+ Kxg8 29. axb3 cxb3 30. Bd5+ Kf8 31. Bxb3 Ke7 32. Qe3 Qf5+
+33. Bc2 Qf6 34. Re1 Kd6 35. Qd3+ Kc7 36. Rd1 Qe7 37. Qc4+ Kb7 38. Be4+ Kb8 39.
+Rg1 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "redbullet64"]
+[Black "Donald666Trump"]
+[Result "1/2-1/2"]
+[ECO "B21"]
+[WhiteElo "2393"]
+[BlackElo "2382"]
+[PlyCount "133"]
+[EventDate "2020.??.??"]
+
+1. e4 c5 2. d4 g6 3. c3 cxd4 4. Nf3 Bg7 5. cxd4 d5 6. Nc3 dxe4 7. Nxe4 Nd7 8.
+Be2 Ngf6 9. Nxf6+ Nxf6 10. O-O O-O 11. Be3 b6 12. Qd2 Bb7 13. Rac1 Ne4 14. Qd3
+Nd6 15. Rfe1 Qd7 16. Qd2 Rac8 17. Bh6 Rxc1 18. Rxc1 Rc8 19. Ne5 Qe6 20. Bg4 f5
+21. Bf3 Bxf3 22. Nxf3 Rxc1+ 23. Qxc1 Bxh6 24. Qxh6 Ne4 25. h4 Qxa2 26. h5 Qf7
+27. Ne5 Qg7 28. Qf4 e6 29. h6 Qc7 30. f3 Nf6 31. Kh2 Nd7 32. Qe3 Nxe5 33. dxe5
+Qd8 34. f4 Qh4+ 35. Kg1 Qxh6 36. Qb3 Kf7 37. Qa4 Qf8 38. Qxa7+ Qe7 39. Qxb6 Qd7
+40. Qd6 Qxd6 41. exd6 Ke8 42. Kf2 Kd7 43. Ke3 Kxd6 44. Kd4 h6 45. b4 g5 46. g3
+gxf4 47. gxf4 h5 48. b5 h4 49. b6 h3 50. Ke3 h2 51. b7 Kc7 52. b8=Q+ Kxb8 53.
+Kd4 h1=Q 54. Ke5 Qe4+ 55. Kf6 Qxf4 56. Ke7 Qe4 57. Kd7 f4 58. Ke7 f3 59. Kf6 f2
+60. Ke7 Qf5 61. Kd6 e5 62. Ke7 e4 63. Kd6 e3 64. Ke7 e2 65. Kd6 Qg6+ 66. Ke7
+e1=Q+ 67. Kd8 1/2-1/2
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Jupiter435"]
+[Black "RyanX4FleteChavale"]
+[Result "0-1"]
+[ECO "B01"]
+[WhiteElo "2473"]
+[BlackElo "2378"]
+[PlyCount "84"]
+[EventDate "2020.??.??"]
+
+1. e4 d5 2. exd5 Bg4 3. Nf3 Nf6 4. Nc3 Bxf3 5. Qxf3 c6 6. dxc6 Nxc6 7. Bb5 Rc8
+8. O-O e6 9. Re1 Bd6 10. d4 Kf8 11. Bg5 h5 12. Bxc6 Rxc6 13. Rad1 Qc8 14. Bxf6
+gxf6 15. Qxf6 Rg8 16. d5 Rg6 17. Qxg6 fxg6 18. dxc6 Qxc6 19. Ne4 Bb4 20. c3 Ba5
+21. Re3 Bb6 22. Rf3+ Kg7 23. Ng5 Kh6 24. Nf7+ Kg7 25. Ne5 Qb5 26. Rf7+ Kg8 27.
+Re1 Qxb2 28. Rf6 Qxc3 29. Rxg6+ Kh7 30. Rxe6 Bxf2+ 31. Kxf2 Qc5+ 32. Re3 Qc2+
+33. Re2 Qb1 34. Re7+ Kh6 35. Re6+ Kg5 36. Rg6+ Kh4 37. g4 Kh3 38. Rg5 Qb6+ 39.
+Kf3 h4 40. Kf4 Qc6 41. Rh5 Qe4+ 42. Kxe4 b5 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "FedaMaster"]
+[Black "ditzoo"]
+[Result "1/2-1/2"]
+[ECO "B21"]
+[WhiteElo "2552"]
+[BlackElo "2420"]
+[PlyCount "171"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 c5 2. d4 cxd4 3. c3 dxc3 4. Nxc3 Nc6 5. Nf3 e6 6. Bc4 Nge7 7. Bg5 f6 8.
+Be3 Ng6 9. O-O a6 10. a3 Be7 11. b4 O-O 12. Bb3 b5 13. Nd5 exd5 14. exd5 Kh8
+15. d6 Bb7 16. dxe7 Ncxe7 17. Re1 d6 18. Nd4 Re8 19. Ne6 Qb8 20. Rc1 Nc6 21. f4
+Bc8 22. f5 Bxe6 23. Bxe6 Nge5 24. Qh5 Rf8 25. Bf4 Nd8 26. Bd5 Ra7 27. Rc3 Ndf7
+28. Rh3 h6 29. Rc3 Rc7 30. Rec1 Rxc3 31. Rxc3 Qb6+ 32. Be3 Qd8 33. Qe2 Qd7 34.
+Be6 Qb7 35. Qc2 Nc4 36. Bc1 Ng5 37. Bxg5 fxg5 38. Bxc4 bxc4 39. Rxc4 Qd5 40. h3
+Qxf5 41. Qxf5 Rxf5 42. Rc8+ Kh7 43. Ra8 Rd5 44. Rxa6 Rd1+ 45. Kf2 d5 46. Ke2
+Ra1 47. b5 Ra2+ 48. Kf3 Rb2 49. a4 h5 50. Rd6 Rb4 51. Rxd5 Rxa4 52. Rxg5 Rb4
+53. Rxh5+ Kg6 54. Rc5 Rb3+ 55. Kg4 Kh7 56. Kf4 Rb2 57. Kf5 Rxg2 58. h4 Rb2 59.
+Kg5 Rb3 60. Kg4 Rb4+ 61. Kf5 Rb1 62. Ke5 Rb2 63. Kd5 Rb3 64. Kc6 Rh3 65. b6
+Rxh4 66. b7 Rb4 67. Rb5 Rf4 68. Kd7 Rf7+ 69. Ke8 Rf6 70. b8=Q Kg6 71. Qg3+ Kh7
+72. Rh5+ Rh6 73. Rxh6+ Kxh6 74. Qh4+ Kg6 75. Kd7 Kf7 76. Kd6 g5 77. Kc7 gxh4
+78. Kb6 h3 79. Kb5 h2 80. Kc4 h1=Q 81. Kd3 Qh2 82. Kc3 Qh3+ 83. Kc4 Qh4+ 84.
+Kc5 Qg4 85. Kc6 Qf5 86. Kc7 1/2-1/2
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "BlueGreensun"]
+[Black "Kidefence"]
+[Result "0-1"]
+[ECO "B02"]
+[WhiteElo "2761"]
+[BlackElo "2706"]
+[PlyCount "34"]
+[EventDate "2020.??.??"]
+
+1. e4 Nf6 2. Nc3 d5 3. e5 Nfd7 4. d4 c5 5. Nxd5 cxd4 6. Nf3 Nc6 7. Bc4 Nb6 8.
+Nxb6 Qxb6 9. O-O e6 10. c3 dxc3 11. bxc3 Bd7 12. Bg5 Qc7 13. Rb1 Nxe5 14. Nxe5
+Qxe5 15. Rxb7 Bc6 16. Qb3 Qxg5 17. Bxe6 Qxg2# 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "C9C9C9C9C9"]
+[Black "drop_stone"]
+[Result "1/2-1/2"]
+[ECO "A13"]
+[WhiteElo "2992"]
+[BlackElo "2918"]
+[PlyCount "111"]
+[EventDate "2020.??.??"]
+
+1. Nf3 d5 2. b3 Nf6 3. Bb2 e6 4. e3 c5 5. c4 Be7 6. cxd5 exd5 7. d4 O-O 8. Be2
+Nc6 9. O-O Bg4 10. dxc5 Bxc5 11. h3 Bh5 12. Nbd2 Re8 13. a3 a6 14. b4 Ba7 15.
+Rc1 Rc8 16. Nb3 Ne4 17. Nbd4 Nxd4 18. Nxd4 Rxc1 19. Qxc1 Bxd4 20. Bxh5 Bxb2 21.
+Qxb2 Qf6 22. Qa2 g6 23. Bf3 Re5 24. Qc2 Kg7 25. Qd3 h5 26. Rd1 Rf5 27. Qd4 Qxd4
+28. Rxd4 Nf6 29. Kf1 Re5 30. Ke2 Kf8 31. g4 hxg4 32. hxg4 Ke7 33. Kd3 Ke6 34.
+Be2 Ne4 35. f4 Nf2+ 36. Kd2 Re4 37. Bf3 Rxd4+ 38. exd4 f5 39. g5 Ne4+ 40. Kc2
+b5 41. Be2 Nd6 42. Kb3 Nc4 43. a4 Kd6 44. a5 Ne3 45. Bf3 Nc4 46. Kc3 Kc6 47.
+Be2 Nd6 48. Bd3 Ne4+ 49. Kc2 Kd6 50. Kd1 Nf2+ 51. Ke2 Nxd3 52. Kxd3 Ke6 53. Ke3
+Kd6 54. Kd3 Ke6 55. Ke3 Kd6 56. Kd3 1/2-1/2
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Lawton25"]
+[Black "gaupasa"]
+[Result "1-0"]
+[ECO "B38"]
+[WhiteElo "2476"]
+[BlackElo "2333"]
+[PlyCount "109"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 c5 2. Nf3 g6 3. d4 cxd4 4. Nxd4 Nc6 5. c4 Bg7 6. Be3 Nf6 7. Nc3 d6 8. Be2
+O-O 9. f3 Bd7 10. Qd2 Nxd4 11. Bxd4 a5 12. O-O-O Bc6 13. g4 Nd7 14. Bxg7 Kxg7
+15. h4 h6 16. h5 g5 17. f4 f6 18. f5 Ne5 19. Kb1 Qb6 20. Qd4 Qxd4 21. Rxd4 Rfc8
+22. Rc1 b6 23. b3 Bb7 24. Kb2 Nc6 25. Rdd1 Ne5 26. Na4 Nd7 27. Rd4 Bc6 28. Nc3
+a4 29. b4 a3+ 30. Kb3 Ne5 31. Nd5 Bxd5 32. Rxd5 Rc7 33. Rb5 Ra6 34. Rc3 Nc6 35.
+Rd5 Ne5 36. c5 Ra8 37. cxd6 Rxc3+ 38. Kxc3 exd6 39. Rxd6 Rb8 40. Kb3 Rc8 41.
+Rxb6 Rc1 42. Rb7+ Kf8 43. b5 Re1 44. Rb8+ Ke7 45. b6 Rxe2 46. b7 Nc6 47. Rc8
+Kd7 48. Kxa3 Re3+ 49. Kb2 Re2+ 50. Kc3 Re3+ 51. Kd2 Ra3 52. Rxc6 Rxa2+ 53. Rc2
+Rxc2+ 54. Kxc2 Kc7 55. e5 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "RigelStar"]
+[Black "Caochonewell"]
+[Result "1-0"]
+[ECO "A31"]
+[WhiteElo "2389"]
+[BlackElo "2440"]
+[PlyCount "49"]
+[EventDate "2020.??.??"]
+
+1. d4 Nf6 2. Nf3 c5 3. c4 cxd4 4. Qxd4 g6 5. Qd1 Bg7 6. Nc3 O-O 7. e3 Nc6 8.
+Be2 d6 9. O-O Bg4 10. h3 Bxf3 11. Bxf3 Rc8 12. Bd2 a6 13. b3 Ne5 14. Rc1 Rb8
+15. Be2 Nc6 16. f4 Qb6 17. Kh2 Rfd8 18. Bf3 Qa7 19. Qe2 Rbc8 20. Be1 Qb8 21.
+Bf2 Nd7 22. Nd5 Nf6 23. e4 Nxd5 24. exd5 Na5 25. Bb6 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "estocastico"]
+[Black "cmvaracalov"]
+[Result "0-1"]
+[ECO "C10"]
+[WhiteElo "2567"]
+[BlackElo "2397"]
+[PlyCount "56"]
+[EventDate "2020.??.??"]
+
+1. e4 e6 2. d4 d5 3. Nc3 dxe4 4. Nxe4 Bd7 5. Nf3 Bc6 6. Ng3 Nd7 7. Bd3 Ngf6 8.
+b3 Be7 9. Bb2 Bxf3 10. Qxf3 c6 11. O-O-O O-O 12. h4 a5 13. a4 b5 14. Qxc6 bxa4
+15. Qxa4 Nb6 16. Qb5 a4 17. Kd2 axb3 18. cxb3 Nfd5 19. Ra1 Bb4+ 20. Ke2 Qf6 21.
+Ne4 Qf4 22. g3 Qg4+ 23. f3 Qg6 24. h5 Qh6 25. Rxa8 Qe3+ 26. Kf1 Qxf3+ 27. Nf2
+Ne3+ 28. Kg1 Qg2# 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "hungzhao"]
+[Black "Betovsky"]
+[Result "0-1"]
+[ECO "B01"]
+[WhiteElo "2634"]
+[BlackElo "2616"]
+[PlyCount "70"]
+[EventDate "2020.??.??"]
+
+1. e4 d5 2. exd5 Nf6 3. Nc3 Nxd5 4. Nf3 Nxc3 5. bxc3 Bf5 6. g3 e6 7. Bg2 c6 8.
+d3 Be7 9. Rb1 O-O 10. Rxb7 Nd7 11. O-O Bf6 12. Rb1 Bxc3 13. Ba3 Re8 14. Rb3 Bf6
+15. Qe2 Rc8 16. Rfb1 Nb6 17. Ne5 Nd5 18. Nc4 Nc3 19. Rxc3 Bxc3 20. Nd6 Qa5 21.
+Nxe8 Qxa3 22. Bxc6 Rxc6 23. Rb8 Qf8 24. g4 Bg6 25. h4 h6 26. h5 Bh7 27. Qf3 Rb6
+28. Ra8 Be5 29. d4 Bb8 30. c4 Qxe8 31. c5 Rb1+ 32. Kg2 Re1 33. Kh3 Be4 34. Rxb8
+Qxb8 35. Qg3 Rh1+ 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "AGG2020"]
+[Black "Mia_Khaliffa"]
+[Result "1-0"]
+[ECO "C45"]
+[WhiteElo "2477"]
+[BlackElo "2433"]
+[PlyCount "81"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 e5 2. Nf3 Nc6 3. d4 exd4 4. Nxd4 Bc5 5. Nb3 Bb6 6. Qe2 d6 7. Be3 Nge7 8.
+Nc3 O-O 9. O-O-O f5 10. g3 fxe4 11. Nxe4 Bf5 12. Bg2 Qe8 13. Kb1 h6 14. Rhe1
+Qf7 15. f4 Bxe4 16. Bxe4 Rfe8 17. Bxb6 axb6 18. Qd2 Kh8 19. a3 Rad8 20. Nd4 d5
+21. Bg2 Nxd4 22. Qxd4 c5 23. Qa4 Nc6 24. Qb5 Rxe1 25. Rxe1 Qc7 26. Rd1 Nd4 27.
+Qd3 b5 28. c3 Nb3 29. Qxb5 c4 30. Ka2 d4 31. cxd4 Rxd4 32. Qe8+ Kh7 33. Be4+
+Rxe4 34. Qxe4+ Kh8 35. Qe8+ Kh7 36. Rd7 Qc6 37. Qf7 Qg6 38. Qxg6+ Kxg6 39. Rxb7
+h5 40. Rxb3 cxb3+ 41. Kxb3 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Rookdom"]
+[Black "Cebuanochessking"]
+[Result "0-1"]
+[ECO "E73"]
+[WhiteElo "2432"]
+[BlackElo "2409"]
+[PlyCount "76"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. c4 Nf6 2. Nc3 g6 3. e4 Bg7 4. d4 d6 5. Be2 O-O 6. Bg5 h6 7. Be3 e5 8. d5 a5
+9. Qd2 h5 10. h3 h4 11. Bg5 Nbd7 12. Bxh4 Qe8 13. g4 Nc5 14. f3 Bd7 15. Bf2 a4
+16. h4 c6 17. h5 Nh7 18. hxg6 fxg6 19. dxc6 Bxc6 20. Qxd6 Ne6 21. O-O-O Nd4 22.
+Nd5 Bxd5 23. Qxd5+ Rf7 24. Bxd4 exd4 25. c5 Rd8 26. Qc4 a3 27. Qb3 axb2+ 28.
+Kb1 d3 29. Rxd3 Rxd3 30. Bxd3 Kh8 31. Bc4 Rd7 32. Bb5 Qe7 33. Bxd7 Qxd7 34. Ne2
+Qd2 35. Nf4 Qxf4 36. Qxb7 Bh6 37. Qc8+ Nf8 38. Rxh6+ Qxh6 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Kelevra90"]
+[Black "CcJBerserkTout"]
+[Result "0-1"]
+[ECO "C42"]
+[WhiteElo "2460"]
+[BlackElo "2542"]
+[PlyCount "120"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 e5 2. Nf3 Nf6 3. Nxe5 d6 4. Nf3 Nxe4 5. d4 d5 6. Bd3 Be7 7. O-O Nc6 8. c4
+Nb4 9. cxd5 Nxd3 10. Qxd3 Qxd5 11. Re1 Bf5 12. g4 Bg6 13. Nc3 Nxc3 14. Qxc3 Qd7
+15. Ne5 Qd8 16. Qe3 Qd6 17. Bd2 Qe6 18. d5 Qf6 19. g5 Qd6 20. Nc4 Qd7 21. Bb4
+O-O 22. Ne5 Qd8 23. Bxe7 Qxe7 24. Nxg6 Qxe3 25. Rxe3 hxg6 26. Re7 Rac8 27. Rc1
+Rfd8 28. Rcxc7 Rxc7 29. Rxc7 Rxd5 30. Rxb7 Rxg5+ 31. Kf1 a5 32. b4 Rf5 33. b5
+a4 34. b6 Rb5 35. Ra7 Rxb6 36. Rxa4 f6 37. Ra7 g5 38. Kg2 Kh7 39. Kf3 Kg6 40.
+a4 Rb3+ 41. Kg2 Ra3 42. a5 Kf5 43. a6 g6 44. Ra8 Kf4 45. h3 f5 46. a7 Ra2 47.
+Kg1 Kf3 48. Rg8 Ra1+ 49. Kh2 Rxa7 50. Rxg6 Kxf2 51. Rxg5 f4 52. h4 f3 53. Kh3
+Ra1 54. Rf5 Rh1+ 55. Kg4 Rg1+ 56. Kf4 Rg3 57. h5 Rh3 58. Rg5 Ke2 59. Ke4 f2 60.
+Rg2 Ke1 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Elhlwagy11"]
+[Black "BillyLaimbeer"]
+[Result "0-1"]
+[ECO "B15"]
+[WhiteElo "2311"]
+[BlackElo "2373"]
+[PlyCount "126"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 c6 2. Nc3 d5 3. e4 dxe4 4. Nxe4 Nf6 5. Ng5 h6 6. Nxf7 Kxf7 7. Nf3 Bf5 8.
+Bc4+ e6 9. Ne5+ Ke8 10. g4 Bh7 11. Bxe6 Qa5+ 12. c3 Nbd7 13. Nc4 Qc7 14. Qe2
+Be7 15. f4 Kd8 16. Bd2 Nd5 17. Bxd7 Kxd7 18. O-O-O Bf6 19. Ne5+ Bxe5 20. dxe5
+Ke8 21. c4 Ne7 22. f5 Rd8 23. Bf4 Qa5 24. a3 Qa4 25. f6 gxf6 26. exf6 Rxd1+ 27.
+Rxd1 Qc2+ 28. Qxc2 Bxc2 29. Kxc2 Ng6 30. Be3 Kf7 31. Rd7+ Ke6 32. Rxb7 Rd8 33.
+Bxh6 Kxf6 34. Rxa7 Ke6 35. a4 Ne5 36. g5 Nxc4 37. g6 Rg8 38. Bg7 Ne3+ 39. Kd3
+Nf5 40. Bc3 Rxg6 41. Rc7 Kd5 42. Rd7+ Kc5 43. b4+ Kb6 44. Bd4+ Nxd4 45. Rxd4
+Rg2 46. h4 Rh2 47. Kc4 Rh3 48. a5+ Ka6 49. Rg4 Rh1 50. Kc5 Rc1+ 51. Kd6 Kb5 52.
+Kc7 Rd1 53. h5 Re1 54. h6 Re7+ 55. Kd6 Rh7 56. Rg5+ Kxb4 57. Rg6 c5 58. Kc6 c4
+59. a6 c3 60. Kb6 c2 61. Rc6 Rxh6 62. Rxh6 c1=Q 63. a7 Qc5+ 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Aisen_Mestnikov"]
+[Black "BerserkAdopter"]
+[Result "0-1"]
+[ECO "E90"]
+[WhiteElo "2402"]
+[BlackElo "2447"]
+[PlyCount "44"]
+[EventDate "2020.??.??"]
+
+1. d4 Nf6 2. c4 g6 3. Nf3 Bg7 4. Nc3 d6 5. e4 Nbd7 6. Be2 e5 7. d5 Nc5 8. O-O
+Ncxe4 9. Nxe4 Nxe4 10. Bd3 Nc5 11. b4 Nxd3 12. Qxd3 O-O 13. Rb1 Bf5 14. Qb3
+Bxb1 15. Qxb1 h6 16. c5 a5 17. a3 axb4 18. axb4 Qf6 19. Nd2 Ra4 20. Ne4 Qf5 21.
+cxd6 cxd6 22. Nxd6 Qxb1 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "murderoflegends"]
+[Black "pmlmail"]
+[Result "1/2-1/2"]
+[ECO "A45"]
+[WhiteElo "2425"]
+[BlackElo "2405"]
+[PlyCount "124"]
+[EventDate "2020.??.??"]
+
+1. d4 Nf6 2. c3 g6 3. Nf3 Bg7 4. Bg5 O-O 5. e3 Ne4 6. Bh4 c5 7. Bd3 Nf6 8. Qc2
+cxd4 9. exd4 Nc6 10. Nbd2 d6 11. O-O Bg4 12. Rfe1 Re8 13. h3 Bxf3 14. Nxf3 Qa5
+15. a3 e5 16. dxe5 dxe5 17. Rad1 Rac8 18. Qb1 Qb6 19. Bc4 e4 20. Ng5 Rf8 21.
+Qa2 Ne5 22. Bb3 Rc7 23. Bg3 Re7 24. Bxe5 Rxe5 25. Nxf7 Rxf7 26. Bxf7+ Kh8 27.
+Bc4 Rf5 28. Rf1 h5 29. Qb3 Kh7 30. Qxb6 axb6 31. Rd6 b5 32. Be6 Re5 33. Rb6 Ne8
+34. Bb3 Re7 35. Rd1 Nd6 36. Rdxd6 Be5 37. Rxg6 Rd7 38. g3 Rd2 39. Rge6 Bg7 40.
+Rxb7 Rxb2 41. Ree7 Rxb3 42. Rxg7+ Kh6 43. Kg2 Rxc3 44. h4 Rf3 45. Rg5 Rf6 46.
+Rb8 b4 47. Rbb5 Kh7 48. axb4 Rh6 49. Rxh5 Rxh5 50. Rxh5+ Kg6 51. Re5 Kf6 52.
+Rxe4 Kf5 53. Re3 Kf6 54. b5 Kf5 55. b6 Kf6 56. b7 Kf5 57. Kf3 Kf6 58. Re4 Kg7
+59. g4 Kg6 60. Kf4 Kf6 61. h5 Kf7 62. b8=Q Kf6 1/2-1/2
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Phoenix-20"]
+[Black "mixo23"]
+[Result "1-0"]
+[ECO "A60"]
+[WhiteElo "2483"]
+[BlackElo "2422"]
+[PlyCount "161"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 e6 2. c4 c5 3. d5 exd5 4. cxd5 Nf6 5. Nc3 Bd6 6. Nf3 Bc7 7. e4 d6 8. Bd3
+O-O 9. O-O a6 10. a4 Nbd7 11. Bf4 Re8 12. h3 Rb8 13. Qe2 Nf8 14. Rfe1 Ng6 15.
+Bh2 Bd7 16. Qc2 b5 17. axb5 axb5 18. b3 Nh5 19. Ne2 Qf6 20. Ra7 Rbc8 21. Rea1
+Bb6 22. R7a6 Rb8 23. Ng3 Nxg3 24. Bxg3 Bxh3 25. Bxb5 Red8 26. Bc4 Bg4 27. Nh2
+Bc8 28. R6a2 h5 29. f3 h4 30. Be1 Nf4 31. Bc3 Qg5 32. Kh1 Bd7 33. Ra6 Bc8 34.
+Ra8 Bb7 35. Rxb8 Rxb8 36. Qf2 Bc8 37. Bd2 Qf6 38. Rf1 Ra8 39. Re1 Ra2 40. Qe3
+g5 41. Qc3 Qxc3 42. Bxc3 Ba5 43. Bxa5 Rxa5 44. Nf1 f6 45. Ne3 Kf7 46. Rc1 Ke7
+47. Rc2 Bd7 48. Kg1 Kd8 49. Kf2 Kc7 50. g3 hxg3+ 51. Kxg3 Ra1 52. Ng2 Ng6 53.
+f4 gxf4+ 54. Nxf4 Nxf4 55. Kxf4 Re1 56. Kf3 f5 57. exf5 Re5 58. Kf4 Rxf5+ 59.
+Ke3 Re5+ 60. Kd3 Bf5+ 61. Kc3 Bxc2 62. Kxc2 Re4 63. Kc3 Rd4 64. Kc2 Kd7 65. Kc3
+Ke7 66. Kc2 Kf6 67. Kc3 Ke5 68. Kc2 Rxd5 69. Kc3 Rd4 70. Ba6 d5 71. Bb7 Rf4 72.
+Kc2 Rf3 73. b4 Kd4 74. b5 Rf2+ 75. Kb3 c4+ 76. Kb4 c3 77. Bxd5 c2 78. Bb3 c1=Q
+79. Ka5 Qb2 80. Ba4 Rf5 81. Kb6 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Lil_D"]
+[Black "vassiukov"]
+[Result "1-0"]
+[ECO "A00"]
+[WhiteElo "2312"]
+[BlackElo "2335"]
+[PlyCount "41"]
+[EventDate "2020.??.??"]
+
+1. g3 Nf6 2. Bg2 d5 3. d3 Bf5 4. Nd2 e6 5. e3 h6 6. Ne2 Be7 7. O-O O-O 8. h3 c6
+9. a3 Nbd7 10. b3 a5 11. Bb2 Qc7 12. f4 Bh7 13. g4 Rfe8 14. Nf3 Bd6 15. Ng3 e5
+16. g5 exf4 17. gxf6 fxg3 18. fxg7 Rxe3 19. Nh4 Rae8 20. Qh5 Be5 21. Qxf7# 1-0
+
+[Event "Rated Rapid game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Tallnicke"]
+[Black "Mukha73"]
+[Result "0-1"]
+[ECO "A67"]
+[WhiteElo "2406"]
+[BlackElo "2386"]
+[PlyCount "122"]
+[EventDate "2020.??.??"]
+[EventType "rapid"]
+
+1. d4 Nf6 2. c4 c5 3. d5 e6 4. Nc3 exd5 5. cxd5 d6 6. e4 g6 7. f4 Bg7 8. Bb5+
+Nfd7 9. Nf3 O-O 10. Bd3 Na6 11. O-O Nb6 12. Qe1 Bg4 13. Ng5 c4 14. Bc2 h6 15.
+Qg3 Bd7 16. Nf3 Nb4 17. Bb1 Na4 18. Nxa4 Bxa4 19. f5 g5 20. f6 Qxf6 21. h4 gxh4
+22. Nxh4 Qd4+ 23. Kh1 Kh8 24. Nf5 Qe5 25. Bf4 Qxb2 26. Qxg7+ Qxg7 27. Nxg7 Kxg7
+28. Bxd6 Nd3 29. Bxf8+ Rxf8 30. Bxd3 cxd3 31. Rf3 d2 32. Rd3 d1=Q+ 33. Raxd1
+Bxd1 34. Rxd1 Kf6 35. Rc1 Ke5 36. Rc7 Kxe4 37. d6 b5 38. Rxa7 Kd5 39. d7 Rd8
+40. Rb7 Kc6 41. Ra7 Rxd7 42. Ra6+ Kc5 43. Rxh6 Kb4 44. Rh3 Ra7 45. Rb3+ Kc4 46.
+Rb2 b4 47. Kh2 Kc3 48. Rf2 Rd7 49. Kh3 Rd2 50. Rf3+ Rd3 51. Rxd3+ Kxd3 52. Kg4
+Kc3 53. Kf5 Kb2 54. Kf6 Kxa2 55. Kxf7 b3 56. g4 b2 57. g5 b1=Q 58. g6 Qf5+ 59.
+Kg7 Kb3 60. Kh6 Qh3+ 61. Kg5 Qh8 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Marohzevich"]
+[Black "yaguigor"]
+[Result "0-1"]
+[ECO "B40"]
+[WhiteElo "2481"]
+[BlackElo "2452"]
+[PlyCount "60"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 c5 2. Nf3 e6 3. b4 cxb4 4. Bb2 d5 5. exd5 exd5 6. Bb5+ Bd7 7. Qe2+ Qe7 8.
+Ne5 Nc6 9. Bxc6 bxc6 10. O-O Nf6 11. Re1 Rc8 12. a3 b3 13. Qa6 bxc2 14. Nc3 Be6
+15. Nxc6 Qd7 16. Nd4 Bd6 17. Ncb5 Bb8 18. Nxe6 fxe6 19. Bxf6 gxf6 20. Rxe6+ Kf7
+21. Rxf6+ Kg7 22. Rc1 Be5 23. Rf3 Rhe8 24. g3 Bb2 25. Nc3 Bxc1 26. Qf6+ Kg8 27.
+Rf5 Bxd2 28. Rg5+ Bxg5 29. Qxg5+ Kh8 30. Qc1 Rxc3 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Yoseqpuedo"]
+[Black "WildBreath"]
+[Result "1-0"]
+[ECO "A00"]
+[WhiteElo "2390"]
+[BlackElo "2394"]
+[PlyCount "71"]
+[EventDate "2020.??.??"]
+
+1. e3 Nf6 2. f4 e6 3. Nf3 d5 4. Be2 c5 5. O-O Nc6 6. d3 d4 7. e4 c4 8. Kh1 cxd3
+9. cxd3 Bd7 10. Qe1 Be7 11. Qg3 O-O 12. Qh3 h6 13. a3 e5 14. f5 Kh8 15. g4 Ng8
+16. Bd2 f6 17. Nh4 Be8 18. Bd1 Kh7 19. Be1 b5 20. Bb3 b4 21. a4 Na5 22. Bd5 Rc8
+23. Nd2 Nc6 24. Ndf3 Bd6 25. Rg1 Nce7 26. Bb3 Bf7 27. Bxf7 Rxf7 28. Ng6 Nxg6
+29. fxg6+ Kxg6 30. g5 hxg5 31. Qf5+ Kh6 32. Nxg5 fxg5 33. Qxf7 Nf6 34. Rg3 Qe8
+35. Rh3+ Nh5 36. Rxh5# 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "profaVa"]
+[Black "JiangoFett"]
+[Result "1-0"]
+[ECO "B06"]
+[WhiteElo "2382"]
+[BlackElo "2382"]
+[PlyCount "49"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 c5 2. d5 g6 3. Nc3 Bg7 4. e4 d6 5. Bg5 h6 6. Be3 Nf6 7. Qd2 Ng4 8. O-O-O
+Nxe3 9. Qxe3 a6 10. Nf3 Bg4 11. h3 Bxf3 12. gxf3 Nd7 13. f4 b5 14. h4 h5 15.
+Bh3 Qa5 16. Kb1 b4 17. Bxd7+ Kxd7 18. Ne2 c4 19. e5 c3 20. e6+ fxe6 21. Qxe6+
+Kd8 22. Nd4 Rc8 23. Nc6+ Rxc6 24. dxc6 cxb2 25. Qd7# 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "bonsitorus"]
+[Black "Chesscoach46"]
+[Result "1-0"]
+[ECO "B40"]
+[WhiteElo "2300"]
+[BlackElo "2314"]
+[PlyCount "91"]
+[EventDate "2020.??.??"]
+
+1. e4 c5 2. Nf3 e6 3. b4 cxb4 4. d4 d5 5. a3 bxa3 6. Ng5 h6 7. Nxf7 Kxf7 8.
+exd5 Qxd5 9. Bd3 Nf6 10. O-O Qxd4 11. Bg6+ Kxg6 12. Qxd4 Nc6 13. Qd3+ Kf7 14.
+Bxa3 e5 15. Bxf8 Rxf8 16. Nc3 Be6 17. Ne4 Rfd8 18. Qe2 Nd5 19. Qf3+ Kg8 20. Nc5
+Bf7 21. Nxb7 Nd4 22. Qa3 Nxc2 23. Qa6 Nxa1 24. Nxd8 Rxd8 25. Qxa1 e4 26. Qxa7
+Be6 27. h3 Rf8 28. Qd4 Rd8 29. Qxe4 Bf7 30. Rd1 Kf8 31. Qf3 Ke7 32. g3 Rd6 33.
+Qa3 Ke6 34. Re1+ Kd7 35. Qa8 Nc7 36. Qb8 Be6 37. Qb2 g5 38. Qg7+ Kc6 39. Qxh6
+Nd5 40. Qxg5 Bd7 41. Rc1+ Kb5 42. Qe5 Rc6 43. Qxd5+ Kb6 44. Rb1+ Kc7 45. Qe5+
+Kc8 46. Rb8# 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "BreatEastonEllis"]
+[Black "troisi"]
+[Result "1-0"]
+[ECO "A40"]
+[WhiteElo "2499"]
+[BlackElo "2394"]
+[PlyCount "63"]
+[EventDate "2020.??.??"]
+
+1. d4 e5 2. dxe5 Nc6 3. Nf3 Nge7 4. Nc3 Ng6 5. e4 Ngxe5 6. Nxe5 Nxe5 7. Bf4 Nc6
+8. Bc4 d6 9. O-O Be7 10. Nd5 O-O 11. c3 Be6 12. Qc2 Ne5 13. Bb3 c6 14. Nxe7+
+Qxe7 15. Bg3 Rae8 16. f4 Bxb3 17. axb3 Ng6 18. f5 Ne5 19. Rxa7 f6 20. b4 Rf7
+21. Qb3 Nd7 22. Rxb7 Kh8 23. Rd1 Ref8 24. Bxd6 Qxe4 25. Bxf8 Qe3+ 26. Kh1 Rxf8
+27. Rbxd7 Re8 28. h3 h5 29. Qf7 Qe2 30. Rd8 Rxd8 31. Rxd8+ Kh7 32. Qg6# 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Kidefence"]
+[Black "BlueGreensun"]
+[Result "0-1"]
+[ECO "B01"]
+[WhiteElo "2712"]
+[BlackElo "2754"]
+[PlyCount "64"]
+[EventDate "2020.??.??"]
+
+1. e4 d5 2. exd5 c6 3. dxc6 Nf6 4. Nf3 Nxc6 5. Bb5 e5 6. O-O Bd6 7. Re1 O-O 8.
+h3 e4 9. Bxc6 bxc6 10. Nd4 c5 11. Ne2 Bc7 12. d3 exd3 13. Qxd3 Qxd3 14. cxd3
+Re8 15. Be3 Bf5 16. d4 cxd4 17. Nxd4 Bg6 18. Nc3 Rab8 19. Ndb5 Be5 20. Bxa7 Rb7
+21. Be3 Reb8 22. a4 h6 23. Ba7 Re8 24. Rad1 Bc2 25. Ra1 Re6 26. Be3 Bd3 27.
+Red1 Bc4 28. Rd8+ Kh7 29. Rc8 Bb3 30. a5 Ra6 31. Bb6 Rbxb6 32. axb6 Rxa1+ 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Kralj56"]
+[Black "Ronald_Ganzon"]
+[Result "1-0"]
+[ECO "D12"]
+[WhiteElo "2451"]
+[BlackElo "2328"]
+[PlyCount "53"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 d5 2. c4 c6 3. e3 Nf6 4. Nf3 Bg4 5. Nc3 e6 6. Qb3 Qc8 7. Ne5 Bf5 8. Bd2
+Nbd7 9. Rc1 Nxe5 10. dxe5 Ne4 11. cxd5 Nxc3 12. dxc6 bxc6 13. Rxc3 Be7 14. Rxc6
+Qd7 15. Rd6 Qc7 16. Bb5+ Kf8 17. Rd7 Qb6 18. Bb4 Bxb4+ 19. Qxb4+ Kg8 20. Qe7
+Rf8 21. Rb7 Qa5+ 22. b4 Qxa2 23. O-O a5 24. Be8 Bg6 25. Rb8 h5 26. Bxf7+ Kh7
+27. Rxf8 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "notasyon"]
+[Black "FishyMcPatzer"]
+[Result "1-0"]
+[ECO "A01"]
+[WhiteElo "2473"]
+[BlackElo "2566"]
+[PlyCount "113"]
+[EventDate "2020.??.??"]
+
+1. b3 e5 2. Bb2 Qe7 3. e3 Nc6 4. c4 Nf6 5. Ne2 b6 6. Nbc3 Bb7 7. d4 exd4 8.
+Nxd4 O-O-O 9. Qd2 d5 10. cxd5 Nxd5 11. O-O-O Nxc3 12. Qxc3 Nxd4 13. Rxd4 Rxd4
+14. Qxd4 f6 15. Be2 Qc5+ 16. Qxc5 Bxc5 17. Rd1 Bd6 18. g3 h5 19. h4 Be4 20. Rd4
+Bg6 21. Ba6+ Kd7 22. Rc4 Re8 23. Bb5+ Ke7 24. Bxe8 Bxe8 25. Rc2 c5 26. Kd1 Bc7
+27. Ke2 Bc6 28. a4 a5 29. Rd2 Ke6 30. Bc3 Bd5 31. Rb2 g5 32. hxg5 fxg5 33. f3
+h4 34. e4 Bb7 35. gxh4 gxh4 36. Ke3 Bg3 37. f4 h3 38. Rb1 h2 39. Rh1 c4 40.
+bxc4 Bc6 41. Be1 Bxe1 42. Rxe1 Bxa4 43. Rh1 Bb3 44. Rxh2 Bxc4 45. Kd4 Kd7 46.
+Rh6 b5 47. Kc5 a4 48. Rh7+ Ke6 49. Rh6+ Kf7 50. f5 a3 51. e5 a2 52. Rh7+ Kg8
+53. Ra7 Kf8 54. e6 Ke8 55. f6 Bxe6 56. Kd6 Bf7 57. Ra8# 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Adrian_DelaCruz"]
+[Black "Melladov"]
+[Result "1-0"]
+[ECO "D06"]
+[WhiteElo "2360"]
+[BlackElo "2459"]
+[PlyCount "119"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. Nf3 d5 2. d4 Bf5 3. c4 e6 4. Nc3 c6 5. Qb3 Qb6 6. c5 Qxb3 7. axb3 a6 8. b4
+Nd7 9. b5 cxb5 10. Nxb5 Rc8 11. Nc3 Ngf6 12. Bf4 Be7 13. e3 Nh5 14. Be5 f6 15.
+Bg3 Nxg3 16. hxg3 h6 17. b4 Kf7 18. b5 axb5 19. Bxb5 Nb6 20. Kd2 Nc4+ 21. Bxc4
+dxc4 22. Ra7 Bd3 23. Rha1 Rc7 24. Nb5 Rd7 25. c6 bxc6 26. Rxd7 cxb5 27. Raa7
+Re8 28. Ne1 Bf5 29. Rdb7 Kf8 30. Rxb5 Rc8 31. Kc3 Bd6 32. Rbb7 g5 33. g4 Bxg4
+34. Rh7 Kg8 35. Rag7+ Kf8 36. Rxg5 hxg5 37. Rh8+ Ke7 38. Rxc8 Be2 39. Nc2 Bh2
+40. Kd2 Bf1 41. g3 f5 42. Ke1 Bd3 43. Na3 f4 44. gxf4 gxf4 45. Rh8 Bg1 46. exf4
+c3 47. Rh1 c2 48. Nxc2 Bxf2+ 49. Kxf2 Bxc2 50. Rc1 Be4 51. Ke3 Bd5 52. f5 exf5
+53. Kf4 Be4 54. Ke5 Kd7 55. d5 Kd8 56. Ke6 f4 57. d6 f3 58. d7 Bb7 59. Kd6 Ba6
+60. Rh1 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "azolot"]
+[Black "Training88"]
+[Result "0-1"]
+[ECO "A00"]
+[WhiteElo "2308"]
+[BlackElo "2315"]
+[PlyCount "94"]
+[EventDate "2020.??.??"]
+
+1. e3 a6 2. c4 b5 3. cxb5 axb5 4. Bxb5 Bb7 5. Bf1 e6 6. d4 c5 7. dxc5 Bxc5 8.
+Qc2 Nf6 9. Qxc5 Nc6 10. Qc2 Ne4 11. Nc3 d5 12. Nxe4 dxe4 13. Qxe4 Qa5+ 14. Bd2
+Qb6 15. Bc3 Rd8 16. Qg4 Rg8 17. Bc4 Qc5 18. Bb3 h5 19. Qc4 Qg5 20. Kf1 Ne5 21.
+Qb5+ Bc6 22. Qxe5 Qxg2+ 23. Ke2 Qxh1 24. e4 Bxe4 25. Ba4+ Bc6 26. Bxc6+ Qxc6
+27. Nf3 Qc4+ 28. Ke1 f6 29. Qe2 Qxe2+ 30. Kxe2 Kf7 31. Rc1 Rge8 32. Bd2 Rc8 33.
+Bc3 e5 34. Rg1 g5 35. Nxg5+ fxg5 36. Rxg5 Ke6 37. Rxh5 Kd5 38. f4 Ke4 39. Rxe5+
+Rxe5 40. fxe5 Rd8 41. a4 Kd5 42. a5 Re8 43. Ke3 Kc6 44. Ke4 Ra8 45. h4 Re8 46.
+h5 Rh8 47. e6 Rxh5 0-1
+
+[Event "Rated Blitz tournament te4AhseI"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Stormart"]
+[Black "emejachasu"]
+[Result "0-1"]
+[WhiteElo "2359"]
+[BlackElo "2322"]
+[PlyCount "0"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+ 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Caochonewell"]
+[Black "RigelStar"]
+[Result "1-0"]
+[ECO "A43"]
+[WhiteElo "2433"]
+[BlackElo "2395"]
+[PlyCount "127"]
+[EventDate "2020.??.??"]
+
+1. d4 c5 2. Nf3 cxd4 3. Nxd4 e5 4. Nf3 Nc6 5. c4 Nf6 6. Nc3 Bb4 7. Bd2 O-O 8.
+a3 Be7 9. e3 d5 10. cxd5 Nxd5 11. Bc4 Nb6 12. Be2 Be6 13. O-O Na5 14. Nxe5 Nb3
+15. Be1 Nxa1 16. Qxa1 Bd6 17. Nf3 Rc8 18. Ne4 Bb8 19. Bc3 Qc7 20. Rc1 Nd5 21.
+Bd2 Qd7 22. Rxc8 Rxc8 23. b4 Bf5 24. Ng3 Bg4 25. h3 Be6 26. Nf1 Rc2 27. Nd4 Rc8
+28. Nxe6 Qxe6 29. Bf3 Qd6 30. Qd4 Nf6 31. Qb2 b6 32. Bc3 Ne8 33. Bd4 Qc7 34. b5
+Qc1 35. Qb3 Qc7 36. g3 Qe7 37. Bc6 Nd6 38. Kg2 Nf5 39. Bb2 g6 40. Qc3 f6 41.
+Qxf6 Qxf6 42. Bxf6 Bd6 43. Nd2 Ne7 44. Ne4 Kf8 45. Nxd6 Rd8 46. Bxe7+ Kxe7 47.
+Ne4 Rd5 48. Ng5 Re5 49. Nf3 Re6 50. Nd4 Rd6 51. f4 Rd8 52. Kf3 Rc8 53. e4 Rb8
+54. Ke3 a6 55. Bd5 Rc8 56. Nc6+ Kd6 57. bxa6 Rxc6 58. Bxc6 Kxc6 59. a7 Kb7 60.
+e5 Ka8 61. e6 b5 62. e7 b4 63. e8=Q+ Kxa7 64. Qa4+ 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "fullchola"]
+[Black "chipmunknau"]
+[Result "0-1"]
+[ECO "A46"]
+[WhiteElo "2437"]
+[BlackElo "2564"]
+[PlyCount "108"]
+[EventDate "2020.??.??"]
+
+1. d4 Nf6 2. Nf3 e6 3. Nc3 c5 4. Bg5 cxd4 5. Bxf6 Qxf6 6. Qxd4 Nc6 7. Qxf6 gxf6
+8. O-O-O a6 9. e4 Bb4 10. Bd3 Bxc3 11. bxc3 d6 12. Rhe1 Bd7 13. g3 Rc8 14. Nd2
+Ke7 15. Kb2 Rc7 16. Nb3 Rhc8 17. c4 Ne5 18. Nd2 b6 19. f3 Nc6 20. a3 Rb8 21. f4
+Bc8 22. e5 fxe5 23. Be4 exf4 24. Bxc6 Rxc6 25. gxf4 Bb7 26. f5 Rg8 27. Rg1 Rxg1
+28. Rxg1 exf5 29. Re1+ Kf6 30. Kc3 Rc5 31. Kd4 Re5 32. Rf1 Ke6 33. Rf2 Bc6 34.
+Kc3 b5 35. cxb5 axb5 36. Nb3 Re3+ 37. Kb2 Ke5 38. Rd2 f4 39. Nd4 Be4 40. Nxb5
+d5 41. Nc3 f3 42. a4 Kf4 43. Nxd5+ Bxd5 44. Rxd5 f2 45. Rd7 Re5 46. Rd4+ Kf3
+47. Rd7 Rf5 48. Rd3+ Ke2 49. Ra3 f1=Q 50. Ra1 Qf4 51. Ra3 Qe5+ 52. Rc3 Rf3 53.
+a5 Qxc3+ 54. Ka2 Rf4 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "BerserkAdopter"]
+[Black "Aisen_Mestnikov"]
+[Result "1-0"]
+[ECO "C20"]
+[WhiteElo "2452"]
+[BlackElo "2397"]
+[PlyCount "47"]
+[EventDate "2020.??.??"]
+
+1. e4 e5 2. d3 Nc6 3. Nd2 g6 4. Ngf3 Bg7 5. g3 Nge7 6. Bg2 O-O 7. O-O d5 8. Nh4
+d4 9. h3 f5 10. exf5 Nxf5 11. Ndf3 Be6 12. Qe2 Qd6 13. Nxf5 gxf5 14. Ng5 Bd5
+15. Qh5 h6 16. Nf3 Rae8 17. Nh4 e4 18. Nxf5 Rxf5 19. Qxf5 Re5 20. Qc8+ Kh7 21.
+Bf4 Be6 22. Qxb7 Qe7 23. Bxe5 Nxe5 24. Qxe4+ 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "vassiukov"]
+[Black "Lil_D"]
+[Result "1-0"]
+[ECO "A40"]
+[WhiteElo "2329"]
+[BlackElo "2318"]
+[PlyCount "63"]
+[EventDate "2020.??.??"]
+
+1. d4 g6 2. Nf3 Bg7 3. Bf4 d6 4. e3 Nf6 5. h3 O-O 6. Nbd2 Nc6 7. c3 Nd7 8. Be2
+e5 9. dxe5 dxe5 10. Bh2 a5 11. a4 Qe7 12. O-O Nc5 13. Qc2 Be6 14. e4 f5 15.
+exf5 gxf5 16. Rfe1 Kh8 17. Nc4 Bd5 18. Rad1 Be4 19. Qc1 Rg8 20. Ne3 Qe6 21. Nd2
+Bh6 22. Nxe4 Nxe4 23. Qc2 Qg6 24. Bf1 Rad8 25. Rxd8 Rxd8 26. Nxf5 Qxf5 27. Qxe4
+Qxe4 28. Rxe4 Rd2 29. Re2 Rd1 30. Bxe5+ Nxe5 31. Rxe5 Rd2 32. Rb5 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "elpepinillo14"]
+[Black "Nesty_Javi_Chess"]
+[Result "0-1"]
+[ECO "B23"]
+[WhiteElo "2575"]
+[BlackElo "2574"]
+[PlyCount "66"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 c5 2. Nc3 d6 3. g3 g6 4. Bg2 Bg7 5. d3 e6 6. Be3 Ne7 7. Qd2 O-O 8. Bh6
+Nbc6 9. h4 Nd4 10. h5 Nxc2+ 11. Qxc2 Bxh6 12. hxg6 Bg7 13. gxh7+ Kh8 14. Nf3
+Ng6 15. Rd1 b6 16. d4 Qe7 17. O-O Bb7 18. d5 Kxh7 19. e5 dxe5 20. d6 Qd8 21.
+Nxe5 Bxe5 22. Bxb7 Rb8 23. Be4 Kg7 24. Bxg6 fxg6 25. Qe4 Qg5 26. Kg2 Rf4 27.
+Qc6 Rbf8 28. Ne4 Qg4 29. Qb7+ R4f7 30. f3 Qh5 31. Qc6 Rh8 32. Kf2 Qxf3+ 33. Ke1
+Qe3# 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "tigra522"]
+[Black "Odirovski"]
+[Result "0-1"]
+[ECO "B03"]
+[WhiteElo "2373"]
+[BlackElo "2463"]
+[PlyCount "52"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 Nf6 2. e5 Nd5 3. d4 d6 4. c4 Nb6 5. f4 dxe5 6. fxe5 Nc6 7. Be3 Bf5 8. Nc3
+e6 9. Be2 Qd7 10. Nf3 O-O-O 11. Qd2 f6 12. exf6 gxf6 13. O-O Qg7 14. b3 Rg8 15.
+Rf2 Bg4 16. Rd1 Bb4 17. Qc2 f5 18. Ng5 Bxe2 19. Nxe2 Qg6 20. d5 exd5 21. c5 Nd7
+22. Rxd5 Nde5 23. Rxd8+ Rxd8 24. Qxf5+ Qxf5 25. Rxf5 Rd3 26. Bc1 Bxc5+ 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Phutressniak"]
+[Black "vava05"]
+[Result "0-1"]
+[ECO "D38"]
+[WhiteElo "2419"]
+[BlackElo "2403"]
+[PlyCount "128"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 d5 2. c4 e6 3. Nc3 Nf6 4. Nf3 Bb4 5. Qa4+ Nc6 6. e3 O-O 7. Qc2 a6 8. Bd2
+dxc4 9. Bxc4 b5 10. Bd3 Bb7 11. O-O Ne7 12. e4 Ng6 13. Rfd1 c5 14. a3 cxd4 15.
+axb4 dxc3 16. Bxc3 Rc8 17. Bxb5 Bxe4 18. Rxd8 Rfxd8 19. Qe2 Nf4 20. Qe3 N4d5
+21. Qg5 axb5 22. Nd4 h6 23. Qg3 Nxc3 24. bxc3 Rd5 25. h4 e5 26. Nb3 Rd3 27.
+Qxe5 Re8 28. Qxb5 Rxc3 29. Nc5 Re5 30. Qb8+ Re8 31. Qf4 Bc6 32. Rc1 Nd5 33. Qd2
+Rxc1+ 34. Qxc1 Nxb4 35. Qc4 Nd5 36. f3 Ne3 37. Qd4 Nf5 38. Qb4 Bd5 39. Ne4 Bxe4
+40. fxe4 Ng3 41. Kh2 Nxe4 42. Qb5 Nf6 43. Qb7 h5 44. Qf3 Ng4+ 45. Kg3 Re3 46.
+Qxe3 Nxe3 47. Kf4 Nxg2+ 48. Kg3 Nxh4 49. Kxh4 g6 50. Kg5 Kg7 51. Kh4 f6 52. Kh3
+g5 53. Kg3 f5 54. Kg2 Kg6 55. Kh2 f4 56. Kh1 g4 57. Kg1 h4 58. Kh1 h3 59. Kg1
+g3 60. Kh1 f3 61. Kg1 Kg5 62. Kh1 Kg4 63. Kg1 f2+ 64. Kh1 f1=Q# 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "lewisbort"]
+[Black "taras05"]
+[Result "1-0"]
+[ECO "A45"]
+[WhiteElo "2366"]
+[BlackElo "2499"]
+[PlyCount "51"]
+[EventDate "2020.??.??"]
+
+1. d4 Nf6 2. Bf4 g6 3. Nc3 d6 4. e4 Bg7 5. Qd2 O-O 6. Nf3 Re8 7. h4 h5 8. O-O-O
+Nc6 9. Be2 Ng4 10. Bc4 e5 11. Be3 Nxe3 12. fxe3 Be6 13. d5 Na5 14. dxe6 Nxc4
+15. exf7+ Kxf7 16. Qd5+ Ke7 17. Qxc4 Bh6 18. Ng5 Bxg5 19. hxg5 Kd7 20. Rhf1 c6
+21. Rf7+ Re7 22. Rdf1 Rxf7 23. Rxf7+ Kc8 24. Qe6+ Kb8 25. Rd7 Qc8 26. Qxd6+ 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "MasterOffPuppets"]
+[Black "burpcow"]
+[Result "1-0"]
+[ECO "E46"]
+[WhiteElo "2362"]
+[BlackElo "2308"]
+[PlyCount "55"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 Nf6 2. c4 e6 3. Nc3 Bb4 4. e3 O-O 5. Bd2 d5 6. Nf3 b6 7. cxd5 exd5 8. Bd3
+Re8 9. O-O Nbd7 10. Bb5 Bd6 11. Bc6 Ba6 12. Bxa8 Bxf1 13. Bxd5 Nxd5 14. Qxf1
+N7f6 15. Nxd5 Nxd5 16. Qc4 h6 17. Rc1 c5 18. dxc5 Bxc5 19. b4 Be7 20. a3 Bf6
+21. h3 Qd7 22. e4 Ne7 23. e5 Rc8 24. Qb3 Bxe5 25. Nxe5 Qxd2 26. Qxf7+ Kh7 27.
+Rxc8 Nxc8 28. Qf5+ 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "metalkingGT"]
+[Black "estocastico"]
+[Result "0-1"]
+[ECO "A07"]
+[WhiteElo "2458"]
+[BlackElo "2559"]
+[PlyCount "43"]
+[EventDate "2020.??.??"]
+
+1. Nf3 d5 2. g3 c6 3. Bg2 Nf6 4. O-O Bf5 5. d3 h6 6. Nbd2 e6 7. e4 dxe4 8. dxe4
+Nxe4 9. Nxe4 Qxd1 10. Rxd1 Bxe4 11. c3 Nd7 12. Bf4 O-O-O 13. Nd4 Bxg2 14. Kxg2
+e5 15. Nf5 exf4 16. gxf4 g6 17. Ne3 Bc5 18. Ng4 h5 19. Ne5 Nxe5 20. fxe5 Rxd1
+21. Rxd1 Rd8 22. Re1 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "ajedrez2021"]
+[Black "sutcunuri"]
+[Result "1-0"]
+[ECO "A04"]
+[WhiteElo "2597"]
+[BlackElo "2516"]
+[PlyCount "117"]
+[EventDate "2020.??.??"]
+
+1. Nf3 f6 2. g3 Nh6 3. Bg2 Nf7 4. O-O c6 5. d4 d6 6. c4 g6 7. Nc3 Bg7 8. e4 O-O
+9. Re1 Na6 10. Be3 Nc7 11. h4 Bd7 12. Qb3 Rb8 13. h5 b5 14. cxb5 Nxb5 15. hxg6
+hxg6 16. Nh4 Nxd4 17. Qd1 c5 18. Nxg6 Rxb2 19. Bxd4 cxd4 20. Qxd4 f5 21. Qc4
+Rc2 22. Rac1 Bxc3 23. Rxc2 Bxe1 24. exf5 Bxf5 25. Nxf8 Kxf8 26. Re2 Ba5 27. Bd5
+Bg6 28. Qg4 Ne5 29. Qe6 Kg7 30. Rxe5 dxe5 31. Qxe5+ Kh7 32. Be4 Qd6 33. Bxg6+
+Kxg6 34. Qxa5 Qd1+ 35. Kg2 Qd6 36. Qxa7 e5 37. Kh2 e4 38. Qe3 Qd5 39. Qf4 Qh5+
+40. Qh4 Qd5 41. Qf4 Qh5+ 42. Kg2 Qd5 43. Kg1 Qd1+ 44. Kh2 Qd5 45. Qg4+ Kf6 46.
+Qh3 Kg6 47. g4 Kf6 48. Qg3 Kg6 49. Qe3 Qxa2 50. Qxe4+ Kg5 51. Qe2 Kh4 52. Qxa2
+Kxg4 53. Qb3 Kh4 54. Qg3+ Kh5 55. Kg2 Kh6 56. Kf3 Kh7 57. Kf4 Kh6 58. Kf5 Kh5
+59. Qg5# 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "SuperDonald"]
+[Black "thatlime"]
+[Result "1-0"]
+[ECO "E39"]
+[WhiteElo "2324"]
+[BlackElo "2325"]
+[PlyCount "123"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 Nf6 2. c4 e6 3. Nc3 Bb4 4. Qc2 c5 5. dxc5 O-O 6. Bg5 Na6 7. Nf3 Nxc5 8.
+Nd2 h6 9. Bh4 b6 10. a3 Bxc3 11. Qxc3 g5 12. Bg3 Nce4 13. Qc2 Nxd2 14. Qxd2 Ne4
+15. Qc2 f5 16. e3 Qf6 17. Bd3 Nc5 18. Bd6 Nxd3+ 19. Qxd3 Rf7 20. O-O-O Ba6 21.
+Kb1 Rc8 22. Rc1 Rc6 23. Rhd1 Bb7 24. f3 a6 25. Rd2 e5 26. Rcd1 Qe6 27. b3 b5
+28. cxb5 axb5 29. Qxb5 Ba6 30. Qb8+ Rc8 31. Qb4 Kh7 32. Kb2 Rc6 33. Qa5 e4 34.
+f4 g4 35. Qe5 Rb6 36. Qxe6 dxe6 37. Bc5 Rc6 38. Rd7 Rxd7 39. Rxd7+ Kg6 40. b4
+Bf1 41. g3 Bc4 42. a4 h5 43. Kc3 Bd3 44. Kd4 Kf6 45. b5 Rc8 46. Be7+ Kg6 47.
+Bd6 Rc4+ 48. Ke5 Rxa4 49. b6 Ra5+ 50. Kxe6 Bc4+ 51. Ke7 Rb5 52. Bc7 Rb2 53.
+Rd6+ Kh7 54. Kf6 Rxh2 55. b7 Rb2 56. b8=Q Rxb8 57. Bxb8 h4 58. gxh4 g3 59. Rd7+
+Kh6 60. Rg7 Kh5 61. Rxg3 Kxh4 62. Rg5 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "drop_stone"]
+[Black "C9C9C9C9C9"]
+[Result "1/2-1/2"]
+[ECO "E77"]
+[WhiteElo "2919"]
+[BlackElo "2991"]
+[PlyCount "134"]
+[EventDate "2020.??.??"]
+
+1. d4 Nf6 2. c4 g6 3. Nc3 Bg7 4. e4 d6 5. h4 e5 6. dxe5 dxe5 7. Qxd8+ Kxd8 8.
+Bg5 h6 9. O-O-O+ Ke8 10. Be3 c6 11. f3 Be6 12. g4 Nbd7 13. Nh3 Bf8 14. Nf2 Bc5
+15. Bxc5 Nxc5 16. b3 Ke7 17. Be2 Rad8 18. Kc2 Bc8 19. Nd3 Nfd7 20. g5 hxg5 21.
+hxg5 Rxh1 22. Rxh1 Ne6 23. Rg1 Rh8 24. Rg2 Rh4 25. Nd1 Nd4+ 26. Kd2 Kd6 27. Ne3
+Nc5 28. Nxc5 Kxc5 29. Bd1 Kd6 30. Kc3 Ne6 31. Kd2 Rh5 32. f4 exf4 33. Nf5+ gxf5
+34. Bxh5 fxe4 35. Bxf7 e3+ 36. Kd3 f3 37. Rg1 e2 38. Ke3 Nd4 39. Bh5 Ke5 40.
+Bxf3 Nf5+ 41. Kxe2 Kf4 42. Kf2 Nd4 43. g6 Nxf3 44. g7 Nxg1 45. g8=Q Nh3+ 46.
+Kg2 Bf5 47. Qb8+ Ke3 48. Qxb7 Nf4+ 49. Kg3 Be4 50. Kh4 Nd3 51. Qxa7+ Kd2 52. b4
+Kc3 53. b5 c5 54. b6 Kxc4 55. Qa6+ Kd4 56. b7 Bxb7 57. Qxb7 c4 58. Qa7+ Kc3 59.
+Kg3 Nb4 60. Kf3 Nc2 61. Qc5 Kd3 62. Qd5+ Nd4+ 63. Kf4 c3 64. Ke5 c2 65. Qxd4+
+Ke2 66. Qc4+ Kd1 67. Qxc2+ Kxc2 1/2-1/2
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "drdrunckenstein"]
+[Black "Nurdin_Abubakar"]
+[Result "1-0"]
+[ECO "A00"]
+[WhiteElo "2526"]
+[BlackElo "2382"]
+[PlyCount "113"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. g3 d5 2. Bg2 Nf6 3. d3 e6 4. Nf3 Be7 5. O-O O-O 6. Nc3 c5 7. e4 Nc6 8. Nd2
+b6 9. h3 Bb7 10. Kh2 Rc8 11. f4 Nd4 12. e5 Nd7 13. Ne2 Nxe2 14. Qxe2 Qc7 15. c3
+d4 16. Ne4 h6 17. c4 a6 18. Bd2 b5 19. b3 Rfe8 20. a4 Qb6 21. Rfb1 Nb8 22. Qe1
+Nc6 23. Qe2 Nb4 24. Rb2 Bc6 25. a5 Qb7 26. Bxb4 cxb4 27. Qf2 Red8 28. Rbb1 Qa8
+29. Rf1 bxc4 30. bxc4 b3 31. f5 exf5 32. Qxf5 Rf8 33. e6 f6 34. Rab1 Rb8 35.
+Rf2 Qb7 36. Nc5 Bxc5 37. Qxc5 Bxg2 38. Rxg2 Qf3 39. e7 Rfe8 40. Qd6 Qxd3 41.
+Rbb2 Qxc4 42. Rgd2 Qf7 43. Rxd4 Qxe7 44. Qd5+ Qe6 45. Qg2 Qe5 46. Rdd2 Rec8 47.
+Re2 Qd4 48. Red2 Qc3 49. Qd5+ Kh8 50. Qg2 Re8 51. Rf2 Re1 52. Rf3 Qc1 53. Rff2
+Rd8 54. g4 Rdd1 55. Qa8+ Kh7 56. Kg3 Rh1 57. Qe4+ 1-0
+
+[Event "Rated Blitz tournament OxRShNHO"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Alfilparanoico"]
+[Black "FanDeGranda"]
+[Result "1/2-1/2"]
+[ECO "B07"]
+[WhiteElo "2475"]
+[BlackElo "2367"]
+[PlyCount "138"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 Nf6 2. Nc3 g6 3. e4 d6 4. Bg5 Bg7 5. Qe2 c5 6. dxc5 dxc5 7. Nd5 Qa5+ 8.
+c3 Nxd5 9. exd5 O-O 10. Bd2 Nd7 11. Qb5 Qc7 12. Nf3 Nf6 13. Qc4 Bf5 14. Be2 Ne4
+15. Rd1 Nd6 16. Qh4 e6 17. dxe6 Bxe6 18. O-O Nf5 19. Qa4 a6 20. Bf4 Qc8 21.
+Rfe1 b5 22. Qa5 Rd8 23. Qc7 Qxc7 24. Bxc7 Rdc8 25. Bf4 Bxa2 26. g4 Ne7 27. Ne5
+Be6 28. Bf3 Ra7 29. h3 b4 30. Kg2 bxc3 31. bxc3 h6 32. Bg3 g5 33. Ra1 a5 34.
+Ra4 Bd5 35. Rea1 Bxf3+ 36. Kxf3 Ng6 37. Nxg6 fxg6 38. Rxa5 Rxa5 39. Rxa5 Bxc3
+40. Ra6 Kg7 41. Ke4 Bd4 42. Ra7+ Kg8 43. Kd5 Rf8 44. Ra2 Rf7 45. Kc4 Kg7 46.
+Re2 h5 47. gxh5 gxh5 48. Bd6 Kf6 49. Bxc5 Bxc5 50. Kxc5 Re7 51. Ra2 Re5+ 52.
+Kd4 Kf5 53. Ra3 Re4+ 54. Kd5 Re1 55. Rf3+ Kg6 56. Kd4 Re7 57. Kd3 Rf7 58. Ke3
+Rxf3+ 59. Kxf3 Kf5 60. Kg3 Ke4 61. Kg2 Kf4 62. Kg1 g4 63. hxg4 hxg4 64. Kg2 Kg5
+65. Kg3 Kf5 66. Kg2 Kf4 67. Kg1 Kf3 68. Kf1 g3 69. fxg3 Kxg3 1/2-1/2
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Betovsky"]
+[Black "hungzhao"]
+[Result "0-1"]
+[ECO "A40"]
+[WhiteElo "2622"]
+[BlackElo "2628"]
+[PlyCount "32"]
+[EventDate "2020.??.??"]
+
+1. d4 e6 2. Be3 f5 3. c4 Nf6 4. Bc1 Bb4+ 5. Nc3 Bxc3+ 6. bxc3 b6 7. Ba3 d6 8.
+Nf3 Ne4 9. Rc1 O-O 10. e3 c5 11. Be2 Bb7 12. O-O Nc6 13. d5 Na5 14. dxe6 Qe7
+15. Qd2 Nxd2 16. Nxd2 Qxe6 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Xychael27"]
+[Black "alireza3700"]
+[Result "1-0"]
+[ECO "D01"]
+[WhiteElo "2306"]
+[BlackElo "2322"]
+[PlyCount "83"]
+[EventDate "2020.??.??"]
+
+1. d4 d5 2. Nc3 Nf6 3. Bf4 c6 4. e3 Nbd7 5. Bd3 e6 6. Nf3 Be7 7. O-O O-O 8. Ne5
+Nxe5 9. Bxe5 Nd7 10. Bg3 f5 11. f3 Bh4 12. Qe1 Bxg3 13. Qxg3 Nf6 14. Rae1 b6
+15. Ne2 Bb7 16. c3 c5 17. Qe5 cxd4 18. Qxe6+ Kh8 19. exd4 Bc8 20. Qc6 Bd7 21.
+Qd6 Re8 22. Nf4 Rc8 23. Kf2 Rc6 24. Rxe8+ Qxe8 25. Qb4 g5 26. Re1 Qb8 27. Nh3
+Qxh2 28. Bb5 g4 29. Bxc6 gxh3 30. Qf8+ Ng8 31. Rg1 f4 32. Bxd7 Qg3+ 33. Kf1 h2
+34. Rh1 h5 35. Bh3 Kh7 36. Qf5+ Kg7 37. Qxh5 Kf8 38. Qg4 Ne7 39. Qf5+ Ke8 40.
+Qxf4 Ng6 41. Qxg3 Nf4 42. Qxh2 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "BlueGreensun"]
+[Black "Kidefence"]
+[Result "1-0"]
+[ECO "B02"]
+[WhiteElo "2759"]
+[BlackElo "2707"]
+[PlyCount "125"]
+[EventDate "2020.??.??"]
+
+1. e4 Nf6 2. e5 Nd5 3. Nc3 Nxc3 4. dxc3 d6 5. Nf3 Nc6 6. Bc4 g6 7. O-O Bg7 8.
+exd6 cxd6 9. Re1 O-O 10. Bg5 Bg4 11. h3 Bxf3 12. Qxf3 Qc7 13. Bf1 Rae8 14. Rad1
+a6 15. Bc1 b5 16. Qg3 Na5 17. h4 h5 18. Qf3 Nc4 19. b3 Nb6 20. Rd3 d5 21. g3 e6
+22. Qd1 Rc8 23. Bf4 Qb7 24. Be5 Bxe5 25. Rxe5 Nd7 26. Rg5 Nf6 27. Qf3 Kg7 28.
+Re5 Qc7 29. Re1 Qd6 30. Ra1 Rc5 31. a4 Rfc8 32. axb5 axb5 33. Ra7 R8c7 34. Ra8
+Ne4 35. Qxe4 dxe4 36. Rxd6 Rxc3 37. Bxb5 Rxc2 38. Bc4 Rc3 39. Rad8 e3 40. fxe3
+Rxe3 41. R8d7 Rxg3+ 42. Kf2 Rxd7 43. Rxd7 Rg4 44. Bxe6 Rxh4 45. Rxf7+ Kh6 46.
+Bc4 Rh2+ 47. Ke3 Rb2 48. Rb7 h4 49. Bd3 h3 50. Rb8 h2 51. Be4 Kg5 52. Bd5 Kf5
+53. Rh8 g5 54. Bc4 g4 55. Rf8+ Kg5 56. Rg8+ Kh4 57. Kf4 Rf2+ 58. Ke3 Kg3 59.
+Bd5 Rb2 60. Rh8 Rxb3+ 61. Bxb3 h1=Q 62. Rxh1 Kg2 63. Rg1+ 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "metalkingGT"]
+[Black "cmvaracalov"]
+[Result "1-0"]
+[ECO "A05"]
+[WhiteElo "2453"]
+[BlackElo "2406"]
+[PlyCount "59"]
+[EventDate "2020.??.??"]
+
+1. Nf3 Nf6 2. g3 g6 3. Bg2 Bg7 4. O-O O-O 5. d3 d6 6. Nbd2 c5 7. e4 Nc6 8. c3
+Bg4 9. a3 Ne5 10. Qc2 Nxf3+ 11. Nxf3 Qd7 12. b4 b6 13. d4 cxd4 14. cxd4 Bh3 15.
+Bb2 Bxg2 16. Kxg2 Rac8 17. Qd3 Qg4 18. Rfe1 Nh5 19. Qe3 e5 20. h3 Nf4+ 21. Qxf4
+Qxf4 22. gxf4 exf4 23. Rac1 f5 24. e5 dxe5 25. dxe5 Kf7 26. e6+ Kg8 27. Bxg7
+Kxg7 28. e7 Rfe8 29. Rxc8 Rxc8 30. e8=Q 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "estocastico"]
+[Black "irakliberadze"]
+[Result "1-0"]
+[ECO "C60"]
+[WhiteElo "2563"]
+[BlackElo "2658"]
+[PlyCount "107"]
+[EventDate "2020.??.??"]
+
+1. e4 e5 2. Nf3 Nc6 3. Bb5 Nge7 4. O-O d6 5. d4 Bd7 6. d5 Nb8 7. Be2 g6 8. c4
+Bg7 9. Nc3 O-O 10. Re1 f5 11. Ng5 Qc8 12. Bf3 h6 13. Ne6 Bxe6 14. dxe6 Qxe6 15.
+exf5 gxf5 16. Bxb7 Nd7 17. Bxa8 Rxa8 18. Nd5 Nxd5 19. cxd5 Qg6 20. f3 Rf8 21.
+Be3 Nf6 22. Qc2 Nh5 23. Qxc7 e4 24. f4 Nf6 25. Qxd6 Qh5 26. h3 Qh4 27. Rac1 Qg3
+28. Qe6+ Kh8 29. Qxf5 h5 30. Bf2 Qd3 31. Rc8 Rxc8 32. Qxc8+ Kh7 33. Qf5+ Kh8
+34. Bh4 Nxd5 35. Qxe4 Qxe4 36. Rxe4 Bxb2 37. g4 hxg4 38. hxg4 Bc1 39. Bg3 Kg7
+40. Kg2 Bb2 41. Kf3 Kf7 42. f5 a5 43. Be5 Bxe5 44. Rxe5 Nf6 45. Rxa5 Kg7 46. g5
+Kg8 47. gxf6 Kf7 48. Ra6 Kf8 49. Ke4 Kf7 50. Ke5 Kf8 51. Ke6 Kg8 52. Ra7 Kf8
+53. Rg7 Ke8 54. Rg8# 1-0
+
+[Event "Rated Blitz tournament te4AhseI"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "LeninGuerra"]
+[Black "Cloud_ec"]
+[Result "0-1"]
+[ECO "B41"]
+[WhiteElo "2446"]
+[BlackElo "2443"]
+[PlyCount "60"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 c5 2. Nf3 e6 3. d4 cxd4 4. Nxd4 a6 5. c4 Nf6 6. Nc3 d6 7. Bd3 b6 8. O-O
+Bb7 9. b3 Nbd7 10. Bc2 Rc8 11. Bb2 g6 12. f4 Bg7 13. f5 Qe7 14. Qd2 O-O 15.
+Rae1 Ne5 16. Kh1 Rfe8 17. a4 Qc7 18. h3 Rcd8 19. Qf2 d5 20. cxd5 exd5 21. fxg6
+hxg6 22. exd5 Nxd5 23. Nxd5 Bxd5 24. Be4 Bxe4 25. Rxe4 Nd3 26. Rxe8+ Rxe8 27.
+Qd2 Nxb2 28. Qxb2 Qc5 29. Rd1 Rd8 30. b4 Rxd4 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "corwinifred"]
+[Black "bayrischerFuchs"]
+[Result "1/2-1/2"]
+[ECO "B20"]
+[WhiteElo "2308"]
+[BlackElo "2367"]
+[PlyCount "134"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 c5 2. b4 cxb4 3. a3 bxa3 4. d4 d5 5. exd5 Qxd5 6. Nf3 Bg4 7. Be2 Nc6 8.
+O-O Nf6 9. c4 Qh5 10. d5 Ne5 11. Nbd2 Nxf3+ 12. Nxf3 e6 13. h3 Bxf3 14. Bxf3
+Qe5 15. Qa4+ Nd7 16. Bxa3 Bxa3 17. Rxa3 Rd8 18. Re3 Qf6 19. Qa3 Qe7 20. dxe6
+fxe6 21. Qxa7 O-O 22. Qxb7 Qf6 23. Qe4 Nc5 24. Qe5 Qxe5 25. Rxe5 Rc8 26. Rfe1
+Rxf3 27. gxf3 Nd3 28. Rxe6 Nxe1 29. Rxe1 Rxc4 30. Kg2 h6 31. Kg3 Kh7 32. f4 Ra4
+33. f3 Kg6 34. h4 Kf5 35. Re5+ Kf6 36. Kg4 Ra6 37. h5 Rb6 38. Rd5 Ra6 39. Rf5+
+Ke6 40. Rf8 Ra5 41. f5+ Ke7 42. Rb8 Kf6 43. Rb6+ Kf7 44. Rb7+ Kf6 45. Rb6+ Kf7
+46. Rb7+ Kg8 47. f4 Ra6 48. Rc7 Rf6 49. Rb7 Kh7 50. Rc7 Ra6 51. Rb7 Kg8 52. Rc7
+Ra1 53. f6 gxf6 54. Kf5 Ra6 55. Kg6 Kf8 56. f5 Ra5 57. Rf7+ Kg8 58. Rxf6 Ra1
+59. Rb6 Rg1+ 60. Kxh6 Kf7 61. Rg6 Rf1 62. f6 Rxf6 63. Rxf6+ Kxf6 64. Kh7 Kf7
+65. h6 Kf8 66. Kh8 Kf7 67. h7 Kf8 1/2-1/2
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Frogkiller"]
+[Black "redbullet64"]
+[Result "1-0"]
+[ECO "B95"]
+[WhiteElo "2392"]
+[BlackElo "2393"]
+[PlyCount "61"]
+[EventDate "2020.??.??"]
+
+1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. Qf3 Qa5 8. Bd2
+Qc7 9. O-O-O Be7 10. Bg5 Nc6 11. Qg3 O-O 12. f4 b5 13. Nxc6 Qxc6 14. Bd3 b4 15.
+Ne2 Bb7 16. Nd4 Qa4 17. Kb1 Rac8 18. e5 dxe5 19. fxe5 Ne4 20. Bxe4 Bxe4 21.
+Bxe7 Bxc2+ 22. Nxc2 Qxc2+ 23. Ka1 Rfe8 24. Bd6 b3 25. Qxb3 Qe2 26. Rc1 Rcd8 27.
+a3 Qxg2 28. h4 a5 29. h5 h6 30. Rhg1 Qe2 31. Qg3 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "hungzhao"]
+[Black "Betovsky"]
+[Result "1/2-1/2"]
+[ECO "B01"]
+[WhiteElo "2633"]
+[BlackElo "2617"]
+[PlyCount "116"]
+[EventDate "2020.??.??"]
+
+1. e4 d5 2. exd5 Nf6 3. Bb5+ Bd7 4. Be2 Nxd5 5. d4 Bf5 6. c4 Nb4 7. Na3 N8c6 8.
+Nf3 e6 9. O-O Be7 10. h3 O-O 11. Be3 Bf6 12. Qd2 Qe7 13. Rfd1 h6 14. Nb5 a6 15.
+Nc3 Rfd8 16. Rac1 Rd7 17. a3 Nc2 18. Rxc2 Bxc2 19. Qxc2 Rad8 20. Qe4 Na5 21. b4
+Nc6 22. g4 Nb8 23. Qxb7 c5 24. Qe4 cxb4 25. axb4 Qxb4 26. Qc2 Nc6 27. Ne4 Bxd4
+28. Nxd4 Nxd4 29. Bxd4 Rxd4 30. Rxd4 Rxd4 31. Kg2 Qe1 32. Bf3 Qb4 33. c5 f5 34.
+gxf5 exf5 35. Nd6 Rxd6 36. cxd6 Qxd6 37. Qxf5 Qf6 38. Qxf6 gxf6 39. Bb7 a5 40.
+Bc6 Kf8 41. Ba4 Ke7 42. Kf3 Kd6 43. Kf4 Kc5 44. Kf5 Kb4 45. Be8 h5 46. Kxf6 a4
+47. Bxa4 Kxa4 48. Kg5 h4 49. Kh5 Kb5 50. Kxh4 Kc6 51. Kg5 Kd7 52. h4 Ke7 53.
+Kg6 Kf8 54. h5 Kg8 55. h6 Kh8 56. f4 Kg8 57. f5 Kh8 58. f6 Kg8 1/2-1/2
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "WildBreath"]
+[Black "troisi"]
+[Result "1-0"]
+[ECO "C55"]
+[WhiteElo "2388"]
+[BlackElo "2390"]
+[PlyCount "67"]
+[EventDate "2020.??.??"]
+
+1. e4 e5 2. Nf3 Nc6 3. Bc4 Nf6 4. d3 Be7 5. c3 O-O 6. O-O h6 7. a3 a6 8. h3 d5
+9. exd5 Nxd5 10. Re1 Nb6 11. Ba2 Bf6 12. Nbd2 Bf5 13. Ne4 Re8 14. Nxf6+ Qxf6
+15. Be3 Rad8 16. Bxb6 cxb6 17. Bb1 e4 18. Nd4 Nxd4 19. cxd4 Rxd4 20. Qb3 Red8
+21. dxe4 Be6 22. Qe3 Rd2 23. Ba2 Bxa2 24. Rxa2 Rxb2 25. Rxb2 Qxb2 26. a4 Qd4
+27. Qb3 Qc5 28. e5 Rd2 29. Qf3 Qxe5 30. Rxe5 Rd6 31. Re8+ Kh7 32. Qf5+ Rg6 33.
+Qxf7 b5 34. Qg8# 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Chesscoach46"]
+[Black "bonsitorus"]
+[Result "1-0"]
+[ECO "A45"]
+[WhiteElo "2308"]
+[BlackElo "2306"]
+[PlyCount "79"]
+[EventDate "2020.??.??"]
+
+1. e4 Nf6 2. d4 Nxe4 3. Bd3 Nf6 4. c4 c5 5. Nc3 cxd4 6. Ne4 e5 7. Nxf6+ Qxf6 8.
+f4 exf4 9. Nf3 Bb4+ 10. Bd2 Qe7+ 11. Kf2 Nc6 12. Re1 Qe3+ 13. Bxe3 dxe3+ 14.
+Ke2 Bxe1 15. Kxe1 O-O 16. Qc2 g6 17. a3 d6 18. b4 Bg4 19. Be2 Bxf3 20. Bxf3 Ne5
+21. Be2 Rac8 22. Rd1 Rfd8 23. Kf1 b5 24. Qe4 bxc4 25. Qxf4 c3 26. Qxe3 c2 27.
+Rc1 f5 28. Qxa7 Nc6 29. Qf2 Nd4 30. Qxd4 d5 31. Bd3 Rd6 32. Rxc2 Re8 33. Bc4
+Red8 34. Rd2 dxc4 35. Qxd6 Rxd6 36. Rxd6 c3 37. Rd7 c2 38. Rc7 c1=N 39. Rxc1
+Kf7 40. Rc6 1-0
+
+[Event "Rated Blitz tournament 24qBif2r"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Kaliberda_Vladimir"]
+[Black "Nikame"]
+[Result "0-1"]
+[ECO "B50"]
+[WhiteElo "2341"]
+[BlackElo "2356"]
+[PlyCount "86"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. Nf3 d6 2. e4 c5 3. c3 Nf6 4. Be2 Nc6 5. d3 g6 6. O-O Bg7 7. Bg5 O-O 8. Nbd2
+h6 9. Bh4 g5 10. Bg3 Nh5 11. Nc4 Nf4 12. Bxf4 gxf4 13. Ncd2 e5 14. a4 f5 15.
+Ne1 Qg5 16. Bf3 Kh8 17. exf5 Bxf5 18. Ne4 Qg6 19. Nc2 Rg8 20. Kh1 Rad8 21. Bh5
+Qe6 22. a5 b6 23. axb6 axb6 24. Ra6 d5 25. Qe2 dxe4 26. dxe4 Bg6 27. Bxg6 Qxg6
+28. Rxb6 Nd4 29. Rxg6 Nxe2 30. Re1 Rd2 31. Na3 Rgd8 32. h4 Rxb2 33. Nc4 Rc2 34.
+Rb1 Rc1+ 35. Rxc1 Nxc1 36. Rc6 Rd1+ 37. Kh2 Nd3 38. g4 Nxf2 39. g5 hxg5 40.
+hxg5 Nxe4 41. g6 Bf6 42. Kg2 Rd3 43. Nb6 f3+ 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "lamadestr"]
+[Black "Steed28"]
+[Result "1-0"]
+[ECO "C36"]
+[WhiteElo "2300"]
+[BlackElo "2405"]
+[PlyCount "49"]
+[EventDate "2020.??.??"]
+
+1. e4 e5 2. f4 d5 3. exd5 exf4 4. Nf3 Nf6 5. Bc4 c6 6. d4 cxd5 7. Bd3 Bd6 8.
+O-O O-O 9. Ne5 Qb6 10. Kh1 Qxd4 11. Bxh7+ Kxh7 12. Qxd4 Re8 13. Bxf4 Bxe5 14.
+Bxe5 Nc6 15. Qh4+ Kg8 16. Bxf6 gxf6 17. Qxf6 Be6 18. Nc3 d4 19. Ne4 Rad8 20.
+Ng5 Bd5 21. Nxf7 Re2 22. Qg6+ Kf8 23. Nxd8+ Ke7 24. Qg5+ Kd7 25. Qxd5+ 1-0
+
+[Event "Rated Blitz tournament uAQ2oGqy"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "FinalCut"]
+[Black "psm-ajedrez"]
+[Result "1-0"]
+[ECO "A04"]
+[WhiteElo "2321"]
+[BlackElo "2376"]
+[PlyCount "83"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. Nf3 e6 2. b3 f5 3. Bb2 Nf6 4. e3 Be7 5. c4 O-O 6. d4 d6 7. Nc3 b6 8. Bd3 Kh8
+9. Qc2 Bb7 10. a4 Na6 11. Ba3 c5 12. O-O Nb4 13. Bxb4 cxb4 14. d5 bxc3 15. dxe6
+Bxf3 16. gxf3 Nh5 17. Bxf5 g6 18. Bg4 Ng7 19. Rad1 Rf6 20. Qxc3 h5 21. Bh3 Kh7
+22. f4 Nxe6 23. Bg2 Rc8 24. Rd5 Nc5 25. Rfd1 Qf8 26. a5 Rf5 27. axb6 axb6 28.
+Qb4 Rxd5 29. Rxd5 Bd8 30. Qd2 Bc7 31. b4 Ne6 32. Bh3 Re8 33. Qd3 Ng7 34. Rg5
+Qf6 35. Bd7 Ra8 36. h4 Ra1+ 37. Kg2 Rc1 38. Bc6 Nf5 39. Be4 Nxh4+ 40. Kh3 Nf5
+41. Bxf5 gxf5 42. Qd5 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Molot_ua"]
+[Black "murderoflegends"]
+[Result "0-1"]
+[ECO "A00"]
+[WhiteElo "2381"]
+[BlackElo "2425"]
+[PlyCount "58"]
+[EventDate "2020.??.??"]
+
+1. d3 Nf6 2. c3 e6 3. Nd2 c5 4. g4 b6 5. g5 Ng8 6. Bg2 Nc6 7. h4 Bb7 8. Ngf3
+Qc7 9. Qa4 Bd6 10. Nc4 Nge7 11. e4 Bf4 12. Bxf4 Qxf4 13. e5 O-O 14. Qc2 b5 15.
+Nd6 Nxe5 16. Nxb7 Nxf3+ 17. Kf1 Nxh4 18. Rxh4 Qxh4 19. Nxc5 d6 20. Bxa8 dxc5
+21. Bg2 Qxg5 22. a4 b4 23. cxb4 cxb4 24. Qc4 a5 25. Re1 Nf5 26. Qb5 Qf6 27. Kg1
+Qxb2 28. Qxa5 Qd2 29. Be4 Qxe1+ 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Tigerscot"]
+[Black "zpxocivubyntmraeswdq"]
+[Result "1/2-1/2"]
+[ECO "A80"]
+[WhiteElo "2468"]
+[BlackElo "2695"]
+[PlyCount "136"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 f5 2. Nc3 Nf6 3. Bf4 d5 4. e3 a6 5. Nf3 e6 6. Ne5 c5 7. a3 Nc6 8. Nxc6
+bxc6 9. dxc5 Bxc5 10. Na4 Bd6 11. Bxd6 Qxd6 12. Qd4 e5 13. Qc5 Qxc5 14. Nxc5 a5
+15. Kd2 Rf8 16. f3 Ke7 17. Be2 Kd6 18. b4 Nd7 19. Nxd7 Bxd7 20. Rhb1 Rfb8 21.
+bxa5 Rxb1 22. Rxb1 Rxa5 23. Rb3 c5 24. e4 fxe4 25. fxe4 c4 26. Rc3 d4 27. Rxc4
+Rxa3 28. Bd3 Ra1 29. Ke2 Rc1 30. Rb4 Rh1 31. h3 Rg1 32. Kf2 Rd1 33. Rb6+ Kc7
+34. Ra6 Rd2+ 35. Kg3 Rd1 36. Ra5 Kd6 37. Ra6+ Kc7 38. Ra5 Kd6 39. Rd5+ Ke6 40.
+Bc4 Rc1 41. Rxd4+ Ke7 42. Rd2 Ba4 43. Bd3 g5 44. Rf2 Bd7 45. Re2 h5 46. h4 g4
+47. Rf2 Be6 48. Kh2 Rd1 49. g3 Rc1 50. Kg2 Bd7 51. Rf1 Rxf1 52. Bxf1 Kd6 53.
+Kf2 Kc5 54. Ke3 Kb4 55. Kd2 Bc6 56. c3+ Kc5 57. Ke3 Bb7 58. Be2 Bc6 59. Bd1 Kc4
+60. Kd2 Bxe4 61. Be2+ Kd5 62. Ke3 Bg6 63. Bb5 Kc5 64. Bd7 Kd5 65. Bb5 Kc5 66.
+Be2 Kd5 67. Bf1 Kc5 68. Be2 Kd5 1/2-1/2
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Aisen_Mestnikov"]
+[Black "BerserkAdopter"]
+[Result "1-0"]
+[ECO "E94"]
+[WhiteElo "2393"]
+[BlackElo "2457"]
+[PlyCount "131"]
+[EventDate "2020.??.??"]
+
+1. d4 Nf6 2. c4 g6 3. Nf3 Bg7 4. Nc3 d6 5. e4 Nbd7 6. Be2 e5 7. O-O O-O 8. Bg5
+h6 9. Bh4 c6 10. d5 c5 11. Ne1 a6 12. Nd3 Qe8 13. Qc2 Nh7 14. f3 f5 15. a3 f4
+16. b4 b6 17. bxc5 bxc5 18. Rab1 g5 19. Bf2 h5 20. Na4 g4 21. Nb6 Ra7 22. Nxc8
+Qxc8 23. Qa4 Ng5 24. fxg4 hxg4 25. Bxg4 Qc7 26. Qc6 Nf6 27. Qxc7 Rxc7 28. Bf5
+f3 29. Rfe1 fxg2 30. Kxg2 Nh5 31. Bg3 Bh6 32. Rb6 Rf6 33. Rb8+ Kg7 34. Nxe5
+dxe5 35. Bxe5 Rcf7 36. Rb6 Kg8 37. Bxf6 Nxf6 38. Rg1 Nfxe4 39. Bxe4 Nxe4 40.
+Kh3+ Kh7 41. Rgg6 Ng5+ 42. Kg4 Rg7 43. Rxh6+ Kg8 44. Rhg6 Nf7 45. Rxg7+ Kxg7
+46. Kf5 Kf8 47. Ke6 Nh6 48. Kd7 Nf7 49. Kc6 Kg7 50. d6 Ne5+ 51. Kc7 Kf6 52. d7+
+Kf5 53. d8=Q Nf7 54. Qd6 Nxd6 55. Kd7 Ke4 56. Kxd6 Kd3 57. Kc6 Kxc4 58. Rxa6
+Kb3 59. Ra5 Ka2 60. Rxc5 Ka1 61. Rd5 Ka2 62. Rd4 Ka1 63. Rc4 Ka2 64. Rc5 Ka1
+65. Rb5 Ka2 66. Rb3 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "JiangoFett"]
+[Black "profaVa"]
+[Result "1-0"]
+[ECO "D08"]
+[WhiteElo "2376"]
+[BlackElo "2388"]
+[PlyCount "109"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 d5 2. c4 e5 3. dxe5 d4 4. Nf3 Nc6 5. a3 Nge7 6. b4 Ng6 7. Bb2 a5 8. b5
+Ncxe5 9. Nxe5 Nxe5 10. e3 Be6 11. Bxd4 Nxc4 12. Be2 Qg5 13. O-O O-O-O 14. Qc2
+Nd6 15. Nd2 Bd5 16. Nf3 Qg6 17. Qc3 Ne4 18. Qxa5 Bd6 19. b6 Qh5 20. bxc7 Rde8
+21. Rac1 Ng5 22. Qa8+ Kd7 23. Ne5+ Bxe5 24. Bxh5 Bxh2+ 25. Kxh2 Rxa8 26. Rfd1
+Ke6 27. Bxg7 Rhg8 28. Bd4 Ne4 29. Bf3 f5 30. Bxe4 fxe4 31. g3 Rac8 32. Bb6 Bc6
+33. Rc5 Rg7 34. Rcc1 Rgxc7 35. Bd4 Rd7 36. Kg1 Rcd8 37. Rc3 Kf5 38. Rdc1 Kg4
+39. Rc5 Kf3 40. Rf5+ Ke2 41. Rcc5 Kd3 42. Kg2 Ke2 43. Rc3 Rxd4 44. exd4 e3+ 45.
+f3 Kd2 46. Re5 Kxc3 47. Rxe3+ Kxd4 48. Re2 Kd3 49. Rf2 Bd5 50. g4 Ke3 51. Kg3
+Rf8 52. f4 Rxf4 53. Rxf4 Be4 54. Rf8 Bd3 55. Re8+ 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "pmlmail"]
+[Black "nightfox"]
+[Result "1-0"]
+[ECO "D45"]
+[WhiteElo "2405"]
+[BlackElo "2432"]
+[PlyCount "53"]
+[EventDate "2020.??.??"]
+
+1. d4 e6 2. Nf3 d5 3. c4 c6 4. Nc3 Nd7 5. e3 Ngf6 6. b3 Bd6 7. Bd3 b6 8. O-O
+O-O 9. e4 Bb7 10. e5 Be7 11. exf6 Nxf6 12. Bb2 c5 13. dxc5 Bxc5 14. cxd5 Nxd5
+15. Nxd5 Qxd5 16. Bc4 Qh5 17. Be2 Rad8 18. Qc2 Rc8 19. Qd3 Rfd8 20. Qb5 Bxf3
+21. gxf3 Rd5 22. Qa6 Rg5+ 23. Kh1 Rd8 24. f4 Qh3 25. fxg5 Bd6 26. f4 Bc5 27.
+Rad1 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Derrotado"]
+[Black "Atomrod"]
+[Result "1/2-1/2"]
+[ECO "A00"]
+[WhiteElo "2399"]
+[BlackElo "2502"]
+[PlyCount "104"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. a4 e5 2. g3 d5 3. Bg2 e4 4. d3 f5 5. dxe4 fxe4 6. c4 c6 7. Nc3 Nf6 8. Bg5
+Bb4 9. Kf1 Bxc3 10. bxc3 O-O 11. cxd5 cxd5 12. Bxf6 Qxf6 13. Qxd5+ Be6 14. Qd4
+Qxd4 15. cxd4 Nc6 16. Bxe4 Nxd4 17. Kg2 Rae8 18. Nf3 Bh3+ 19. Kxh3 Rxe4 20.
+Nxd4 Rxd4 21. Kg2 Rd2 22. Rhe1 Re8 23. Rab1 b6 24. a5 bxa5 25. Ra1 Rdxe2 26.
+Rxe2 Rxe2 27. Rxa5 Re7 28. f4 Kf7 29. Kf3 Ke6 30. g4 Kd6 31. f5 Kc6 32. h4 Kb6
+33. Ra1 a5 34. g5 Kb5 35. Kf4 Re2 36. f6 Rf2+ 37. Ke5 gxf6+ 38. gxf6 a4 39. Ke6
+Re2+ 40. Kd7 Rf2 41. Ke7 Re2+ 42. Kf7 Kb4 43. Kg7 Rg2+ 44. Kxh7 Rh2 45. f7
+Rxh4+ 46. Kg7 Rg4+ 47. Kh7 Rf4 48. Kg7 a3 49. f8=Q+ Rxf8 50. Kxf8 Kb3 51. Kf7
+a2 52. Rxa2 Kxa2 1/2-1/2
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Dashibalov"]
+[Black "Pharaohs-Curse"]
+[Result "1-0"]
+[ECO "B10"]
+[WhiteElo "2382"]
+[BlackElo "2349"]
+[PlyCount "87"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 c6 2. d3 d5 3. Nf3 dxe4 4. dxe4 Qxd1+ 5. Kxd1 Nf6 6. Nfd2 e5 7. f3 Bc5 8.
+Nc4 Nbd7 9. c3 O-O 10. Kc2 Re8 11. b4 Bf8 12. Be3 b6 13. Nbd2 c5 14. b5 a6 15.
+bxa6 Bxa6 16. a4 b5 17. axb5 Bxb5 18. Be2 h6 19. Rhb1 Ba4+ 20. Kc1 Bc6 21. Na5
+Rec8 22. Nxc6 Rxa1 23. Rxa1 Rxc6 24. Ra8 Kh7 25. Bb5 Rb6 26. c4 Rb8 27. Ra7 Rd8
+28. Nb3 g5 29. Na5 Kg6 30. Nc6 Rc8 31. Na5 Rd8 32. Ra6 Kg7 33. Kc2 g4 34. Nc6
+Rc8 35. Kc3 gxf3 36. gxf3 h5 37. h4 Bd6 38. Bg5 Kg6 39. Na7 Rc7 40. Bxd7 Rxd7
+41. Nc8 Ne8 42. Be7 Rxe7 43. Nxe7+ Kg7 44. Nf5+ 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Evgen_88"]
+[Black "starkspieler"]
+[Result "1-0"]
+[ECO "D02"]
+[WhiteElo "2520"]
+[BlackElo "2418"]
+[PlyCount "51"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 d5 2. Nf3 Nf6 3. g3 c6 4. Bg2 Bf5 5. O-O h6 6. c4 e6 7. Nc3 Nbd7 8. Qb3
+Qb6 9. c5 Qxb3 10. axb3 a6 11. b4 Rc8 12. Nd2 Be7 13. Nb3 g5 14. Na5 Rc7 15. h4
+Rg8 16. hxg5 hxg5 17. f3 e5 18. dxe5 Nxe5 19. f4 gxf4 20. Bxf4 Nfd7 21. Bxe5
+Nxe5 22. Rxf5 f6 23. Bf3 Rxg3+ 24. Kf2 Rg8 25. Rg1 Bd8 26. Rxg8+ 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Lil_D"]
+[Black "vassiukov"]
+[Result "1-0"]
+[ECO "A00"]
+[WhiteElo "2313"]
+[BlackElo "2334"]
+[PlyCount "47"]
+[EventDate "2020.??.??"]
+
+1. g3 d5 2. Bg2 Nf6 3. d3 Bf5 4. Nd2 e6 5. e4 dxe4 6. dxe4 Bg6 7. Ne2 c6 8. O-O
+Bd6 9. Nf4 Bxf4 10. gxf4 Qc7 11. f5 exf5 12. exf5 Bxf5 13. Re1+ Kf8 14. Nc4 h6
+15. Nd6 Be6 16. Bf4 Qd7 17. Nxb7 Qxb7 18. Qd8+ Ne8 19. Bd6+ Kg8 20. Qxe8+ Kh7
+21. Qe7 Nd7 22. Rxe6 fxe6 23. Be4+ Kg8 24. Qxe6# 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "LordGrim2500"]
+[Black "KingoFish"]
+[Result "0-1"]
+[ECO "B06"]
+[WhiteElo "2462"]
+[BlackElo "2398"]
+[PlyCount "58"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 g6 2. d4 Bg7 3. Nc3 a6 4. Be3 d6 5. a4 Nc6 6. h3 Nf6 7. Nf3 O-O 8. Be2 e5
+9. O-O Re8 10. d5 Nd4 11. a5 Bd7 12. Nd2 c6 13. dxc6 bxc6 14. Bd3 d5 15. Na4
+Be6 16. c3 Nb5 17. Nc5 d4 18. Nxe6 fxe6 19. cxd4 exd4 20. Bg5 e5 21. f4 h6 22.
+Bxf6 Bxf6 23. f5 g5 24. Qh5 Qe7 25. Qxh6 Qg7 26. Qh5 Nd6 27. Nc4 Qf7 28. Qg4
+Nxc4 29. h4 Ne3 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Ngc99"]
+[Black "fullchola"]
+[Result "1/2-1/2"]
+[ECO "A46"]
+[WhiteElo "2305"]
+[BlackElo "2433"]
+[PlyCount "150"]
+[EventDate "2020.??.??"]
+
+1. d4 d6 2. Nf3 Nf6 3. e3 Bg4 4. Be2 Bxf3 5. Bxf3 c6 6. d5 Nbd7 7. dxc6 bxc6 8.
+Bxc6 Rc8 9. Bf3 e5 10. O-O Be7 11. c3 O-O 12. Nd2 d5 13. e4 d4 14. cxd4 exd4
+15. Nb3 Ne5 16. Nxd4 Bc5 17. Nf5 Nxf3+ 18. Qxf3 Qb6 19. Qg3 g6 20. Bh6 Rfe8 21.
+Bg5 Nxe4 22. Nh6+ Kg7 23. Qh4 Nxg5 24. Qxg5 Qf6 25. Qxf6+ Kxf6 26. Ng4+ Kf5 27.
+h3 h5 28. Nh2 Kf6 29. Nf3 Kg7 30. Rac1 Bb6 31. Rxc8 Rxc8 32. Rd1 Rc2 33. Rd2
+Rc1+ 34. Kh2 Bc7+ 35. g3 Bb6 36. Kg2 Ra1 37. a3 Rc1 38. Ne5 Rc5 39. Nd7 Rb5 40.
+Nxb6 axb6 41. b4 Re5 42. Rd6 b5 43. Rd3 g5 44. h4 gxh4 45. gxh4 Kg6 46. Re3 Rd5
+47. Rc3 Rd4 48. Rc5 Rxh4 49. Rxb5 Rd4 50. a4 f6 51. a5 Rd2 52. a6 h4 53. a7 Rd8
+54. Rb8 h3+ 55. Kxh3 Rd3+ 56. Kg2 Rd5 57. a8=Q Rg5+ 58. Kf1 Re5 59. Qg2+ Kf5
+60. Rg8 Ke6 61. Qg4+ Kf7 62. Qg6+ Ke7 63. Re8+ Kd6 64. Rxe5 Kxe5 65. Qxf6+ Kxf6
+66. Ke2 Ke6 67. Ke3 Kd5 68. Kf4 Kc4 69. Kg5 Kxb4 70. f4 Kc5 71. f5 Kd6 72. f6
+Ke6 73. Kg6 Ke5 74. Kg7 Ke4 75. f7 Ke5 1/2-1/2
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "LeonStein"]
+[Black "alphonsea"]
+[Result "1-0"]
+[ECO "A57"]
+[WhiteElo "2310"]
+[BlackElo "2313"]
+[PlyCount "65"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 Nf6 2. c4 c5 3. d5 b5 4. cxb5 a6 5. f3 d6 6. e4 g6 7. Nc3 Bg7 8. Be3 axb5
+9. Bxb5+ Bd7 10. a4 Na6 11. Nge2 Nb4 12. O-O O-O 13. Nc1 Qc7 14. Nd3 Rfb8 15.
+Qe2 Nh5 16. Rfc1 Qb7 17. g4 Nf6 18. h4 Ne8 19. Kg2 Bxb5 20. axb5 Rxa1 21. Rxa1
+Nc7 22. Nxb4 cxb4 23. Ra7 Qc8 24. b6 Ne8 25. Na2 Rb7 26. Nxb4 Qb8 27. Nc6 Qc8
+28. Nxe7+ Rxe7 29. Rxe7 h5 30. b7 Qb8 31. Ba7 Qd8 32. Rxe8+ Qxe8 33. b8=Q 1-0
+
+[Event "Rated Rapid game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Fleetwood_Mac"]
+[Black "Mivo11"]
+[Result "0-1"]
+[ECO "B96"]
+[WhiteElo "2491"]
+[BlackElo "2427"]
+[PlyCount "82"]
+[EventDate "2020.??.??"]
+[EventType "rapid"]
+
+1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 h6 8. Bxf6
+Qxf6 9. Qd2 Nc6 10. O-O-O Nxd4 11. Qxd4 Qxd4 12. Rxd4 Be7 13. Na4 O-O 14. Nb6
+Rb8 15. Bc4 Bd8 16. Nxc8 Rxc8 17. Bb3 Be7 18. Rf1 Rfd8 19. g3 Rc5 20. h4 b5 21.
+c3 h5 22. a3 a5 23. f5 e5 24. Rd5 a4 25. Bd1 Rxd5 26. exd5 g6 27. Be2 Rb8 28.
+Kd2 Kg7 29. Ke3 g5 30. hxg5 Bxg5+ 31. Ke4 h4 32. g4 Kf6 33. Rh1 Ke7 34. Bd1 f6
+35. Rh2 Kd7 36. c4 bxc4 37. Bxa4+ Ke7 38. Bc6 Rb3 39. Re2 h3 40. Ba4 h2 41.
+Bxb3 h1=Q+ 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "isralino"]
+[Black "locelsiano"]
+[Result "1-0"]
+[ECO "A40"]
+[WhiteElo "2306"]
+[BlackElo "2364"]
+[PlyCount "93"]
+[EventDate "2020.??.??"]
+
+1. d4 b6 2. Nc3 Bb7 3. e4 Nf6 4. Bd3 e6 5. Qe2 Bb4 6. Bd2 c5 7. Nf3 Bxc3 8.
+Bxc3 c4 9. Bxc4 Nxe4 10. O-O Nxc3 11. bxc3 O-O 12. Ne5 d6 13. Nf3 Nc6 14. Bd3
+h6 15. Rae1 Rc8 16. Nd2 Na5 17. c4 Qg5 18. f4 Qf6 19. c3 Ba6 20. Ne4 Qe7 21.
+Nd2 Qc7 22. f5 exf5 23. Bxf5 Nxc4 24. Bxc8 Nxd2 25. Bxa6 Nxf1 26. Rxf1 Qxc3 27.
+Qd3 Qa5 28. Bc4 d5 29. Bb3 Re8 30. Bc2 g6 31. Qf3 Re7 32. Bxg6 Qd2 33. Bxf7+
+Kf8 34. Bxd5+ Ke8 35. Qf8+ Kd7 36. Qf5+ Kd6 37. Qf4+ Kd7 38. Qxd2 Kd8 39. Bf3
+Kc7 40. d5 Rd7 41. Qc3+ Kb8 42. Qc6 a6 43. Qxd7 Ka8 44. Qd6 Ka7 45. Qc6 a5 46.
+d6 Ka6 47. Qb7+ 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "taras05"]
+[Black "metalkingGT"]
+[Result "1-0"]
+[ECO "C05"]
+[WhiteElo "2491"]
+[BlackElo "2458"]
+[PlyCount "89"]
+[EventDate "2020.??.??"]
+
+1. e4 e6 2. d4 d5 3. Nd2 Nf6 4. e5 Nfd7 5. f4 c5 6. c3 Nc6 7. Ndf3 cxd4 8. cxd4
+f6 9. Bd3 fxe5 10. fxe5 Bb4+ 11. Kf2 O-O 12. Kg3 g6 13. h4 Ne7 14. Ne2 Qe8 15.
+Ng5 Nf5+ 16. Kh3 Nb6 17. g4 Ng7 18. Rf1 Bd7 19. Nf4 Rc8 20. Nxh7 Rxf4 21. Nf6+
+Rxf6 22. exf6 Nh5 23. f7+ Qxf7 24. Rxf7 Kxf7 25. g5 e5+ 26. Kg2 e4 27. Be2 Ng7
+28. Bg4 Nf5 29. Bxf5 Bxf5 30. Be3 Nc4 31. Bf4 Nxb2 32. Qb3 Nd3 33. Rf1 Rc4 34.
+a3 Be7 35. Qxb7 Rc2+ 36. Kg3 Re2 37. Qxe7+ Kxe7 38. Rb1 Ke6 39. Rb7 Nxf4 40.
+Rb6+ Kd7 41. Rxg6 Kc7 42. Kxf4 Kb7 43. Ke5 Bd7 44. Rg7 e3 45. g6 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Klaksidee"]
+[Black "RyanX4FleteChavale"]
+[Result "1/2-1/2"]
+[ECO "A04"]
+[WhiteElo "2604"]
+[BlackElo "2389"]
+[PlyCount "145"]
+[EventDate "2020.??.??"]
+
+1. Nf3 c6 2. e4 Nf6 3. e5 Nd5 4. d4 Ne3 5. c4 Nxd1 6. Kxd1 e6 7. Nc3 Be7 8. Be3
+b5 9. Bd3 bxc4 10. Bxc4 Na6 11. a3 Nc7 12. Bd3 Nd5 13. Ne4 Nxe3+ 14. fxe3 d5
+15. Ke2 dxe4 16. Bxe4 O-O 17. h4 a5 18. Ng5 Ba6+ 19. Kf3 Bxg5 20. hxg5 g6 21.
+Rh6 Re8 22. Rah1 Kf8 23. Rxh7 Ke7 24. Bxg6 Rf8 25. Bh5 Qd5+ 26. e4 Qxd4 27. g6
+Qxe5 28. g7 Rg8 29. Rh4 Qf6+ 30. Rf4 Qxb2 31. Rxf7+ Kd6 32. Rh6 Qc3+ 33. Kg4
+Rxg7+ 34. Rxg7 Qxg7+ 35. Rg6 Qxg6+ 36. Bxg6 Rc8 37. Kh5 Rb8 38. g4 Rb3 39. g5
+Rxa3 40. Bh7 Bd3 41. g6 Bxe4 42. g7 Bxh7 43. Kh6 Bg8 44. Kg6 Rg3+ 45. Kf6 Rxg7
+46. Kxg7 a4 47. Kf6 a3 48. Kg7 a2 49. Kf8 a1=Q 50. Ke8 Qa5 51. Kf8 Qc5 52. Kxg8
+e5 53. Kf7 e4 54. Kg6 Kd5 55. Kf5 Kd4+ 56. Kf6 Kd3 57. Ke6 e3 58. Kd7 e2 59.
+Kc7 e1=Q 60. Kb8 Qee5+ 61. Kb7 Qcd6 62. Ka6 Qee7 63. Ka5 Qdd7 64. Ka4 c5+ 65.
+Kb3 Qc7 66. Kb2 Qed6 67. Kb1 Qdb6+ 68. Kc1 Qca7 69. Kd1 Qb5 70. Ke1 Qaa4 71.
+Kf2 Qbb3 72. Kf3 Qaa2 73. Kf4 1/2-1/2
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "kinez24"]
+[Black "imdejong"]
+[Result "1/2-1/2"]
+[ECO "C16"]
+[WhiteElo "2326"]
+[BlackElo "2354"]
+[PlyCount "78"]
+[EventDate "2020.??.??"]
+
+1. e4 e6 2. Nc3 d5 3. d4 Bb4 4. e5 Ne7 5. Bd2 Bxc3 6. Bxc3 b6 7. Nf3 Ba6 8. Bd3
+Bxd3 9. cxd3 c5 10. dxc5 bxc5 11. d4 Nd7 12. O-O O-O 13. dxc5 Nxc5 14. Bd4 Ne4
+15. Re1 Rb8 16. Nd2 Nxd2 17. Qxd2 Nc6 18. Rac1 Nxd4 19. Qxd4 Qb6 20. Qa4 Qxb2
+21. Qxa7 Ra8 22. Qd4 Rxa2 23. Qxb2 Rxb2 24. Re3 g5 25. Rg3 h6 26. h4 f6 27.
+exf6 Rxf6 28. hxg5 Rfxf2 29. gxh6+ Kh7 30. Re1 Rbe2 31. Ra1 d4 32. Ra7+ Kxh6
+33. Ra8 Rf7 34. Rh8+ Rh7 35. Rhg8 Re5 36. R3g6+ Kh5 37. Rg3 Kh6 38. R3g6+ Kh5
+39. Rg3 Kh6 1/2-1/2
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "C9C9C9C9C9"]
+[Black "drop_stone"]
+[Result "0-1"]
+[ECO "A14"]
+[WhiteElo "2989"]
+[BlackElo "2920"]
+[PlyCount "96"]
+[EventDate "2020.??.??"]
+
+1. Nf3 d5 2. g3 Nf6 3. Bg2 e6 4. O-O Be7 5. c4 O-O 6. b3 d4 7. e3 c5 8. Bb2 Nc6
+9. Re1 Qb6 10. exd4 cxd4 11. d3 Rd8 12. Nbd2 Bd7 13. a3 a5 14. Rc1 Be8 15. Qc2
+Rac8 16. c5 Qa7 17. Qc4 Nd5 18. Nxd4 Nxd4 19. Bxd4 b6 20. b4 axb4 21. axb4 Qa4
+22. Rb1 Bb5 23. Qc1 Nxb4 24. Ra1 Nxd3 25. Rxa4 Nxc1 26. Rb4 Nd3 27. Rxb5 Nxe1
+28. cxb6 Rxd4 29. b7 Rb8 30. Nb3 Rd1 31. Be4 f5 32. Bc6 g5 33. Kf1 Rb1 34. Ke2
+Nc2 35. Kd3 Nb4+ 36. Kc4 Nxc6 37. Rb6 Ne5+ 38. Kd4 Nd7 39. Rxe6 Kf7 40. Re3 f4
+41. gxf4 gxf4 42. Rf3 Bf6+ 43. Ke4 Rxb7 44. Nd2 R7b4+ 45. Kf5 Rb5+ 46. Kg4 R1b4
+47. Kh3 Rh5+ 48. Kg2 Rg5+ 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "CarlosMontenegro"]
+[Black "Schacher101"]
+[Result "0-1"]
+[ECO "A00"]
+[WhiteElo "2409"]
+[BlackElo "2443"]
+[PlyCount "52"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. g3 d5 2. Bg2 c6 3. Nf3 Nf6 4. d3 g6 5. O-O Bg7 6. c4 O-O 7. Nc3 dxc4 8. dxc4
+Be6 9. Qa4 Na6 10. Rd1 Qc8 11. Nd4 Bh3 12. Bh1 Nc5 13. Qb4 Ne6 14. Qxe7 Nxd4
+15. Rxd4 Nd5 16. Rxd5 cxd5 17. Bxd5 Qd7 18. Qxd7 Bxd7 19. Bxb7 Rab8 20. Bd5
+Rfc8 21. e4 Be6 22. Kf1 Bxd5 23. Nxd5 Rxc4 24. f3 Bxb2 25. Bxb2 Rxb2 26. Ne3
+Rd4 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "sutcunuri"]
+[Black "ajedrez2021"]
+[Result "1-0"]
+[ECO "A02"]
+[WhiteElo "2512"]
+[BlackElo "2601"]
+[PlyCount "75"]
+[EventDate "2020.??.??"]
+
+1. f4 g6 2. Nf3 Bg7 3. g3 c5 4. Bg2 Nc6 5. O-O Nf6 6. c3 O-O 7. d3 d5 8. Na3
+Re8 9. Nc2 e5 10. fxe5 Nxe5 11. Nxe5 Rxe5 12. Bf4 Re8 13. Qd2 Bg4 14. Rae1 Qb6
+15. Ne3 h5 16. Nxd5 Nxd5 17. Bxd5 c4+ 18. d4 Be6 19. Bxe6 Qxe6 20. e4 Qh3 21.
+e5 b5 22. Bg5 b4 23. cxb4 Rac8 24. a3 Qe6 25. Rf3 Qd5 26. Ref1 Rc7 27. Qf2 Rf8
+28. Bd2 a6 29. Bc3 Re8 30. Rf4 Re6 31. h4 f6 32. exf6 Bf8 33. f7+ Kh7 34. g4
+hxg4 35. Rxg4 Ree7 36. Qc2 Qc6 37. d5 Qd7 38. Qxg6# 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "WildBreath"]
+[Black "Frogkiller"]
+[Result "1-0"]
+[ECO "B23"]
+[WhiteElo "2394"]
+[BlackElo "2398"]
+[PlyCount "49"]
+[EventDate "2020.??.??"]
+
+1. e4 c5 2. Nc3 d6 3. Bb5+ Nd7 4. Bxd7+ Bxd7 5. d3 g6 6. f4 Bg7 7. Nf3 Bc6 8.
+O-O e6 9. Qe1 Nf6 10. Qh4 Nd7 11. Qh3 b5 12. f5 b4 13. Ne2 exf5 14. exf5 O-O
+15. Bh6 Bxf3 16. Rxf3 Ne5 17. Rg3 Qd7 18. Nf4 Bxh6 19. Qxh6 Qxf5 20. Nh5 Qxh5
+21. Qxh5 Rfe8 22. Rf1 Re7 23. Qh6 Rae8 24. h4 Nd7 25. h5 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "troisi"]
+[Black "redbullet64"]
+[Result "0-1"]
+[ECO "E61"]
+[WhiteElo "2384"]
+[BlackElo "2388"]
+[PlyCount "106"]
+[EventDate "2020.??.??"]
+
+1. d4 Nf6 2. c4 g6 3. Nc3 Bg7 4. Nf3 d6 5. e3 O-O 6. h3 Nc6 7. a4 e5 8. a5 exd4
+9. exd4 Re8+ 10. Be3 a6 11. Be2 Bf5 12. O-O Ne4 13. Nxe4 Bxe4 14. Qd2 Qe7 15.
+b4 Nd8 16. b5 axb5 17. cxb5 Bd5 18. Rfe1 c6 19. a6 bxa6 20. bxa6 Ra7 21. Qa5
+Ne6 22. Bd3 Rea8 23. Qb6 Qc7 24. Qxc7 Nxc7 25. Nd2 Nxa6 26. Bc4 Nc7 27. Rxa7
+Rxa7 28. Bxd5 Nxd5 29. Nc4 Bf8 30. Rb1 Ra4 31. Nb6 Nxb6 32. Rxb6 Rc4 33. Rb8
+Kg7 34. Rd8 Be7 35. Rd7 Kf6 36. Bg5+ Kxg5 37. Rxe7 Kf6 38. Rd7 d5 39. f3 Ke6
+40. Rc7 Kd6 41. Rxf7 Rxd4 42. Rxh7 c5 43. Rh6 c4 44. Rxg6+ Ke5 45. Kf2 c3 46.
+Rc6 Rc4 47. Rxc4 dxc4 48. Ke3 Kd5 49. f4 Kc5 50. f5 Kb4 51. f6 Kb3 52. f7 c2
+53. f8=Q c1=Q+ 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "bonsitorus"]
+[Black "Chesscoach46"]
+[Result "0-1"]
+[ECO "A04"]
+[WhiteElo "2300"]
+[BlackElo "2314"]
+[PlyCount "112"]
+[EventDate "2020.??.??"]
+
+1. Nf3 c5 2. d4 e6 3. dxc5 Bxc5 4. e4 d5 5. exd5 Qxd5 6. Qxd5 exd5 7. Nc3 Nf6
+8. Bg5 Be6 9. Bxf6 gxf6 10. O-O-O d4 11. Ne4 Be7 12. Nxd4 Bd5 13. Bb5+ Kf8 14.
+f3 a6 15. Bd3 Nc6 16. Nf5 Be6 17. Nxe7 Kxe7 18. Rhe1 Rad8 19. f4 f5 20. Ng3 Kf6
+21. Nh5+ Kg6 22. Be2 Nd4 23. Ng3 Nxe2+ 24. Rxe2 h5 25. Rde1 h4 26. Nf1 Kf6 27.
+Nd2 Rd4 28. g3 hxg3 29. hxg3 Rg8 30. Nf1 Rgd8 31. c3 R4d6 32. Nh2 Bxa2 33. Nf3
+Bb3 34. Nd4 Rxd4 35. cxd4 Rxd4 36. Rd2 Rc4+ 37. Kb1 a5 38. Rd6+ Kg7 39. Rd3 a4
+40. Rc3 Rd4 41. Rc7 b5 42. Rc5 Kf6 43. Rxb5 Rd2 44. Rb6+ Kg7 45. Rb5 Rg2 46.
+Rxf5 Bc2+ 47. Ka2 Bxf5 48. Ka3 Be6 49. f5 Rxg3+ 50. Kxa4 Bxf5 51. b4 Kf6 52. b5
+Rg2 53. b6 Ra2+ 54. Kb3 Ra8 55. b7 Rb8 56. Re7 Kxe7 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Ania_Andrzejewska"]
+[Black "Near__You"]
+[Result "0-1"]
+[ECO "A45"]
+[WhiteElo "2358"]
+[BlackElo "2345"]
+[PlyCount "50"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 Nf6 2. c3 d5 3. Bg5 Ne4 4. Bf4 Bf5 5. Qb3 Nd7 6. Qxb7 Rb8 7. Qxd5 e6 8.
+Qc6 Rxb2 9. f3 Rb6 10. Qxc7 Nf2 11. Kxf2 Bxb1 12. Qxa7 e5 13. Be3 Rb2 14. Nh3
+Bd6 15. g3 O-O 16. Bc1 Rb8 17. Bg2 exd4 18. cxd4 Bf5 19. Bf4 Nb6 20. Rhd1 Re8
+21. e4 Bxh3 22. Bxd6 Qxd6 23. Bxh3 Ra8 24. Qb7 Reb8 25. e5 Qh6 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Kidefence"]
+[Black "BlueGreensun"]
+[Result "0-1"]
+[ECO "B00"]
+[WhiteElo "2702"]
+[BlackElo "2764"]
+[PlyCount "96"]
+[EventDate "2020.??.??"]
+
+1. e4 e5 2. d4 Nc6 3. dxe5 d6 4. Nf3 Bg4 5. exd6 Bxd6 6. Bd3 Nf6 7. Nc3 Qe7 8.
+h3 Bh5 9. Bg5 O-O-O 10. g4 Bg6 11. Qe2 h6 12. Bh4 Bb4 13. e5 Bxd3 14. cxd3 g5
+15. exf6 Qxf6 16. O-O gxh4 17. Ne4 Qf4 18. Rad1 h5 19. Qe3 Bd6 20. Qxf4 Bxf4
+21. g5 Rhg8 22. Kh1 Rd5 23. Rg1 Rgd8 24. Nxh4 Rxd3 25. Rxd3 Rxd3 26. Kg2 Ne5
+27. Re1 b6 28. a3 c5 29. b4 Rxa3 30. bxc5 b5 31. Nd6+ Kc7 32. Nxb5+ Kc6 33.
+Nxa3 Nd3 34. Re7 a5 35. Rxf7 Bxg5 36. Nf3 Bc1 37. Nc4 a4 38. Nfe5+ Nxe5 39.
+Nxe5+ Kxc5 40. Ra7 Kb5 41. Nd3 Bg5 42. Ne5 Bf4 43. Ra8 Bxe5 44. Re8 Bd6 45. Rh8
+a3 46. Rxh5+ Kb4 47. Rh7 Bc5 48. Ra7 Bxa7 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Brocha"]
+[Black "NEKI_NOVI_KLINAC"]
+[Result "0-1"]
+[ECO "C00"]
+[WhiteElo "2461"]
+[BlackElo "2450"]
+[PlyCount "90"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 e6 2. d3 d5 3. Nd2 dxe4 4. Nxe4 Nf6 5. Nxf6+ gxf6 6. g3 Bd6 7. Bg2 c6 8.
+Ne2 b6 9. Bf4 Bb7 10. Qd2 e5 11. Bh6 Nd7 12. O-O-O Qe7 13. f4 O-O-O 14. Nc3 Bb4
+15. a3 Bxa3 16. bxa3 Qxa3+ 17. Kb1 Qb4+ 18. Ka1 Nc5 19. Na2 Qa4 20. Rhe1 Rxd3
+21. Qxd3 Nxd3 22. cxd3 c5 23. Bxb7+ Kxb7 24. Bg7 Rg8 25. Bxf6 exf4 26. Be5 fxg3
+27. Bxg3 h5 28. d4 h4 29. Bf2 Rg2 30. Rd2 Rxf2 31. Rxf2 Qxd4+ 32. Rb2 a5 33.
+Kb1 h3 34. Nc1 a4 35. Ree2 a3 36. Rb3 c4 37. Rxa3 f5 38. Rc2 Qe4 39. Rxh3 f4
+40. Rhc3 f3 41. Rxc4 Qf5 42. Rc7+ Kb8 43. Rc8+ Kb7 44. R8c7+ Ka6 45. Nd3 Qxd3
+0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "MiroMiljkovic"]
+[Black "irakliberadze"]
+[Result "1-0"]
+[ECO "E17"]
+[WhiteElo "2603"]
+[BlackElo "2650"]
+[PlyCount "61"]
+[EventDate "2020.??.??"]
+
+1. d4 Nf6 2. Nf3 e6 3. g3 b6 4. Bg2 Bb7 5. O-O Be7 6. c4 O-O 7. Nc3 d6 8. d5 e5
+9. e4 Nbd7 10. Ne1 c5 11. Nd3 Ne8 12. f4 exf4 13. gxf4 f6 14. f5 Ne5 15. Nf4
+Nc7 16. Ne6 Nxe6 17. fxe6 Nxc4 18. Bf4 Ne5 19. Bxe5 dxe5 20. Kh1 a6 21. Bh3 b5
+22. Qg4 c4 23. Rg1 g6 24. Qh4 Qe8 25. Bf5 Kh8 26. Bxg6 Qxg6 27. Rxg6 Rg8 28.
+Rag1 Rxg6 29. Rxg6 Re8 30. Qh6 f5 31. Qg7# 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "RigelStar"]
+[Black "estocastico"]
+[Result "1-0"]
+[ECO "A45"]
+[WhiteElo "2390"]
+[BlackElo "2570"]
+[PlyCount "95"]
+[EventDate "2020.??.??"]
+
+1. d4 Nf6 2. e3 g6 3. Nf3 Bg7 4. Be2 d5 5. b3 c5 6. Bb2 cxd4 7. exd4 O-O 8. O-O
+Ne4 9. c4 Nc6 10. Nbd2 Bg4 11. h3 Bf5 12. c5 Rc8 13. Rc1 a5 14. a3 Re8 15. Bb5
+Bh6 16. g4 Nxd2 17. Nxd2 Bd7 18. Bxc6 Bxc6 19. f4 f6 20. b4 Qc7 21. Qf3 Ra8 22.
+Rce1 axb4 23. axb4 Ra2 24. Bc3 Ra3 25. Nb1 Rb3 26. Qd1 Rxb1 27. Qxb1 Bxf4 28.
+Qd3 e5 29. b5 e4 30. Qe2 Bd7 31. Ra1 f5 32. Ba5 Qb8 33. Rae1 Bh6 34. Rb1 f4 35.
+c6 Bc8 36. c7 Qa8 37. Ra1 f3 38. Qc2 b6 39. Bxb6 Qb7 40. Qc6 Be3+ 41. Kh1 Bf4
+42. Qxb7 Bxb7 43. Ra7 Bc8 44. Bc5 e3 45. b6 e2 46. Raa1 exf1=Q+ 47. Rxf1 Bb7
+48. Kg1 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "alireza3700"]
+[Black "Sauledramolac"]
+[Result "1-0"]
+[ECO "A00"]
+[WhiteElo "2316"]
+[BlackElo "2301"]
+[PlyCount "93"]
+[EventDate "2020.??.??"]
+
+1. d4 c5 2. Nc3 cxd4 3. Qxd4 Nc6 4. Qh4 f6 5. e4 d6 6. f4 Be6 7. Nf3 Bf7 8. Bb5
+e5 9. fxe5 dxe5 10. Be3 Bb4 11. O-O Nge7 12. Rfd1 Qa5 13. Bxc6+ Nxc6 14. Nd5
+Bxd5 15. Rxd5 Qc7 16. Rad1 O-O 17. c3 Be7 18. Rd7 f5 19. Rxc7 Bxh4 20. Nxh4
+fxe4 21. Rxb7 Rf7 22. Rdd7 Rxd7 23. Rxd7 Rb8 24. Nf5 g6 25. Nh6+ Kf8 26. b4 Ne7
+27. Bc5 Re8 28. Kf2 Kg7 29. Rxe7+ Rxe7 30. Bxe7 Kxh6 31. Bf6 a6 32. h3 g5 33.
+Bxe5 Kg6 34. Ke3 g4 35. Kxe4 gxh3 36. gxh3 h5 37. h4 a5 38. bxa5 Kf7 39. a6 Ke8
+40. a7 Kd7 41. a8=Q Ke6 42. Qd5+ Ke7 43. Qd6+ Kf7 44. Qf6+ Ke8 45. Qg7 Kd8 46.
+Kd4 Kc8 47. Qc7# 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Betovsky"]
+[Black "hungzhao"]
+[Result "1-0"]
+[ECO "C01"]
+[WhiteElo "2617"]
+[BlackElo "2633"]
+[PlyCount "93"]
+[EventDate "2020.??.??"]
+
+1. d4 e6 2. e4 Nf6 3. Bd3 d5 4. exd5 exd5 5. Nf3 Bd6 6. O-O O-O 7. h3 g6 8. c4
+dxc4 9. Bxc4 Re8 10. Bg5 Be6 11. Bxe6 Rxe6 12. Nc3 c6 13. Re1 Rxe1+ 14. Qxe1
+Nbd7 15. Ne4 Be7 16. Ng3 Nd5 17. Bh6 Bf8 18. Bd2 Bg7 19. Qd1 Qb6 20. Qc2 Re8
+21. a3 N7f6 22. Re1 Rxe1+ 23. Bxe1 Qb5 24. Bc3 Nd7 25. Ne4 a5 26. Nd6 Qa6 27.
+Ne8 Bf8 28. Ne5 Nxe5 29. dxe5 Qc4 30. Qd2 b6 31. h4 Qxh4 32. Nf6+ Nxf6 33. exf6
+h5 34. Qd8 Qe4 35. Qxb6 a4 36. Qd8 Qd5 37. Qxd5 cxd5 38. Kf1 Bc5 39. Ke2 Kf8
+40. f3 Ke8 41. g4 h4 42. Kf1 g5 43. Bd2 Bd4 44. Bc1 Bxf6 45. Kg2 Kd7 46. f4 Kc6
+47. fxg5 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "MrMania"]
+[Black "lord_barre"]
+[Result "0-1"]
+[ECO "A00"]
+[WhiteElo "2381"]
+[BlackElo "2413"]
+[PlyCount "126"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. g3 d5 2. Bg2 e5 3. d4 exd4 4. Nf3 c5 5. O-O Nc6 6. c3 dxc3 7. Nxc3 d4 8. Ne4
+Bf5 9. Nh4 Be6 10. Bg5 Qd7 11. Rc1 b6 12. b4 Nxb4 13. Nxc5 bxc5 14. Bxa8 Nxa2
+15. Rb1 Nb4 16. e3 d3 17. Nf3 Bd6 18. Bf4 Nf6 19. Ne5 Bxe5 20. Bxe5 O-O 21.
+Bxf6 Rxa8 22. Bc3 a5 23. Qh5 Qd5 24. Qh4 Qf3 25. Qg5 f6 26. Qf4 Bd5 27. Qxf3
+Bxf3 28. h4 Nd5 29. Bd2 c4 30. Rfc1 Rc8 31. Rxc4 Rxc4 32. Bxa5 Rc2 33. g4 d2
+34. Bxd2 Rxd2 35. g5 fxg5 36. hxg5 h5 37. Kh2 Rxf2+ 38. Kg3 Be4 39. Kxf2 Bxb1
+40. Kg3 Bg6 41. e4 Ne7 42. Kf4 Kf7 43. e5 Ke6 44. Ke3 Nd5+ 45. Kf3 Kxe5 46. Kg3
+Kf5 47. Kh4 Kf4 48. Kh3 Kxg5 49. Kh2 Bf5 50. Kh1 g6 51. Kg1 h4 52. Kh2 Kg4 53.
+Kg1 g5 54. Kh2 Nf4 55. Kg1 Nh3+ 56. Kh2 Kf4 57. Kh1 g4 58. Kh2 g3+ 59. Kh1 Kg4
+60. Kg2 Be4+ 61. Kf1 g2+ 62. Ke2 g1=Q 63. Kd2 Qd4+ 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "vassiukov"]
+[Black "Lil_D"]
+[Result "1-0"]
+[ECO "A40"]
+[WhiteElo "2328"]
+[BlackElo "2319"]
+[PlyCount "71"]
+[EventDate "2020.??.??"]
+
+1. d4 g6 2. Nf3 Bg7 3. Bf4 d6 4. e3 Nf6 5. h3 O-O 6. Nbd2 Nc6 7. c3 Nd7 8. Be2
+e5 9. dxe5 dxe5 10. Bh2 a5 11. O-O a4 12. Qc2 Qe7 13. Rfe1 f5 14. Bb5 a3 15. b4
+Na7 16. Bc4+ Kh8 17. Rad1 Nb6 18. Bb3 Nb5 19. c4 e4 20. cxb5 exf3 21. Nxf3 Qxb4
+22. Bxc7 Qxb5 23. Rd6 Na4 24. Ng5 h6 25. Rxg6 Ra6 26. Rxa6 Qxa6 27. Nf7+ Rxf7
+28. Bxf7 Nb2 29. Bf4 b5 30. Rc1 Bd7 31. Qb3 b4 32. Bc4 Bb5 33. Bxb5 Qxb5 34.
+Qf7 Kh7 35. Rc7 Nd3 36. Qxg7# 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "hanysayed"]
+[Black "elRope"]
+[Result "0-1"]
+[ECO "C45"]
+[WhiteElo "2309"]
+[BlackElo "2361"]
+[PlyCount "114"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 e5 2. Nf3 Nc6 3. d4 exd4 4. Bc4 Nf6 5. e5 Ng4 6. Bxf7+ Kxf7 7. Ng5+ Kg8
+8. Qxg4 h6 9. Nf3 d6 10. e6 Qf6 11. O-O Bxe6 12. Qg3 Be7 13. Na3 a6 14. Re1 Kh7
+15. Bd2 Rhf8 16. c3 Bd5 17. Nxd4 Nxd4 18. cxd4 Rae8 19. Nc2 Bd8 20. h3 Qg6 21.
+Qxg6+ Kxg6 22. Nb4 Be4 23. f3 Bf5 24. Nd5 c6 25. Nf4+ Kf7 26. g4 Bd7 27. Rxe8
+Rxe8 28. Re1 Rf8 29. d5 Bg5 30. Re2 cxd5 31. Nxd5 Bb5 32. Rg2 Bd8 33. Nc3 Bc6
+34. Ne4 d5 35. Nd6+ Ke6 36. Nf5 Bb6+ 37. Kh2 g6 38. Bxh6 Rh8 39. Re2+ Kd7 40.
+Re7+ Kd8 41. Bg5 Kc8 42. Nd6+ Kb8 43. Nf7 Rf8 44. Bf4+ Ka7 45. Bd6 d4 46. Kg3
+d3 47. Bb4 d2 48. Bxd2 Bc5 49. Be3 Bxe3 50. Rxe3 Rxf7 51. h4 Kb6 52. g5 Kc5 53.
+f4 Kd6 54. b4 Re7 55. f5 Rxe3+ 56. Kf4 Re4+ 57. Kg3 gxf5 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "MISSISSIPPIPLAYER"]
+[Black "Pirocanac91"]
+[Result "1-0"]
+[ECO "E48"]
+[WhiteElo "2396"]
+[BlackElo "2330"]
+[PlyCount "169"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 Nf6 2. c4 e6 3. Nc3 Bb4 4. e3 O-O 5. Bd3 d5 6. cxd5 exd5 7. Nge2 c5 8.
+Qc2 b6 9. Bd2 Ba6 10. Bxa6 Nxa6 11. O-O Bxc3 12. bxc3 Re8 13. Ng3 Nc7 14. a4
+Ne6 15. Bc1 Rc8 16. Qe2 g6 17. Qa6 Qd7 18. a5 b5 19. Rb1 Rb8 20. Ba3 Qb7 21.
+Qxb7 Rxb7 22. dxc5 Rc8 23. Ne2 Nxc5 24. Nd4 a6 25. Rfd1 Nce4 26. Ne2 Rc4 27. f3
+Nc5 28. Nd4 Na4 29. Ne2 Rb8 30. Be7 Ne8 31. Rxd5 Nxc3 32. Nxc3 Rxc3 33. Rbd1 f5
+34. Rd7 Rbc8 35. Ra7 R3c7 36. Rd7 Rxd7 37. Rxd7 Rc7 38. Rxc7 Nxc7 39. Kf2 Nd5
+40. Bd8 Kf7 41. e4 fxe4 42. fxe4 Nf6 43. Ke3 Ke6 44. Kd4 Nd7 45. Bb6 Kd6 46.
+Ba7 Kc6 47. e5 Nf8 48. Bb8 Ne6+ 49. Ke4 b4 50. Bd6 b3 51. Ba3 Kb5 52. Kd5 Nf4+
+53. Kd6 Kxa5 54. g3 Ne2 55. Bb2 Nc3 56. Bxc3+ Kb5 57. e6 a5 58. e7 a4 59. e8=Q+
+Kc4 60. Qe4+ Kxc3 61. Qxa4 Kb2 62. Qb5 Kc2 63. Qxb3+ Kxb3 64. Ke5 Kc3 65. Kf6
+Kd3 66. h4 Ke3 67. g4 Kf3 68. h5 Kxg4 69. h6 Kh5 70. Kg7 g5 71. Kxh7 g4 72. Kg7
+g3 73. h7 g2 74. h8=Q+ Kg4 75. Qh2 Kf3 76. Qg1 Kg3 77. Kg6 Kf3 78. Kf5 Kg3 79.
+Ke4 Kh3 80. Ke3 Kg3 81. Ke2 Kg4 82. Kf2 Kf4 83. Qxg2 Ke5 84. Qf3 Kd4 85. Qe3+
+1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "fusionpro"]
+[Black "Morphysher"]
+[Result "1-0"]
+[ECO "A40"]
+[WhiteElo "2452"]
+[BlackElo "2313"]
+[PlyCount "107"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 e6 2. g3 d5 3. Bg2 Nf6 4. Nf3 Bd6 5. O-O O-O 6. c4 c5 7. Nc3 Nc6 8. cxd5
+exd5 9. a3 Nxd4 10. Nxd4 cxd4 11. Qxd4 Be6 12. Bg5 Be7 13. Rfd1 h6 14. Bf4 Qb6
+15. Qxb6 axb6 16. Nxd5 Nxd5 17. Bxd5 Bxd5 18. Rxd5 Rac8 19. Rad1 Bf6 20. Be5
+Bxe5 21. Rxe5 Rc2 22. Rd7 Rxb2 23. Rxb7 Ra8 24. Ree7 Rf8 25. e3 Ra2 26. Ra7 b5
+27. Reb7 Rb2 28. Kg2 Rb3 29. Kf3 g6 30. Ra5 Rc8 31. Rbxb5 Rxb5 32. Rxb5 Ra8 33.
+Rb3 Ra4 34. Ke2 Kg7 35. Kd2 Kf6 36. Kc2 Ke5 37. f3 Rc4+ 38. Kb2 Kd5 39. Rd3+
+Kc5 40. Rc3 Rxc3 41. Kxc3 Kb5 42. Kd4 f6 43. Kd5 Ka4 44. Ke6 f5 45. Kf6 Kxa3
+46. Kxg6 Kb3 47. Kxf5 Kc3 48. e4 Kd3 49. e5 Kd4 50. e6 Ke3 51. f4 Kf3 52. e7
+Kg2 53. e8=Q Kxh2 54. Kg4 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "nightfox"]
+[Black "Molot_ua"]
+[Result "0-1"]
+[ECO "A00"]
+[WhiteElo "2426"]
+[BlackElo "2376"]
+[PlyCount "88"]
+[EventDate "2020.??.??"]
+
+1. d3 c6 2. g3 d6 3. Bg2 Nd7 4. e4 h6 5. Ne2 g5 6. Nbc3 Bg7 7. h4 Ngf6 8. hxg5
+hxg5 9. Rxh8+ Bxh8 10. Bxg5 Qb6 11. Qc1 Ne5 12. Be3 Qa5 13. Qd2 Neg4 14. Bd4 e5
+15. Be3 Nxe3 16. Qxe3 Ng4 17. Qg5 Qb6 18. Qg8+ Ke7 19. O-O-O Qxf2 20. Rf1 Qe3+
+21. Kb1 Bf6 22. Bh3 Qg5 23. Qh7 Be6 24. Bxg4 Rh8 25. Qxh8 Bxh8 26. Bxe6 Kxe6
+27. a3 Bg7 28. Ka2 Ke7 29. Rd1 Qg4 30. Rd2 Bh6 31. Rd1 Qf3 32. d4 exd4 33. Rxd4
+c5 34. Rd3 Qf6 35. Nd5+ Ke6 36. Nxf6 Kxf6 37. Rxd6+ Kg7 38. Rxh6 Kxh6 39. Kb3
+Kg5 40. Kc4 b6 41. Kb5 Kf6 42. Ka6 b5 43. Kxa7 b4 44. Kb6 bxa3 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "provolution"]
+[Black "CheKarloz"]
+[Result "1-0"]
+[ECO "A45"]
+[WhiteElo "2307"]
+[BlackElo "2334"]
+[PlyCount "67"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 Nf6 2. Nc3 e6 3. Bg5 d5 4. Qd2 Bb4 5. a3 Bxc3 6. Qxc3 Nc6 7. Nf3 h6 8.
+Bxf6 Qxf6 9. e3 Bd7 10. Bd3 O-O 11. b4 a6 12. O-O Rfc8 13. a4 a5 14. b5 Nb4 15.
+Ne5 Be8 16. Be2 c6 17. Qd2 cxb5 18. axb5 Rxc2 19. Qd1 b6 20. Ra4 Rac8 21. Bd3
+Nxd3 22. Qxd3 R8c3 23. Qd1 Bxb5 24. Ra1 Qe7 25. Re1 f6 26. Nf3 a4 27. Rb1 Qd7
+28. Ra1 Qc6 29. Qb1 Bc4 30. Rd1 b5 31. Nd2 b4 32. Nxc4 dxc4 33. Qxb4 a3 34.
+Rxa3 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Club-Jaque-al-Rey"]
+[Black "gmmitkov"]
+[Result "0-1"]
+[ECO "C45"]
+[WhiteElo "2528"]
+[BlackElo "2514"]
+[PlyCount "42"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 e5 2. Nf3 Nc6 3. d4 exd4 4. Nxd4 Bc5 5. Be3 Qf6 6. c3 Nge7 7. Qd2 Qg6 8.
+Nb5 Bxe3 9. Qxe3 Kd8 10. Nd2 a6 11. Nd4 d6 12. O-O-O Bd7 13. f4 Kc8 14. g3 Re8
+15. Qf2 Nxd4 16. cxd4 d5 17. e5 Bf5 18. Nf3 Qc6+ 19. Kd2 Qa4 20. a3 Nc6 21. Rc1
+Be4 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "imdejong"]
+[Black "DavidcabTOP9"]
+[Result "0-1"]
+[ECO "B31"]
+[WhiteElo "2354"]
+[BlackElo "2322"]
+[PlyCount "76"]
+[EventDate "2020.??.??"]
+
+1. e4 c5 2. Nf3 Nc6 3. Bb5 g6 4. Bxc6 bxc6 5. O-O Bg7 6. Re1 e5 7. b4 cxb4 8.
+a3 Ne7 9. axb4 O-O 10. Bb2 Qc7 11. d4 d6 12. dxe5 dxe5 13. Nbd2 c5 14. b5 Be6
+15. c4 Rfd8 16. Qc2 h6 17. Ra6 g5 18. Rea1 Ng6 19. g3 Qe7 20. b6 Qb7 21. bxa7
+Ne7 22. Bc3 Nc6 23. Qa4 Nd4 24. Bxd4 exd4 25. e5 Bg4 26. Ne1 Bxe5 27. Nd3 Bh3
+28. f3 Bg7 29. Ne4 Re8 30. Ndxc5 Qc7 31. Rd6 f5 32. Nf6+ Bxf6 33. Rxf6 Qxc5 34.
+Qd7 d3+ 35. Kh1 Re7 36. Qd5+ Qxd5 37. cxd5 Rae8 38. d6 Re1+ 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Mia_Khaliffa"]
+[Black "EzWin78"]
+[Result "1-0"]
+[ECO "C55"]
+[WhiteElo "2427"]
+[BlackElo "2498"]
+[PlyCount "81"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 e5 2. Nf3 Nc6 3. Bc4 Nf6 4. d3 Be7 5. Bb3 O-O 6. c3 d6 7. h3 Kh8 8. g4
+Be6 9. Nbd2 Nd7 10. Nf1 Nc5 11. Bc2 d5 12. Qe2 a5 13. Ng3 b5 14. b3 d4 15. c4
+a4 16. Bb2 Nb4 17. O-O Bd6 18. cxb5 Qd7 19. bxa4 Nxa4 20. Bxa4 Rxa4 21. a3 Na2
+22. Nf5 Qxb5 23. Rfb1 Qa6 24. Ng5 Bxa3 25. Nxe6 Qxe6 26. f4 Nc3 27. Bxc3 dxc3
+28. fxe5 Qxe5 29. Qc2 Raa8 30. d4 Qf4 31. Kg2 g6 32. Rf1 Qd2+ 33. Qxd2 cxd2 34.
+Ng3 Bb2 35. Rxa8 Rxa8 36. d5 Ra1 37. Rxf7 d1=Q 38. Rxc7 Qg1+ 39. Kf3 Ra4 40.
+Rc8+ Kg7 41. Rc7+ 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "camilomunoz0107"]
+[Black "Glig"]
+[Result "1-0"]
+[ECO "D21"]
+[WhiteElo "2365"]
+[BlackElo "2452"]
+[PlyCount "131"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 d5 2. c4 dxc4 3. Nf3 e6 4. Qa4+ Bd7 5. Qxc4 Bc6 6. Nc3 Nd7 7. a4 Ngf6 8.
+Bg5 Be7 9. g3 Bxf3 10. exf3 Nb6 11. Qd3 a6 12. Rd1 Nbd5 13. Bg2 h6 14. Bc1 O-O
+15. O-O c6 16. Ne4 a5 17. b3 Qb6 18. Bb2 Rfd8 19. Qc4 Qb4 20. Rc1 Nb6 21. Qc2
+Rxd4 22. Bc3 Rxe4 23. Bxb4 Rxb4 24. Rfd1 Nbd5 25. f4 Nd7 26. Bf1 N7b6 27. Bc4
+Bf6 28. Rd3 g6 29. Rcd1 Kg7 30. h4 h5 31. Kg2 Nc8 32. Rf3 Nd6 33. Bd3 Nf5 34.
+Bxf5 gxf5 35. Rdd3 Rc8 36. Rxd5 exd5 37. Qxf5 Re8 38. Qxh5 Re1 39. Qg4+ Kh7 40.
+Qf5+ Kg7 41. h5 Ba1 42. Qg5+ Kh7 43. Qf5+ Kg7 44. g4 Rd4 45. Rd3 Rde4 46. Re3
+R4xe3 47. fxe3 Rxe3 48. g5 Rxb3 49. h6+ Kg8 50. g6 fxg6 51. Qxg6+ Kh8 52. f5
+Rb2+ 53. Kh3 Rb3+ 54. Kg4 Rb1 55. Qe8+ Kh7 56. Qg6+ Kh8 57. Qe8+ Kh7 58. Qd7+
+Kh8 59. f6 Bxf6 60. Kf5 Ba1 61. Qe8+ Kh7 62. Qf7+ Kh8 63. Ke6 Re1+ 64. Kd7 Rh1
+65. h7 Rxh7 66. Ke6 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Aisen_Mestnikov"]
+[Black "Frogkiller"]
+[Result "1-0"]
+[ECO "D15"]
+[WhiteElo "2399"]
+[BlackElo "2392"]
+[PlyCount "117"]
+[EventDate "2020.??.??"]
+
+1. d4 d5 2. c4 c6 3. Nf3 Nf6 4. Nc3 a6 5. g3 g6 6. Bg2 Bg7 7. cxd5 cxd5 8. O-O
+O-O 9. Bf4 Ne4 10. Ne5 Nxc3 11. bxc3 e6 12. Qb3 Nd7 13. Nd3 Nb6 14. e4 dxe4 15.
+Bxe4 Nd5 16. Rab1 b5 17. a4 bxa4 18. Qa3 Bd7 19. c4 Nxf4 20. Nxf4 Rc8 21. d5
+exd5 22. Bxd5 Be5 23. Nd3 Bg7 24. Rfd1 Bf5 25. Rbc1 Bd7 26. Nc5 Qc7 27. Nxd7
+Qxd7 28. c5 Qc7 29. Qxa4 a5 30. c6 Rcd8 31. Bf3 Rxd1+ 32. Rxd1 Rd8 33. Rd7 Rxd7
+34. cxd7 Be5 35. Qc6 Qd8 36. Qc8 Bc7 37. Qxd8+ Bxd8 38. Bc6 Kf8 39. Ba4 Ke7 40.
+f4 h5 41. Kf2 Bb6+ 42. Kf3 Kd8 43. h3 Ke7 44. g4 hxg4+ 45. hxg4 Bd8 46. f5 gxf5
+47. gxf5 Kf6 48. Ke4 Ke7 49. Kf4 f6 50. Kg4 Kd6 51. Kh5 Ke5 52. Kg6 Bc7 53. Kf7
+Kxf5 54. Ke7 Ke5 55. d8=Q Bxd8+ 56. Kxd8 f5 57. Kc7 f4 58. Kb6 f3 59. Kxa5 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Paanoos"]
+[Black "WildBreath"]
+[Result "1-0"]
+[ECO "C48"]
+[WhiteElo "2399"]
+[BlackElo "2400"]
+[PlyCount "55"]
+[EventDate "2020.??.??"]
+
+1. e4 e5 2. Nc3 Nc6 3. Nf3 Nf6 4. Bb5 Nd4 5. Bc4 d6 6. d3 Bg4 7. Be3 Nxf3+ 8.
+gxf3 Be6 9. Rg1 Bxc4 10. dxc4 g6 11. Nd5 c6 12. Nc3 Nh5 13. Qd2 Be7 14. O-O-O
+Qa5 15. Kb1 O-O-O 16. Nd5 Qxd2 17. Nxe7+ Kd7 18. Rxd2 Kxe7 19. Rgd1 Rd7 20.
+Bxa7 c5 21. Bxc5 Rhd8 22. Bb6 Rc8 23. c5 Rc6 24. cxd6+ Rcxd6 25. Bc5 Ke6 26.
+Rxd6+ Rxd6 27. Rxd6+ Ke7 28. Rxg6+ 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "irakliberadze"]
+[Black "MiroMiljkovic"]
+[Result "1-0"]
+[ECO "B32"]
+[WhiteElo "2644"]
+[BlackElo "2609"]
+[PlyCount "111"]
+[EventDate "2020.??.??"]
+
+1. e4 c5 2. Nf3 Nc6 3. d4 cxd4 4. Nxd4 e5 5. Nxc6 bxc6 6. Bd3 Nf6 7. O-O Be7 8.
+c4 O-O 9. Nc3 d6 10. f3 Be6 11. Be3 Qc7 12. Rc1 h6 13. Bf2 Nd7 14. Nd5 Bxd5 15.
+cxd5 c5 16. b4 Qb7 17. bxc5 Nxc5 18. Bxc5 dxc5 19. d6 Bxd6 20. Bc4 Be7 21. Bd5
+Qb6 22. Bxa8 Rxa8 23. Qd7 Bg5 24. Rb1 Be3+ 25. Kh1 Qa6 26. Qd5 Rc8 27. Qxe5 Bd4
+28. Qf5 Re8 29. Rfc1 Qxa2 30. Rb7 Qe6 31. Qxe6 fxe6 32. Rxa7 e5 33. Rc7 Kh7 34.
+h4 Re6 35. Rb1 Rg6 36. Kh2 h5 37. Kh3 Be3 38. Rbb7 Bf4 39. g4 hxg4+ 40. fxg4
+Be3 41. g5 Bxg5 42. hxg5 Rxg5 43. Kh4 Rg6 44. Rxc5 Rh6+ 45. Kg4 Rg6+ 46. Kf5
+Rf6+ 47. Kxe5 Rg6 48. Kd4 Rd6+ 49. Rd5 Re6 50. Rc7 Ra6 51. Rdd7 Ra4+ 52. Ke5
+Kh8 53. Kf5 Rxe4 54. Kxe4 Kh7 55. Rxg7+ Kh6 56. Rg8 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "metalkingGT"]
+[Black "BerserkAdopter"]
+[Result "1-0"]
+[ECO "A04"]
+[WhiteElo "2453"]
+[BlackElo "2450"]
+[PlyCount "83"]
+[EventDate "2020.??.??"]
+
+1. Nf3 g6 2. g3 Bg7 3. Bg2 d6 4. O-O Bd7 5. d3 Qc8 6. c3 Bh3 7. e4 h5 8. Bg5
+Nc6 9. Na3 Nf6 10. Qd2 e5 11. Nc4 Bxg2 12. Kxg2 Qd7 13. Ne3 O-O-O 14. b4 Rdf8
+15. a4 Ng4 16. Nd5 f6 17. Be3 g5 18. h4 gxh4 19. Nxh4 Rhg8 20. Nf5 Bh8 21. Rh1
+Nxe3+ 22. Qxe3 Bg7 23. b5 Nd8 24. Qxa7 Qe6 25. b6 c6 26. Nde7+ Kd7 27. Nxg8
+Rxg8 28. Qb8 Bf8 29. Qc7+ Ke8 30. Rxh5 Qd7 31. Rh7 Nf7 32. Qb8+ Nd8 33. Rxd7
+Kxd7 34. Qc7+ Ke8 35. Nxd6+ Bxd6 36. Qxd6 Rg7 37. Rh1 Rd7 38. Rh8+ Kf7 39. Qf8+
+Kg6 40. Rg8+ Rg7 41. Qxg7+ Kh5 42. Qg4+ 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "ajedrez2021"]
+[Black "sutcunuri"]
+[Result "1-0"]
+[ECO "A04"]
+[WhiteElo "2594"]
+[BlackElo "2519"]
+[PlyCount "59"]
+[EventDate "2020.??.??"]
+
+1. Nf3 Nc6 2. g3 e5 3. Bg2 Nf6 4. O-O d5 5. c4 Be7 6. cxd5 Nxd5 7. d4 e4 8.
+Nfd2 f5 9. e3 Be6 10. Nc3 O-O 11. Rb1 a5 12. a3 Qd7 13. Kh1 Rf6 14. Qe2 Rh6 15.
+f3 exf3 16. Qxf3 Nxc3 17. bxc3 Rd8 18. Rxb7 Bd5 19. Qxd5+ Qxd5 20. Bxd5+ Rxd5
+21. Rxc7 Bd8 22. Rc8 Kf7 23. Kg2 Rd7 24. e4 g6 25. exf5 gxf5 26. Rxf5+ Kg7 27.
+Rc5 Ne7 28. Ne4 Nxc8 29. Bxh6+ Kxh6 30. Rxc8 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "drop_stone"]
+[Black "C9C9C9C9C9"]
+[Result "1-0"]
+[ECO "A40"]
+[WhiteElo "2927"]
+[BlackElo "2983"]
+[PlyCount "143"]
+[EventDate "2020.??.??"]
+
+1. d4 b6 2. e4 Bb7 3. Nc3 e6 4. Bd3 Nf6 5. a3 c5 6. d5 exd5 7. exd5 Bd6 8. Qf3
+Be5 9. Nge2 O-O 10. O-O d6 11. Bf4 Nbd7 12. Rae1 Re8 13. h3 h6 14. Bb5 a6 15.
+Bc6 Rb8 16. Ng3 Bxf4 17. Qxf4 Bxc6 18. dxc6 Ne5 19. Nf5 Rc8 20. Qg3 Nh5 21.
+Nxh6+ Kh7 22. Nxf7 Nxg3 23. Nxd8 Nxf1 24. Nb7 Rxc6 25. Kxf1 Re7 26. f4 Rxb7 27.
+fxe5 dxe5 28. Rxe5 b5 29. Ne4 Rbc7 30. h4 c4 31. g4 Rd7 32. Ke2 Kg6 33. h5+ Kf7
+34. Rf5+ Ke7 35. Re5+ Kd8 36. g5 Re7 37. Rd5+ Kc7 38. Ke3 Rce6 39. Rd4 Re5 40.
+Kf4 Rc5 41. Nxc5 Kc6 42. Ne4 Rf7+ 43. Ke3 Re7 44. Rd6+ Kc7 45. Rg6 a5 46. h6
+gxh6 47. gxh6 Re8 48. Rg7+ Kc6 49. h7 Kd5 50. Rg8 Rxe4+ 51. Kf3 Re1 52. h8=Q
+Rf1+ 53. Ke2 Rf7 54. Re8 Rd7 55. Re5+ Kc6 56. Qf6+ Rd6 57. Re6 Rxe6+ 58. Qxe6+
+Kc5 59. c3 b4 60. a4 bxc3 61. Qe5+ Kc6 62. bxc3 Kb6 63. Qb5+ Kc7 64. Qxc4+ Kb6
+65. Qb5+ Ka7 66. c4 Ka8 67. c5 Ka7 68. c6 Ka8 69. c7 Ka7 70. Ke3 Ka8 71. c8=Q+
+Ka7 72. Qcb7# 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "BillyLaimbeer"]
+[Black "wtfai"]
+[Result "1/2-1/2"]
+[ECO "D91"]
+[WhiteElo "2378"]
+[BlackElo "2347"]
+[PlyCount "125"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. Nf3 g6 2. d4 d5 3. c4 Bg7 4. Nc3 Nf6 5. Bg5 Ne4 6. cxd5 Nxg5 7. Nxg5 e6 8.
+h4 exd5 9. e3 c6 10. Bd3 h6 11. Nf3 Bg4 12. Qc2 Bxf3 13. gxf3 Nd7 14. Rg1 Qf6
+15. f4 O-O-O 16. O-O-O Kb8 17. Kb1 Qxh4 18. a4 h5 19. a5 Rhe8 20. a6 b6 21.
+Bxg6 fxg6 22. Qxg6 Bf6 23. Rg3 Qh2 24. Rd2 h4 25. Rg2 Qh3 26. b4 Qe6 27. b5 Rg8
+28. f5 Rxg6 29. fxe6 Rxg2 30. exd7 Rxd7 31. bxc6 Rd6 32. Rd1 h3 33. Rh1 h2 34.
+Kc2 Rxf2+ 35. Kd3 Bd8 36. e4 Rh6 37. Nxd5 Rg2 38. e5 Rg1 39. Rxh2 Rxh2 40. e6
+Rd1+ 41. Kc3 Rc1+ 42. Kd3 Rxc6 43. e7 Bxe7 44. Nxe7 Rch6 45. Nf5 R6h3+ 46. Kc4
+Rf2 47. Ne7 Rh4 48. Nc6+ Kc7 49. Nxa7 Rff4 50. Nb5+ Kc6 51. Na7+ Kd7 52. Nb5
+Kc8 53. Nd6+ Kb8 54. Nb5 Rxd4+ 55. Nxd4 Rxd4+ 56. Kxd4 Ka7 57. Kc4 Kxa6 58. Kb4
+b5 59. Kb3 Ka5 60. Ka3 b4+ 61. Kb3 Kb5 62. Kb2 Ka4 63. Kb1 1/2-1/2
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "FedaMaster"]
+[Black "Cebuanochessking"]
+[Result "1/2-1/2"]
+[ECO "B21"]
+[WhiteElo "2550"]
+[BlackElo "2415"]
+[PlyCount "125"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 c5 2. d4 cxd4 3. c3 d3 4. Bxd3 Nc6 5. c4 d6 6. h3 Nf6 7. Nf3 g6 8. O-O
+Bg7 9. Nc3 O-O 10. Be3 Nd7 11. Rc1 Nde5 12. b3 Nxd3 13. Qxd3 Qa5 14. Rfd1 Re8
+15. Nd5 Be6 16. Ng5 Bxd5 17. exd5 Ne5 18. Qd2 Qxd2 19. Rxd2 b6 20. f4 Nd7 21.
+Nf3 a5 22. Nd4 Nc5 23. Nc6 e6 24. Bxc5 bxc5 25. dxe6 Rxe6 26. Rcd1 a4 27. Rxd6
+Bd4+ 28. R1xd4 cxd4 29. Rxe6 fxe6 30. Nxd4 axb3 31. axb3 Kf7 32. Kf2 Ke7 33.
+Ke3 Ra2 34. g4 Rh2 35. g5 Rxh3+ 36. Ke4 h5 37. gxh6 Rxh6 38. c5 Rh1 39. b4 Re1+
+40. Kd3 e5 41. fxe5 g5 42. b5 g4 43. b6 g3 44. Nf5+ Ke6 45. Nxg3 Kxe5 46. Kc4
+Rc1+ 47. Kb5 Kd5 48. b7 Rb1+ 49. Ka6 Kc6 50. Ka5 Rxb7 51. Ne4 Kd5 52. Nd6 Rc7
+53. Kb6 Rc6+ 54. Kb7 Rxc5 55. Nc8 Rb5+ 56. Kc7 Rc5+ 57. Kd7 Rc1 58. Ne7+ Ke5
+59. Nc6+ Kf6 60. Kd6 Rd1+ 61. Kc5 Ke6 62. Nd4+ Rxd4 63. Kxd4 1/2-1/2
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "fullchola"]
+[Black "taras05"]
+[Result "0-1"]
+[ECO "A80"]
+[WhiteElo "2431"]
+[BlackElo "2496"]
+[PlyCount "150"]
+[EventDate "2020.??.??"]
+
+1. d4 f5 2. Nf3 Nf6 3. Nc3 e6 4. Bg5 d5 5. Bxf6 Qxf6 6. Ne5 Nd7 7. f4 c6 8. e3
+Bd6 9. Bd3 O-O 10. O-O g5 11. fxg5 Qxg5 12. Rf3 Nxe5 13. dxe5 Bxe5 14. Ne2 Kh8
+15. Nf4 Rg8 16. Qe2 Bxb2 17. Raf1 Bg7 18. Nh3 Qe7 19. c4 Bd7 20. cxd5 cxd5 21.
+Rg3 Raf8 22. Qh5 Be5 23. Rxg8+ Rxg8 24. Nf4 Qc5 25. Qf3 d4 26. e4 Qd6 27. exf5
+exf5 28. Qh3 Bxf4 29. Bxf5 Be3+ 30. Kh1 Bxf5 31. Qxf5 Qg6 32. Qf3 Bh6 33. Qxb7
+Bg7 34. Qf3 Qd6 35. g3 Rd8 36. Rd1 d3 37. Qe4 d2 38. h4 Qd3 39. Qxd3 Rxd3 40.
+Kg2 Bc3 41. Kf2 Rd6 42. Ke2 Re6+ 43. Kf3 Re1 44. Rxd2 Bxd2 45. g4 Re3+ 46. Kf2
+Ra3 47. Kg2 Bg5 48. hxg5 Kg7 49. Kf2 Kg6 50. Ke2 Rxa2+ 51. Ke3 Ra6 52. Kf3 Rb6
+53. Kg3 a5 54. Kf4 a4 55. Kg3 a3 56. Kh4 a2 57. Kh3 a1=Q 58. Kg3 Qg1+ 59. Kh4
+Qc5 60. Kg3 Qd6+ 61. Kh4 Rb1 62. Kh3 Rh1+ 63. Kg2 Qe5 64. Kxh1 Qxg5 65. Kg2
+Qxg4+ 66. Kf2 Qf5+ 67. Ke3 Qg5+ 68. Kf2 h5 69. Kf3 h4 70. Kf2 Qg3+ 71. Kf1 Kg5
+72. Ke2 Kg4 73. Kf1 Qf3+ 74. Ke1 Qg2 75. Kd1 h3 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "yaguigor"]
+[Black "Rama75"]
+[Result "1/2-1/2"]
+[ECO "C64"]
+[WhiteElo "2458"]
+[BlackElo "2470"]
+[PlyCount "117"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 e5 2. Nf3 Nc6 3. Bb5 Bc5 4. c3 f5 5. d4 fxe4 6. Nfd2 Bb6 7. d5 e3 8. fxe3
+Nce7 9. Nc4 Nf6 10. d6 Nc6 11. Nxb6 axb6 12. Bc4 cxd6 13. Qxd6 Qe7 14. Qxe7+
+Kxe7 15. Nd2 d5 16. Be2 Be6 17. b3 Rhf8 18. O-O Ng4 19. Bxg4 Bxg4 20. Rxf8 Kxf8
+21. a4 Kf7 22. e4 d4 23. Bb2 Ke6 24. Nc4 Be2 25. Nxb6 Rd8 26. Nd5 d3 27. Kf2
+Rf8+ 28. Ke3 Na5 29. Ba3 Nxb3 30. Bxf8 Nxa1 31. Nb4 Nc2+ 32. Kd2 Nxb4 33. cxb4
+Bf1 34. g3 g6 35. a5 Kd7 36. b5 h5 37. Bg7 Kd6 38. a6 bxa6 39. bxa6 Kc6 40.
+Bxe5 Kb6 41. Bd4+ Kxa6 42. e5 Kb7 43. e6 Kc6 44. e7 Kd7 45. Bc5 Be2 46. h4 Bf1
+47. Bb4 Be2 48. Ke3 Ke8 49. Kf4 Bg4 50. Ke3 Bf5 51. Kd2 Be4 52. Ke3 Bf5 53. Bc5
+Kf7 54. Ba3 Ke8 55. Bb4 Kd7 56. Kf4 Ke8 57. Ke3 Kd7 58. Kf4 Ke8 59. Ke3 1/2-1/2
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "hungzhao"]
+[Black "Betovsky"]
+[Result "1/2-1/2"]
+[ECO "B01"]
+[WhiteElo "2627"]
+[BlackElo "2623"]
+[PlyCount "112"]
+[EventDate "2020.??.??"]
+
+1. e4 d5 2. exd5 Nf6 3. Bb5+ Bd7 4. Be2 Nxd5 5. a3 Bf5 6. c4 Nb6 7. d4 e5 8.
+dxe5 Qxd1+ 9. Kxd1 Nc6 10. Nf3 O-O-O+ 11. Ke1 Bg4 12. Nbd2 Bc5 13. b4 Bxf3 14.
+Nxf3 Bd4 15. Ra2 Nxe5 16. Nxe5 Bxe5 17. Be3 Rhe8 18. Rc2 g6 19. h4 f5 20. g3
+Bf6 21. Kf1 Na4 22. Kg2 Nc3 23. Bf3 Ne4 24. Rd1 Rxd1 25. Bxd1 a6 26. c5 Bg7 27.
+a4 c6 28. b5 axb5 29. axb5 Nf6 30. bxc6 bxc6 31. Bf3 Nd5 32. Bxd5 cxd5 33. c6
+Re6 34. Bf4 d4 35. Rb2 Be5 36. Re2 d3 37. Rd2 Bxf4 38. gxf4 Rd6 39. Kf3 Kc7 40.
+Ke3 Kxc6 41. Rxd3 Re6+ 42. Kf3 Re4 43. Rc3+ Kd7 44. Re3 Ke7 45. Rxe4+ fxe4+ 46.
+Kxe4 Kf6 47. f5 g5 48. hxg5+ Kxg5 49. Ke5 h6 50. f6 h5 51. f7 h4 52. f8=Q Kg4
+53. Qg7+ Kh3 54. Qh6 Kh2 55. Qxh4+ Kg2 56. Qg3+ Kf1 1/2-1/2
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "BlueGreensun"]
+[Black "Kidefence"]
+[Result "1-0"]
+[ECO "A45"]
+[WhiteElo "2769"]
+[BlackElo "2698"]
+[PlyCount "101"]
+[EventDate "2020.??.??"]
+
+1. e4 Nf6 2. d4 Nxe4 3. Nc3 Nxc3 4. bxc3 d5 5. Nf3 c6 6. Bd3 Bg4 7. Rb1 b6 8.
+c4 e6 9. cxd5 exd5 10. O-O Be7 11. h3 Bh5 12. Re1 O-O 13. Qe2 Bf6 14. Bf4 Nd7
+15. g4 Bg6 16. g5 c5 17. gxf6 Nxf6 18. Bxg6 hxg6 19. dxc5 bxc5 20. Rb7 Ne4 21.
+c4 Qf6 22. Be5 Qf5 23. cxd5 Nf6 24. d6 Qxh3 25. Ng5 Qf5 26. Bxf6 gxf6 27. Ne4
+Rad8 28. Qb2 Kg7 29. Rxa7 Qg4+ 30. Kf1 Qh3+ 31. Ke2 Qg4+ 32. Kd2 Qf4+ 33. Kc2
+Rfe8 34. Re7 Rb8 35. Rxe8 Rxb2+ 36. Kxb2 c4 37. d7 Qc7 38. d8=Q Qb7+ 39. Kc2
+Qa6 40. Qxf6+ Qxf6 41. Nxf6 Kxf6 42. R8e4 c3 43. Rc4 Kg5 44. Rxc3 f5 45. a4 Kh5
+46. a5 g5 47. a6 Kh4 48. a7 f4 49. a8=Q Kg4 50. Qf3+ Kh4 51. Rh1# 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "alireza3700"]
+[Black "locelsiano"]
+[Result "1-0"]
+[ECO "C13"]
+[WhiteElo "2322"]
+[BlackElo "2357"]
+[PlyCount "39"]
+[EventDate "2020.??.??"]
+
+1. d4 Nf6 2. Nc3 e6 3. e4 d5 4. Bg5 Be7 5. e5 Ne4 6. Bxe7 Qxe7 7. Nxe4 dxe4 8.
+Qg4 O-O 9. Qxe4 c5 10. dxc5 Qxc5 11. O-O-O Nc6 12. Nf3 b6 13. Bd3 g6 14. h4 h5
+15. g4 hxg4 16. h5 Kg7 17. hxg6 f5 18. exf6+ Rxf6 19. Rh7+ Kg8 20. Rdh1 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Elhlwagy11"]
+[Black "H-Random"]
+[Result "0-1"]
+[ECO "A45"]
+[WhiteElo "2306"]
+[BlackElo "2365"]
+[PlyCount "110"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 Nf6 2. Nc3 c5 3. d5 d6 4. e4 g6 5. f4 Bg7 6. Bb5+ Nfd7 7. Nf3 O-O 8. O-O
+a6 9. Be2 b5 10. Qe1 b4 11. Nd1 Nb6 12. Be3 a5 13. c4 a4 14. Rb1 e6 15. b3 exd5
+16. cxd5 Ba6 17. Bxa6 Nxa6 18. Qh4 Qxh4 19. Nxh4 Nc7 20. Nf3 Nb5 21. Nf2 Nc3
+22. Rb2 Rfe8 23. Rc2 Nxe4 24. Nxe4 Rxe4 25. Bc1 axb3 26. axb3 Nxd5 27. Rd1 Nxf4
+28. Rxd6 Ne2+ 29. Kf2 Nxc1 30. Rxc1 Ra2+ 31. Kg3 Ree2 32. Rxc5 Rxg2+ 33. Kf4
+Bh6+ 34. Ke4 Rae2+ 35. Kd5 Rd2+ 36. Nxd2 Rxd2+ 37. Kc6 Rxd6+ 38. Kxd6 Bf8+ 39.
+Kd5 Bxc5 40. Kxc5 f5 41. Kxb4 f4 42. Kc3 Kf7 43. Kd3 Ke6 44. Ke4 g5 45. h4 h6
+46. b4 Kd6 47. h5 Kc6 48. Kf5 f3 49. Kg6 f2 50. Kxh6 f1=Q 51. Kxg5 Qg2+ 52. Kh6
+Kd6 53. b5 Ke7 54. b6 Kf7 55. b7 Qg7# 0-1
+
+[Event "Rated Blitz tournament uAQ2oGqy"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "HelgaDj"]
+[Black "psm-ajedrez"]
+[Result "1-0"]
+[ECO "C21"]
+[WhiteElo "2357"]
+[BlackElo "2370"]
+[PlyCount "37"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 e5 2. d4 f5 3. dxe5 d6 4. exd6 Bxd6 5. Nc3 Nf6 6. Bg5 O-O 7. Bc4+ Kh8 8.
+Bxf6 Qxf6 9. Qe2 Ba3 10. e5 Bxb2 11. exf6 Bxc3+ 12. Kf1 Bxa1 13. fxg7+ Bxg7 14.
+Nf3 Nc6 15. Ng5 Ne5 16. f4 Nxc4 17. Qxc4 h6 18. Nf7+ Kh7 19. Ne5 1-0
+
+[Event "Rated Bullet tournament H3UwNQec"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "RhenzRheann_Auza98"]
+[Black "ScherlockKA"]
+[Result "0-1"]
+[ECO "A39"]
+[WhiteElo "2378"]
+[BlackElo "2335"]
+[PlyCount "68"]
+[EventDate "2020.??.??"]
+
+1. Nf3 c5 2. g3 Nc6 3. Bg2 g6 4. O-O Bg7 5. c4 Nf6 6. Nc3 O-O 7. d4 cxd4 8.
+Nxd4 Nxd4 9. Qxd4 d6 10. b3 a6 11. Bb2 Rb8 12. Rfd1 b5 13. cxb5 axb5 14. Nd5
+Bb7 15. Rac1 Bxd5 16. Bxd5 Nh5 17. Qd2 Bxb2 18. Qxb2 Nf6 19. Bf3 Qb6 20. Kg2
+Rfc8 21. h4 h5 22. Qd2 Qa7 23. Rxc8+ Rxc8 24. Rb1 Rc5 25. Qb2 e5 26. a3 e4 27.
+Qxf6 exf3+ 28. Qxf3 Rf5 29. Qd3 Qxf2+ 30. Kh3 Re5 31. Qxd6 Qf5+ 32. Kh2 Rxe2+
+33. Kg1 Qf2+ 34. Kh1 Qh2# 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "EPThompson"]
+[Black "Klaksidee"]
+[Result "0-1"]
+[ECO "A43"]
+[WhiteElo "2534"]
+[BlackElo "2601"]
+[PlyCount "112"]
+[EventDate "2020.??.??"]
+
+1. d4 c5 2. d5 e6 3. Nc3 exd5 4. Nxd5 d6 5. e4 Be6 6. Bf4 Nc6 7. Nf3 Nf6 8. Nc3
+d5 9. e5 Ne4 10. Nxe4 dxe4 11. Ng5 Qxd1+ 12. Rxd1 Nd4 13. Nxe6 Nxe6 14. Bb5+
+Ke7 15. Rd7+ Ke8 16. Rxb7+ Kd8 17. Be3 a6 18. Bc4 Be7 19. O-O Ke8 20. Rd1 Rd8
+21. Rxd8+ Nxd8 22. Ra7 f6 23. e6 h5 24. Bxa6 g6 25. Bb5+ Kf8 26. Bd7 h4 27. a4
+h3 28. a5 hxg2 29. Kxg2 f5 30. a6 Bd6 31. b4 Rxh2+ 32. Kf1 cxb4 33. Bb6 Ke7 34.
+Bc8+ Ke8 35. Bd7+ Ke7 36. Bc6+ Kxe6 37. Bxd8 Rh1+ 38. Ke2 Ra1 39. Bd7+ Ke5 40.
+Bg5 Bc5 41. Rb7 Rxa6 42. Be3 Kd6 43. Bxc5+ Kxc5 44. Bxf5 Ra2 45. Rg7 gxf5 46.
+Rg6 Kd4 47. Rg5 Kc3 48. Rxf5 Rxc2+ 49. Ke3 Rd2 50. Kxe4 Rd3 51. Rc5+ Kd2 52.
+Rd5 Rxd5 53. Kxd5 b3 54. Kc4 b2 55. f4 b1=Q 56. f5 Qc2+ 0-1
+
+[Event "Rated Blitz tournament OxRShNHO"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Lioni26"]
+[Black "AttackSparrow"]
+[Result "1/2-1/2"]
+[ECO "B47"]
+[WhiteElo "2387"]
+[BlackElo "2457"]
+[PlyCount "156"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 c5 2. Nf3 e6 3. d4 cxd4 4. Nxd4 Nc6 5. Nc3 Qc7 6. g3 a6 7. Bg2 Nge7 8.
+Nb3 Ne5 9. O-O b5 10. f4 Nc4 11. e5 Bb7 12. Ne4 Nf5 13. Qe2 h5 14. c3 h4 15. g4
+Qb6+ 16. Qf2 h3 17. Bh1 Nfe3 18. Bxe3 Nxe3 19. Rfe1 Nc4 20. Qxb6 Nxb6 21. Nd6+
+Bxd6 22. Bxb7 Ra7 23. Bxa6 Rxa6 24. exd6 Nc4 25. Nd4 Rh4 26. Nxb5 Rxg4+ 27. Kf2
+Rg2+ 28. Kf3 Rb6 29. a4 Nxb2 30. Re2 Rxe2 31. Kxe2 Nc4 32. Kd3 Nxd6 33. Nxd6+
+Rxd6+ 34. Kc4 Rc6+ 35. Kb5 Rxc3 36. a5 Rc8 37. a6 Ke7 38. a7 Ra8 39. Kb6 d5 40.
+Kb7 Rd8 41. a8=Q Rxa8 42. Rxa8 Kf6 43. Kc6 Kf5 44. Ra7 f6 45. Rxg7 Kxf4 46. Kd6
+Kf5 47. Rg3 d4 48. Kc5 e5 49. Rxh3 Ke4 50. Rh6 f5 51. Kc4 f4 52. Kb3 f3 53. Kc2
+Ke3 54. Kd1 f2 55. Rf6 e4 56. h4 d3 57. h5 Kd4 58. Rxf2 e3 59. Rf4+ Ke5 60. Ra4
+Kf5 61. Ra3 e2+ 62. Kd2 Kg5 63. Rxd3 Kxh5 64. Kxe2 Kg5 65. Rf3 Kg4 66. Ke3 Kg5
+67. Rf4 Kh5 68. Kf3 Kg5 69. Ke4 Kg6 70. Rf5 Kh6 71. Ke5 Kg6 72. Kf4 Kh6 73. Kg4
+Kg6 74. Rf4 Kh6 75. Rf6+ Kg7 76. Kg5 Kh7 77. Rf7+ Kg8 78. Kg6 Kh8 1/2-1/2
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Lil_D"]
+[Black "vassiukov"]
+[Result "1-0"]
+[ECO "A00"]
+[WhiteElo "2313"]
+[BlackElo "2334"]
+[PlyCount "47"]
+[EventDate "2020.??.??"]
+
+1. g3 d5 2. Bg2 Nf6 3. d3 Bf5 4. Nd2 e6 5. e3 h5 6. Ne2 h4 7. h3 hxg3 8. fxg3
+Bd6 9. g4 Bg6 10. Nf4 Bxf4 11. exf4 Qd6 12. O-O Nbd7 13. Nf3 O-O-O 14. Ng5 e5
+15. f5 Bh7 16. Nxf7 Qb6+ 17. Rf2 Rhf8 18. Nxd8 Rxd8 19. g5 Ne8 20. d4 exd4 21.
+Bxd5 d3 22. Be6 Kb8 23. Qxd3 Nc5 24. Qxd8# 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "estocastico"]
+[Black "Paanoos"]
+[Result "1/2-1/2"]
+[ECO "B03"]
+[WhiteElo "2562"]
+[BlackElo "2405"]
+[PlyCount "118"]
+[EventDate "2020.??.??"]
+
+1. e4 Nf6 2. e5 Nd5 3. c4 Nb6 4. d4 d6 5. exd6 cxd6 6. Be3 g6 7. Nc3 Bg7 8. Rc1
+O-O 9. b3 e5 10. dxe5 dxe5 11. Qxd8 Rxd8 12. c5 N6d7 13. Bc4 Nc6 14. Nf3 Na5
+15. Bd5 Nf8 16. Ng5 Rd7 17. O-O h6 18. Nge4 Rc7 19. Nb5 Re7 20. Nbd6 Nc6 21. f4
+exf4 22. Bxf4 Be6 23. Bxe6 Nxe6 24. Bg3 f5 25. Nc3 Ned4 26. Nd5 Ne2+ 27. Kh1
+Nxc1 28. Nxe7+ Nxe7 29. Rxc1 b6 30. c6 g5 31. c7 f4 32. Bf2 Be5 33. c8=Q+ Nxc8
+34. Rxc8+ Rxc8 35. Nxc8 Kf7 36. Nxa7 Bc7 37. Nc8 b5 38. Na7 b4 39. Nc6 Bd6 40.
+Be1 Ke6 41. Bxb4 Bc7 42. Bf8 Kd5 43. Bxh6 Kxc6 44. Bxg5 Kd5 45. Kg1 Ke4 46. Kf1
+Bb6 47. h4 Bd4 48. h5 Be5 49. h6 Kd3 50. b4 Ke4 51. b5 Kd5 52. a4 Kc5 53. Kf2
+Kb4 54. Kf3 Kxa4 55. Bxf4 Kxb5 56. Bxe5 Kc6 57. h7 Kd5 58. h8=Q Ke6 59. Qf6+
+Kd5 1/2-1/2
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "mixo23"]
+[Black "Rusticous"]
+[Result "1-0"]
+[ECO "A45"]
+[WhiteElo "2417"]
+[BlackElo "2346"]
+[PlyCount "89"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 Nf6 2. Bg5 e6 3. e4 d5 4. e5 h6 5. Bc1 Nfd7 6. f4 c5 7. Nf3 Nc6 8. c3 f5
+9. h4 Qb6 10. h5 Be7 11. Kf2 Rg8 12. Na3 a6 13. Nc2 Qa7 14. Be3 b5 15. Rg1 g5
+16. hxg6 Rxg6 17. Rh1 Nb6 18. b3 c4 19. Be2 Bd7 20. Rh5 O-O-O 21. Qh1 Rdg8 22.
+Bf1 Bf8 23. Rh2 Be8 24. Be2 Qg7 25. Rg1 Rg3 26. Rh3 Rg4 27. g3 cxb3 28. axb3
+Na5 29. Nd2 Qc7 30. Bxg4 fxg4 31. Rxh6 Qxc3 32. Rxe6 Bc6 33. Qh7 Nxb3 34. Qxg8
+Nxd2 35. Rxc6+ Qxc6 36. Qxf8+ Kb7 37. Bxd2 Qxc2 38. Qe7+ Ka8 39. Qf8+ Kb7 40.
+Qb4 Nc4 41. Rh1 Qe4 42. Rh7+ Kb6 43. Rh6+ Kb7 44. Qe7+ Kc8 45. Rh8# 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "vkruhina"]
+[Black "WarShoe"]
+[Result "1/2-1/2"]
+[ECO "C00"]
+[WhiteElo "2321"]
+[BlackElo "2341"]
+[PlyCount "128"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 e6 2. d4 d5 3. Bd3 dxe4 4. Bxe4 Nf6 5. Bf3 Be7 6. Ne2 O-O 7. Nbc3 c5 8.
+Be3 cxd4 9. Qxd4 Nc6 10. Qxd8 Rxd8 11. Ng3 Nd5 12. Nxd5 exd5 13. O-O-O Be6 14.
+c3 d4 15. cxd4 Bxa2 16. d5 Ne5 17. Be4 Rac8+ 18. Kd2 Nc4+ 19. Ke2 Nxb2 20. Rd2
+Bc4+ 21. Kf3 Na4 22. Nf5 Bc5 23. Bxc5 Rxc5 24. d6 Nc3 25. Ne7+ Kf8 26. Bxb7 Nb5
+27. Rhd1 Nxd6 28. Nc6 Rxc6 29. Bxc6 Ke7 30. Bd5 Bb5 31. Re1+ Kf6 32. g4 h6 33.
+h4 g5 34. hxg5+ hxg5 35. Rh1 Nc4 36. Rd4 Bc6 37. Rhd1 Rxd5 38. Rxd5 Nb6 39. Ke4
+Bxd5+ 40. Kd4 Bf3 41. Ra1 Nc8 42. Ra6+ Kg7 43. Ra5 f6 44. Rc5 Bxg4 45. f3 Bh3
+46. Rc7+ Kg6 47. Kd5 Bf5 48. Kd4 g4 49. fxg4 Bxg4 50. Ke3 Bf5 51. Kf4 Be6 52.
+Rc6 Bh3 53. Rc3 Nb6 54. Rxh3 a5 55. Rg3+ Kf7 56. Rb3 Nd5+ 57. Ke4 Nb4 58. Ra3
+Nc6 59. Rc3 Nb4 60. Kf5 Ke7 61. Rc7+ Kd6 62. Ra7 Nc6 63. Kxf6 Kc5 64. Rxa5+
+Nxa5 1/2-1/2
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "sutcunuri"]
+[Black "ajedrez2021"]
+[Result "1-0"]
+[ECO "B06"]
+[WhiteElo "2515"]
+[BlackElo "2599"]
+[PlyCount "53"]
+[EventDate "2020.??.??"]
+
+1. e4 g6 2. d4 Bg7 3. Nc3 c5 4. d5 d6 5. f4 Nf6 6. Bb5+ Nfd7 7. Nf3 O-O 8. a4
+a6 9. Bc4 Nb6 10. Nd2 Bg4 11. Qxg4 N8d7 12. O-O Nxc4 13. Nxc4 b5 14. axb5 Bxc3
+15. bxc3 Nf6 16. Qh4 axb5 17. Rxa8 Qxa8 18. Nd2 Qa2 19. f5 Qxc2 20. e5 dxe5 21.
+d6 Nh5 22. dxe7 Re8 23. Ne4 f6 24. Nxf6+ Nxf6 25. Qxf6 Qe4 26. Bh6 Qe3+ 27.
+Bxe3 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Atomrod"]
+[Black "Kelevra90"]
+[Result "1-0"]
+[ECO "E60"]
+[WhiteElo "2500"]
+[BlackElo "2456"]
+[PlyCount "43"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 Nf6 2. Nf3 g6 3. c4 c5 4. Nc3 cxd4 5. Nxd4 Nc6 6. g3 Bg7 7. Bg2 O-O 8.
+O-O Nxd4 9. Qxd4 d6 10. Bg5 Be6 11. Qd3 Qa5 12. Bd2 Rab8 13. b3 Rfc8 14. Nd5
+Qd8 15. Bg5 Bxd5 16. Bxd5 Nxd5 17. Qxd5 Rc5 18. Qd2 Bxa1 19. Rxa1 Qa5 20. b4
+Qc7 21. bxc5 Qxc5 22. Rc1 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "MissMariposa"]
+[Black "reachvsara"]
+[Result "1-0"]
+[ECO "C50"]
+[WhiteElo "2332"]
+[BlackElo "2323"]
+[PlyCount "75"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 e5 2. Nf3 Nc6 3. Bc4 Bc5 4. O-O Nf6 5. d3 O-O 6. c3 d5 7. exd5 Nxd5 8.
+Re1 Bg4 9. Nbd2 Re8 10. Ne4 Bf8 11. h3 Bh5 12. Ng3 Bg6 13. Bg5 f6 14. Be3 Kh8
+15. Rc1 Nxe3 16. Rxe3 a6 17. b4 b5 18. Bb3 f5 19. Re1 a5 20. a3 axb4 21. axb4
+Ra3 22. Qc2 e4 23. dxe4 fxe4 24. Nh2 e3 25. Qb2 exf2+ 26. Kxf2 Qa8 27. Rxe8
+Bxe8 28. Nf3 Qa7+ 29. Kf1 Bg6 30. Rd1 Bd6 31. Ne2 h6 32. Ned4 Nxd4 33. Nxd4 Qa8
+34. Kg1 Ra6 35. Nxb5 Qe8 36. Nxd6 cxd6 37. Qf2 Rc6 38. Ba4 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "CarlosMontenegro"]
+[Black "panicOttack"]
+[Result "1-0"]
+[ECO "A00"]
+[WhiteElo "2404"]
+[BlackElo "2316"]
+[PlyCount "63"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. g3 c5 2. Bg2 d6 3. d3 e5 4. c4 Ne7 5. Nc3 g6 6. Nf3 Bg7 7. O-O O-O 8. Rb1
+Nbc6 9. a3 Nd4 10. b4 Rb8 11. e3 Nxf3+ 12. Bxf3 b6 13. Qa4 a6 14. Bd2 Qc7 15.
+bxc5 dxc5 16. Nd5 Nxd5 17. Bxd5 Qa7 18. e4 Bd7 19. Qc2 Kh8 20. a4 f5 21. f3 f4
+22. g4 Qc7 23. h3 Qd6 24. Rb2 Qe7 25. Be1 Qe8 26. Ra2 h5 27. Bf2 Bf6 28. Rb1 h4
+29. a5 bxa5 30. Rxa5 Be7 31. Rxa6 Bc8 32. Rxb8 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Licenciadomate"]
+[Black "vava05"]
+[Result "1-0"]
+[ECO "D38"]
+[WhiteElo "2410"]
+[BlackElo "2409"]
+[PlyCount "101"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. Nf3 d5 2. d4 Nf6 3. c4 e6 4. Nc3 Bb4 5. cxd5 exd5 6. Qa4+ Nc6 7. Bf4 O-O 8.
+Rc1 Ne4 9. e3 a6 10. Bd3 b5 11. Qc2 Bf5 12. O-O Bxc3 13. bxc3 Na5 14. a4 Nc4
+15. axb5 axb5 16. Ne5 Nxe5 17. Bxe5 c6 18. f3 f6 19. Bf4 g5 20. fxe4 dxe4 21.
+Bxe4 Bxe4 22. Qxe4 gxf4 23. Rxf4 Qd5 24. Qe7 Rf7 25. Rg4+ Kh8 26. Qb4 Ra2 27.
+e4 Qh5 28. h3 f5 29. exf5 Qxf5 30. Qd6 Ra8 31. Qxc6 Rc8 32. Qh6 b4 33. cxb4 Rb8
+34. Rc5 Qf2+ 35. Kh2 Rbf8 36. Rh5 Qc2 37. Qe3 Qc7+ 38. Qe5+ Qxe5+ 39. Rxe5 Rb7
+40. b5 Rfb8 41. Rgg5 h6 42. Rg6 Kh7 43. Ree6 Rxb5 44. Rxh6+ Kg7 45. Rhg6+ Kf7
+46. Ra6 Rd5 47. Rgd6 Rd8 48. Ra7+ Ke8 49. Rh6 R5d7 50. Rh8+ Ke7 51. Rxd7+ 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "alwaysplanahead"]
+[Black "Piranaseven"]
+[Result "1-0"]
+[ECO "A00"]
+[WhiteElo "2332"]
+[BlackElo "2305"]
+[PlyCount "147"]
+[EventDate "2020.??.??"]
+
+1. e3 g6 2. d4 Bg7 3. Bd3 c6 4. c4 d5 5. Nc3 Nf6 6. cxd5 cxd5 7. Nf3 Nc6 8. O-O
+Bg4 9. Be2 e6 10. h3 Bxf3 11. Bxf3 O-O 12. Qe2 Rc8 13. Rd1 a6 14. g3 h5 15. Bg2
+h4 16. g4 Re8 17. Bd2 Qe7 18. f4 Nd7 19. Be1 b5 20. Qf2 b4 21. Ne2 Nb6 22. Qxh4
+Qxh4 23. Bxh4 Nc4 24. Rd3 Nxb2 25. Rb3 Nc4 26. Be1 a5 27. a3 a4 28. Rxb4 Nxb4
+29. Bxb4 Bf8 30. Bf3 Bxb4 31. axb4 a3 32. Kf2 Rb8 33. e4 Rxb4 34. exd5 exd5 35.
+Bxd5 Nb6 36. Bf3 Ra4 37. Nc3 Rxd4 38. Rxa3 Nc4 39. Ra7 Rd2+ 40. Kg3 Rd3 41. Nd5
+Ne3 42. Nf6+ Kf8 43. Nxe8 Kxe8 44. Kf2 Nd5 45. Bxd5 Rxd5 46. Ra8+ Ke7 47. Ra7+
+Kf6 48. Ra2 Kg7 49. Re2 Rb5 50. Kg3 Rb3+ 51. Kh4 Rb4 52. g5 Rxf4+ 53. Kg3 Rf5
+54. h4 Ra5 55. Re4 Ra3+ 56. Kg4 Ra1 57. Rb4 Ra7 58. Rb6 Re7 59. Rb8 Re5 60. Rc8
+Rd5 61. Rc4 Rd4+ 62. Rxd4 Kg8 63. Rf4 Kg7 64. Rf6 Kg8 65. h5 Kf8 66. h6 Kg8 67.
+Kf4 Kh8 68. Ra6 Kg8 69. Ra8+ Kh7 70. Ke5 f6+ 71. Kd5 fxg5 72. Ra7+ Kxh6 73. Ra1
+Kh5 74. Rh1+ 1-0
+
+[Event "Rated Blitz tournament te4AhseI"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "mux77"]
+[Black "Alberto_Santos"]
+[Result "1-0"]
+[ECO "A08"]
+[WhiteElo "2441"]
+[BlackElo "2323"]
+[PlyCount "149"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. Nf3 d5 2. g3 Nf6 3. Bg2 e6 4. O-O Be7 5. d4 O-O 6. c4 dxc4 7. Qc2 a6 8. a4
+Bd7 9. Qxc4 Bc6 10. Bg5 a5 11. Nc3 Nbd7 12. Rfd1 Nb6 13. Qb3 h6 14. Bxf6 Bxf6
+15. e4 Be7 16. d5 exd5 17. exd5 Bd7 18. Ne5 Bd6 19. Nxd7 Qxd7 20. Ne4 Rfe8 21.
+Rdc1 Re5 22. Nc5 Bxc5 23. Rxc5 Rae8 24. h3 Re1+ 25. Rxe1 Rxe1+ 26. Kh2 Qf5 27.
+f4 Re2 28. Qf3 Rxb2 29. Rxc7 Qxd5 30. Qxd5 Nxd5 31. Rc8+ Kh7 32. Kg1 Nf6 33.
+Rc7 Rb4 34. Rxb7 Rxa4 35. Rxf7 Ra2 36. g4 a4 37. Ra7 a3 38. g5 hxg5 39. fxg5
+Nh5 40. Be4+ Kg8 41. Bg6 Kf8 42. Bxh5 Ra1+ 43. Kg2 a2 44. Be2 g6 45. Bc4 Rc1
+46. Bxa2 Rc5 47. Kg3 Rxg5+ 48. Kh4 Rc5 49. Kg4 Rc4+ 50. Kg5 Rc5+ 51. Kxg6 Rc6+
+52. Kg5 Rb6 53. Ra8+ Ke7 54. Ra3 Rb5+ 55. Kg4 Rb6 56. Kg3 Rb4 57. Kh2 Kf6 58.
+Rf3+ Kg5 59. Rf2 Kh6 60. Kg2 Ra4 61. Be6 Ra5 62. Bg4 Ra6 63. Rf3 Ra5 64. Kg3
+Ra2 65. Rf5 Ra5 66. Kh4 Ra4 67. Rh5+ Kg7 68. Rg5+ Kh6 69. Rb5 Ra7 70. Rh5+ Kg7
+71. Rc5 Kh6 72. Rc6+ Kg7 73. Kg5 Rf7 74. Bf5 Re7 75. Rg6+ 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "aidenzhouu"]
+[Black "Phutressniak"]
+[Result "0-1"]
+[ECO "E15"]
+[WhiteElo "2445"]
+[BlackElo "2413"]
+[PlyCount "64"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 Nf6 2. c4 e6 3. Nf3 b6 4. g3 Ba6 5. Qc2 c5 6. d5 exd5 7. cxd5 Bb7 8. Bg2
+Nxd5 9. Qe4+ Be7 10. O-O O-O 11. Nh4 Bxh4 12. gxh4 Re8 13. Qg4 Nf6 14. Qg3 Bxg2
+15. Qxg2 d5 16. Bh6 g6 17. Nc3 Nc6 18. Rad1 Nd4 19. e3 Nf5 20. Nxd5 Nxh6 21.
+Qg5 Nxd5 22. Qxh6 Re5 23. e4 Rxe4 24. Qd2 Rd4 25. Qh6 Rxh4 26. Qd2 Rd4 27. Qh6
+Nf4 28. Rxd4 Qxd4 29. Re1 Rd8 30. h4 Ne6 31. h5 Qg4+ 32. Kf1 Qxh5 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "corwinifred"]
+[Black "NormWeinstein"]
+[Result "1-0"]
+[ECO "A43"]
+[WhiteElo "2308"]
+[BlackElo "2343"]
+[PlyCount "77"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 c5 2. Nf3 cxd4 3. Nxd4 d5 4. g3 e5 5. Nb3 Nf6 6. Bg2 Nc6 7. O-O Be7 8.
+Bg5 Be6 9. Nc3 d4 10. Bxf6 gxf6 11. Ne4 Bd5 12. c4 Bxc4 13. Rc1 Bd5 14. Nbc5
+Bxc5 15. Rxc5 Be6 16. Qd2 f5 17. Ng5 Qd6 18. Rfc1 O-O 19. Bxc6 bxc6 20. Rxc6
+Qd5 21. R1c5 Qxa2 22. Rxe5 Bd5 23. Rc5 Rad8 24. Qf4 f6 25. Re7 Bf7 26. Nxf7
+Rxf7 27. Rxf7 Qxf7 28. Rxf5 Qe6 29. Rxf6 Qxe2 30. Qg5+ Kh8 31. Re6 Qxe6 32.
+Qxd8+ Kg7 33. Qxd4+ Kg6 34. Qd3+ Kg7 35. Qe3 Qxe3 36. fxe3 Kf6 37. Kf2 Ke5 38.
+h3 Kd5 39. Ke2 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "MiroMiljkovic"]
+[Black "irakliberadze"]
+[Result "0-1"]
+[ECO "D56"]
+[WhiteElo "2604"]
+[BlackElo "2649"]
+[PlyCount "42"]
+[EventDate "2020.??.??"]
+
+1. d4 d5 2. c4 e6 3. Nc3 Nf6 4. Bg5 Be7 5. e3 h6 6. Bh4 O-O 7. Nf3 Ne4 8. Bxe7
+Qxe7 9. Rc1 Nxc3 10. Rxc3 c6 11. Qc2 Nd7 12. Bd3 dxc4 13. Rxc4 e5 14. O-O Re8
+15. a3 e4 16. Bxe4 Qxe4 17. Qc3 Nf6 18. Ne5 Be6 19. Rb4 Rab8 20. Qc5 Bd5 21.
+Ra4 Qxg2# 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Molot_ua"]
+[Black "dimochka_tsoi"]
+[Result "0-1"]
+[ECO "A00"]
+[WhiteElo "2382"]
+[BlackElo "2642"]
+[PlyCount "50"]
+[EventDate "2020.??.??"]
+
+1. d3 d5 2. c3 e5 3. Nd2 Nf6 4. h3 Be7 5. g4 O-O 6. Bg2 Ne8 7. Nf1 c6 8. Ng3
+Be6 9. Nf3 Nd7 10. e4 Nd6 11. Nf5 dxe4 12. dxe4 Nxe4 13. Nxe7+ Qxe7 14. Nxe5
+Nxe5 15. Bxe4 Bc4 16. b3 Rad8 17. bxc4 Rxd1+ 18. Kxd1 Rd8+ 19. Kc2 Nxc4 20. f3
+Qc5 21. Re1 Qf2+ 22. Kb3 Na5+ 23. Ka4 Qxe1 24. Kxa5 Qxc3+ 25. Ka4 Qxa1 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "starkspieler"]
+[Black "Evgen_88"]
+[Result "0-1"]
+[ECO "C02"]
+[WhiteElo "2414"]
+[BlackElo "2524"]
+[PlyCount "120"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 e6 2. d4 d5 3. e5 c5 4. c3 Qb6 5. Nf3 Nc6 6. Bd3 cxd4 7. cxd4 Bd7 8. O-O
+Nxd4 9. Nbd2 Nxf3+ 10. Nxf3 Bb5 11. Be3 Qa6 12. Bxb5+ Qxb5 13. Rc1 Qd7 14. Qd2
+Ne7 15. Bc5 Nc6 16. Bxf8 Kxf8 17. b4 a6 18. a4 h6 19. b5 axb5 20. axb5 Na5 21.
+Ra1 b6 22. Nd4 g6 23. Nc6 Kg7 24. Nxa5 bxa5 25. Rxa5 Rab8 26. Qb2 Rb6 27. Rb1
+Rhb8 28. h3 d4 29. Rd1 d3 30. Qc3 Rd8 31. Ra3 Rxb5 32. Rxd3 Qxd3 33. Qxd3 Rxd3
+34. Rxd3 Rxe5 35. Rd7 g5 36. g3 Ra5 37. Kg2 Ra3 38. Rd2 h5 39. Rb2 Kg6 40. Rb5
+f5 41. Rb4 Kf6 42. h4 g4 43. Rb8 Ra7 44. Rh8 Kg6 45. Re8 Ra6 46. Rg8+ Kh7 47.
+Re8 Kg7 48. Re7+ Kg6 49. Re8 f4 50. gxf4 Kf5 51. Rf8+ Ke4 52. Kg3 Ra3+ 53. Kg2
+Rf3 54. Rf6 Kd5 55. Rh6 Rxf4 56. Rxh5+ Ke4 57. Rg5 e5 58. h5 Rf5 59. h6 Rxg5
+60. h7 Rh5 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "DavidcabTOP9"]
+[Black "alireza3700"]
+[Result "0-1"]
+[ECO "C00"]
+[WhiteElo "2329"]
+[BlackElo "2328"]
+[PlyCount "92"]
+[EventDate "2020.??.??"]
+
+1. e4 e6 2. Qe2 d5 3. d3 dxe4 4. dxe4 c5 5. g3 Nc6 6. Bg2 Nd4 7. Qd3 Bd7 8. c4
+Ba4 9. b3 Bc6 10. Nc3 Nf6 11. Nge2 e5 12. O-O Be7 13. Nxd4 cxd4 14. Nd5 Bxd5
+15. exd5 O-O 16. Re1 Bd6 17. Bg5 h6 18. Bxf6 Qxf6 19. Be4 Rae8 20. a3 Qg5 21.
+b4 f5 22. Bg2 e4 23. Qxd4 Be5 24. Qxa7 Bxa1 25. Rxa1 e3 26. f4 Qf6 27. Re1 Qc3
+28. Kf1 Qd3+ 29. Kg1 Qd2 30. Rf1 e2 31. Qf2 e1=Q 32. Rxe1 Qxe1+ 33. Qxe1 Rxe1+
+34. Bf1 Rfe8 35. c5 R8e2 36. d6 Rd2 37. b5 Rc1 38. a4 Rxc5 39. a5 Rd1 40. a6
+bxa6 41. d7 Rxd7 42. bxa6 Rc1 43. a7 Rxf1+ 44. Kg2 Rxa7 45. Kh3 Ra2 46. Kh4
+Rxh2# 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "metalkingGT"]
+[Black "RigelStar"]
+[Result "1-0"]
+[ECO "A04"]
+[WhiteElo "2459"]
+[BlackElo "2399"]
+[PlyCount "69"]
+[EventDate "2020.??.??"]
+
+1. Nf3 c6 2. g3 d5 3. Bg2 Nf6 4. O-O h6 5. d3 Bf5 6. Nbd2 Bh7 7. Qe1 e6 8. e3
+Bb4 9. e4 Bxd2 10. Nxd2 O-O 11. e5 Nfd7 12. f4 c5 13. Nf3 Nc6 14. Qe2 Qb6 15.
+Kh1 Rae8 16. c3 Qa6 17. Rd1 f6 18. exf6 Rxf6 19. Be3 e5 20. fxe5 Ndxe5 21. Bxc5
+Bxd3 22. Qe3 Rfe6 23. Nxe5 Nxe5 24. Bxd5 Bc4 25. Bxe6+ Rxe6 26. Rd8+ Kh7 27.
+Qe4+ g6 28. Rad1 Nf7 29. Qd4 Nxd8 30. Qxd8 Qc6+ 31. Kg1 Bb5 32. Bf2 Qf3 33.
+Rd7+ Bxd7 34. Qxd7+ Qf7 35. Qxf7+ 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "C9C9C9C9C9"]
+[Black "drop_stone"]
+[Result "1-0"]
+[ECO "A13"]
+[WhiteElo "2976"]
+[BlackElo "2934"]
+[PlyCount "33"]
+[EventDate "2020.??.??"]
+
+1. Nf3 d5 2. c4 e6 3. d4 Nf6 4. g3 Bb4+ 5. Nbd2 dxc4 6. Bg2 O-O 7. O-O b5 8.
+Ne5 c6 9. a4 Qxd4 10. Nxc6 Nxc6 11. Bxc6 Rb8 12. e3 Qd6 13. axb5 Rd8 14. Qc2
+Bxd2 15. Rd1 Qd3 16. Rxd2 Qxc2 17. Rxd8+ 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Nurdin_Abubakar"]
+[Black "drdrunckenstein"]
+[Result "0-1"]
+[ECO "B06"]
+[WhiteElo "2378"]
+[BlackElo "2529"]
+[PlyCount "124"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 g6 2. d4 d6 3. Nc3 Bg7 4. Be3 Nf6 5. f3 O-O 6. Nge2 Nc6 7. Qd2 e5 8.
+O-O-O Nd7 9. h4 h5 10. g4 exd4 11. Nxd4 Nde5 12. gxh5 Nxd4 13. Qxd4 Nxf3 14.
+Qd3 Ne5 15. Qd2 gxh5 16. Be2 Ng4 17. Rdg1 Be6 18. Bg5 Qd7 19. Bh6 f6 20. Bxg7
+Qxg7 21. Nd5 Kh8 22. Nf4 Bf7 23. Bxg4 hxg4 24. h5 Qg5 25. h6 Kh7 26. Kb1 Rae8
+27. Re1 g3 28. Rhg1 Rg8 29. Qe3 b6 30. Qf3 a5 31. Re3 Ref8 32. Rc3 c5 33. Rd3
+Rd8 34. Nd5 Bxd5 35. Rxd5 Qg6 36. Rf5 Rdf8 37. Qf4 g2 38. Qxd6 Qxh6 39. Qd1 Rd8
+40. Qe2 Rg5 41. Rf3 Rdg8 42. b3 Kg7 43. Qd3 Kh8 44. Qc3 Rh5 45. Rxf6 Qg7 46. e5
+Rh1 47. Qe1 Rxg1 48. Qxg1 Qh7 49. Kb2 Qh1 50. Qe3 g1=Q 51. Rh6+ Kg7 52. Rxh1
+Qxe3 53. Rd1 Qxe5+ 54. Kb1 Re8 55. Rc1 Kf7 56. Rf1+ Qf6 57. Rd1 Re6 58. Rc1 Qe7
+59. Rf1+ Ke8 60. Rc1 Re1 61. a4 Qe6 62. Kb2 Qe5+ 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "imdejong"]
+[Black "Frogkiller"]
+[Result "0-1"]
+[ECO "B54"]
+[WhiteElo "2348"]
+[BlackElo "2386"]
+[PlyCount "126"]
+[EventDate "2020.??.??"]
+
+1. e4 c5 2. Nf3 d6 3. d4 Nc6 4. d5 Ne5 5. Nxe5 dxe5 6. Bb5+ Bd7 7. Bxd7+ Qxd7
+8. O-O Nf6 9. Nc3 a6 10. a4 e6 11. Bg5 Be7 12. Qf3 exd5 13. Bxf6 Bxf6 14. Nxd5
+Bg5 15. Nb6 Qd8 16. Nxa8 Qxa8 17. Rad1 O-O 18. Rd7 b5 19. Rfd1 bxa4 20. Qf5 Bf6
+21. g4 h6 22. h4 Bxh4 23. Qxe5 Bf6 24. Qd5 Bxb2 25. Rxf7 Qxd5 26. Rxf8+ Kxf8
+27. exd5 a3 28. d6 Ke8 29. f4 a2 30. d7+ Kd8 31. f5 a1=Q 32. Rxa1 Bxa1 33. Kf2
+Bf6 34. Kf3 Kxd7 35. Ke4 Kd6 36. c4 a5 37. Kd3 a4 38. Kc2 Ke5 39. Kb1 Kd4 40.
+Ka2 Kxc4 41. Ka3 Kd5 42. Kxa4 Ke5 43. Kb5 Kf4 44. Kxc5 Kxg4 45. Kd5 Kxf5 46.
+Kd6 Kg4 47. Kd7 Kg3 48. Ke8 Kg2 49. Kf7 h5 50. Kg6 h4 51. Kh5 h3 52. Kg4 h2 53.
+Kh5 h1=Q+ 54. Kg6 Bc3 55. Kf7 g5 56. Kg8 g4 57. Kf7 g3 58. Ke6 Qf1 59. Kd5 Qf6
+60. Kc4 Be5 61. Kb3 Qd6 62. Kc2 Qd4 63. Kb3 Kf3 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "vassiukov"]
+[Black "Lil_D"]
+[Result "1-0"]
+[ECO "A40"]
+[WhiteElo "2328"]
+[BlackElo "2320"]
+[PlyCount "73"]
+[EventDate "2020.??.??"]
+
+1. d4 g6 2. Nf3 Bg7 3. Bf4 d6 4. h3 Nf6 5. e3 O-O 6. Nbd2 Nc6 7. c3 Nd7 8. Be2
+e5 9. dxe5 dxe5 10. Bh2 f5 11. O-O e4 12. Nd4 Nde5 13. Qc2 Qe7 14. Rad1 a5 15.
+Rfe1 a4 16. Nc4 Kh8 17. Nb5 Be6 18. Nxe5 Nxe5 19. c4 Qf7 20. b3 axb3 21. axb3
+h5 22. Nd4 Bc8 23. Rf1 Bd7 24. Nb5 Bc8 25. Nc3 Kh7 26. Nd5 Ra3 27. Nf4 Be6 28.
+Bg3 Rfa8 29. Rb1 Ra2 30. Qd1 R8a3 31. Nxh5 gxh5 32. Bxh5 Qe7 33. Be2 Nd3 34.
+Bxd3 exd3 35. Qxd3 Qg5 36. Bf4 Qg6 37. e4 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Aisen_Mestnikov"]
+[Black "fullchola"]
+[Result "0-1"]
+[ECO "A41"]
+[WhiteElo "2405"]
+[BlackElo "2427"]
+[PlyCount "136"]
+[EventDate "2020.??.??"]
+
+1. d4 d6 2. c4 Bg4 3. f3 Bd7 4. e4 c5 5. d5 e6 6. Nc3 exd5 7. cxd5 Nf6 8. Nge2
+Be7 9. Ng3 O-O 10. Be2 Na6 11. O-O Nc7 12. a4 a6 13. a5 Rb8 14. Be3 Re8 15. f4
+Bf8 16. Bf3 Qc8 17. Re1 Ng4 18. Bd2 Nb5 19. h3 Nxc3 20. Bxc3 Nf6 21. e5 dxe5
+22. fxe5 Nxd5 23. Qxd5 Be6 24. Qe4 b5 25. Qh4 b4 26. Bd2 Be7 27. Bg5 Bf8 28.
+Be4 g6 29. Bf6 Bg7 30. Bxg7 Kxg7 31. Qf6+ Kg8 32. h4 Qd8 33. h5 Qxf6 34. exf6
+Rbd8 35. hxg6 hxg6 36. Rac1 Rc8 37. Bb7 Rc7 38. Bxa6 Ra8 39. Bb5 Rxa5 40. Bc4
+Ra6 41. Bxe6 fxe6 42. Ne4 c4 43. Nd6 Rxd6 44. Re4 c3 45. Rxb4 c2 46. Re4 Rd1+
+47. Re1 Rcd7 48. Kf2 Rxe1 49. Kxe1 Rd5 50. Rxc2 Rf5 51. Rf2 Kf7 52. Kf1 Kxf6
+53. Rxf5+ gxf5 54. g3 e5 55. Kf2 Ke6 56. b4 Kd5 57. b5 Kc5 58. Kf3 Kxb5 59. g4
+f4 60. Ke4 Kc4 61. g5 Kc3 62. g6 Kd2 63. g7 f3 64. Kxf3 Kd3 65. Kg4 e4 66. Kf5
+e3 67. g8=Q e2 68. Qe8 Kd2 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Betovsky"]
+[Black "hungzhao"]
+[Result "1/2-1/2"]
+[ECO "C01"]
+[WhiteElo "2623"]
+[BlackElo "2627"]
+[PlyCount "141"]
+[EventDate "2020.??.??"]
+
+1. d4 e6 2. e4 d5 3. exd5 exd5 4. Bd3 Nc6 5. c3 Bd6 6. Qf3 Qe7+ 7. Ne2 Be6 8.
+h3 h6 9. Bf4 Bxf4 10. Nxf4 Nf6 11. O-O O-O-O 12. Re1 Qd6 13. Nxe6 fxe6 14. Rxe6
+Qf8 15. Nd2 Kb8 16. Rae1 Qf7 17. R6e2 Rhe8 18. Qg3 Rxe2 19. Rxe2 a6 20. Nb3 Ka7
+21. Nc5 Rd6 22. Bg6 Qf8 23. Ne6 Qe7 24. Nf4 Qd7 25. Bd3 Nd8 26. Ng6 Re6 27. Ne5
+Qe7 28. Bf5 Rb6 29. Nc6+ Nxc6 30. Rxe7 Nxe7 31. Qxc7 Nxf5 32. b4 Rc6 33. Qf7 h5
+34. g4 hxg4 35. hxg4 Nd6 36. Qxg7 Nfe4 37. f3 Nxc3 38. Qe5 Nc4 39. Qe1 Nb5 40.
+Qf2 Ncd6 41. a4 Nc3 42. g5 Nxa4 43. g6 Nf5 44. Qg2 Nh4 45. Qg4 Rxg6 46. Kf2
+Rxg4 47. fxg4 Ng6 48. b5 Nc3 49. bxa6 Kxa6 50. Ke3 Ne4 51. Kd3 Kb5 52. g5 Kc6
+53. Ke3 Kd6 54. Kf3 Ke6 55. Kg4 Nxg5 56. Kh5 Nf4+ 57. Kxg5 Ne2 58. Kg4 Nxd4 59.
+Kg3 Nc6 60. Kf2 Kd6 61. Ke1 Kc5 62. Kd1 b5 63. Kc1 b4 64. Kd1 Kc4 65. Kc1 Na5
+66. Kb1 Nb3 67. Kb2 Nd4 68. Kc1 b3 69. Kd2 Kb4 70. Kc1 Kc3 71. Kb1 1/2-1/2
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Kidefence"]
+[Black "BlueGreensun"]
+[Result "1/2-1/2"]
+[ECO "B07"]
+[WhiteElo "2693"]
+[BlackElo "2774"]
+[PlyCount "142"]
+[EventDate "2020.??.??"]
+
+1. e4 d6 2. d4 e5 3. Nc3 exd4 4. Qxd4 Nc6 5. Bb5 Bd7 6. Qd3 Ne5 7. Qe2 c6 8.
+Ba4 Nf6 9. Bf4 b5 10. Bb3 b4 11. Nd1 a5 12. a3 a4 13. Ba2 bxa3 14. bxa3 Qa5+
+15. Bd2 Qc5 16. Nf3 Bg4 17. Ne3 Bh5 18. O-O Nxe4 19. Bb4 Qb6 20. Nf5 d5 21. c4
+Bxb4 22. cxd5 O-O 23. Qxe4 Nxf3+ 24. gxf3 Bc3 25. Rac1 cxd5 26. Bxd5 Qf6 27.
+Ng3 Bg6 28. Qc4 Bb2 29. Bxa8 Bxc1 30. Rxc1 Rxa8 31. Kg2 h6 32. Qb4 Kh7 33. Rc7
+Rd8 34. Qxa4 Rd3 35. Qc6 Qxc6 36. Rxc6 Rxa3 37. Rc7 f6 38. h4 Ra5 39. Kh3 h5
+40. Kg2 Ra3 41. Ne2 Ra4 42. Kg3 Ra1 43. Nf4 Rg1+ 44. Kh2 Rf1 45. Kg2 Ra1 46.
+Ne6 Ra4 47. Nxg7 Kh6 48. Ne6 Rxh4 49. Kg3 Rh1 50. Kg2 Re1 51. Nf8 Re8 52. Nxg6
+Kxg6 53. Rc4 Rg8 54. Rh4 Rg7 55. Rc4 Kh6+ 56. Kh3 Rg5 57. Rf4 Rg6 58. Kh4 Kg7
+59. Rf5 Rg5 60. Rxg5+ fxg5+ 61. Kxg5 h4 62. Kxh4 Kg6 63. f4 Kf6 64. f5 Kf7 65.
+Kg3 Kg7 66. f3 Kf7 67. f4 Kf8 68. Kf3 Kf7 69. Kg4 Kf8 70. f6 Kf7 71. f5 Kf8
+1/2-1/2
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Superman89"]
+[Black "Ngc99"]
+[Result "1-0"]
+[ECO "D43"]
+[WhiteElo "2327"]
+[BlackElo "2301"]
+[PlyCount "113"]
+[EventDate "2020.??.??"]
+
+1. d4 d5 2. c4 c6 3. Nc3 Nf6 4. Nf3 e6 5. Bf4 dxc4 6. a4 Nd5 7. Bc1 Nxc3 8.
+bxc3 Qa5 9. Qc2 Nd7 10. e4 Nb6 11. Be2 Be7 12. O-O Bd7 13. e5 Rc8 14. Bg5 Bxg5
+15. Nxg5 h6 16. Ne4 O-O 17. Nd6 Rcd8 18. f4 Bc8 19. Bg4 c5 20. f5 cxd4 21. cxd4
+exf5 22. Bxf5 Bxf5 23. Rxf5 Qd5 24. Raf1 Qxd4+ 25. Kh1 Rxd6 26. exd6 Qxd6 27.
+a5 Nd7 28. Qxc4 Nb8 29. Rxf7 Rxf7 30. Qxf7+ Kh7 31. Qf5+ Qg6 32. Qxg6+ Kxg6 33.
+Rb1 Nc6 34. Rxb7 Nxa5 35. Rxa7 Nc4 36. Ra6+ Kh7 37. Kg1 Ne5 38. Kf2 Nd3+ 39.
+Ke3 Ne5 40. Re6 Ng4+ 41. Kf4 Nf6 42. Rxf6 gxf6 43. Kf5 Kg7 44. h4 Kf7 45. h5
+Kg7 46. Ke6 f5 47. Kxf5 Kf7 48. g4 Kg7 49. Ke6 Kg8 50. Kf6 Kh7 51. Kf7 Kh8 52.
+Kg6 Kg8 53. Kxh6 Kh8 54. Kg6 Kg8 55. g5 Kh8 56. Kf6 Kg8 57. g6 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "TORTITADECHOCLO2021"]
+[Black "mandarria"]
+[Result "0-1"]
+[ECO "B06"]
+[WhiteElo "2302"]
+[BlackElo "2304"]
+[PlyCount "54"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 g6 2. d4 Bg7 3. Nc3 d6 4. Be3 a6 5. Qd2 b5 6. f3 Bb7 7. Nge2 Nd7 8. Ng3
+c5 9. d5 h5 10. h4 Ngf6 11. Be2 Ne5 12. Nd1 O-O 13. Bh6 e6 14. Bxg7 Kxg7 15.
+dxe6 fxe6 16. Qg5 Nf7 17. Qd2 d5 18. Nf2 dxe4 19. Qxd8 Raxd8 20. Ngxe4 Nxe4 21.
+Nxe4 Bxe4 22. fxe4 Ne5 23. Rd1 Rxd1+ 24. Kxd1 Rf4 25. Bd3 c4 26. Be2 Rxe4 27.
+Rf1 Rxh4 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "KingoFish"]
+[Black "Maybach77"]
+[Result "0-1"]
+[ECO "C64"]
+[WhiteElo "2405"]
+[BlackElo "2375"]
+[PlyCount "74"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 e5 2. Nf3 Nc6 3. Bb5 Nf6 4. O-O Bc5 5. c3 O-O 6. d4 Bb6 7. Bg5 h6 8. Bxf6
+Qxf6 9. Bxc6 Qxc6 10. Nxe5 Qxe4 11. a4 a5 12. Nd2 Qf5 13. Ndc4 Ba7 14. Nxa5 d6
+15. Nec4 Re8 16. Nb3 Be6 17. Nbd2 c5 18. Ne3 Qg6 19. d5 Bd7 20. Ndc4 Re4 21. f3
+Re7 22. Qc2 Qf6 23. Ng4 Qf4 24. b3 b5 25. axb5 Bxb5 26. g3 Qg5 27. h4 Qh5 28.
+Rfe1 Rxe1+ 29. Rxe1 Bxc4 30. bxc4 f5 31. Nh2 Bb6 32. Qe2 Ra3 33. Qe6+ Kh7 34.
+Qxd6 Ba5 35. Qxc5 Ra2 36. Qe3 Qg6 37. Qe6 Qxg3+ 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Bulingot"]
+[Black "Guga1606"]
+[Result "0-1"]
+[ECO "B06"]
+[WhiteElo "2357"]
+[BlackElo "2361"]
+[PlyCount "72"]
+[EventDate "2020.??.??"]
+
+1. e4 g6 2. h4 Bg7 3. h5 c5 4. Nc3 Nc6 5. Bc4 d6 6. Nf3 a6 7. Ng5 e6 8. d3 b5
+9. Bb3 Bb7 10. Qf3 Qe7 11. Qg3 O-O-O 12. Nf3 Nf6 13. h6 Bf8 14. Bg5 e5 15. Nd5
+Nxd5 16. Bxe7 Ndxe7 17. Bxf7 Ng8 18. Ng5 Nxh6 19. Bd5 Nd4 20. Kd2 Bxd5 21. exd5
+Nhf5 22. Qh3 Be7 23. Ne6 Nxe6 24. dxe6 Rdf8 25. c3 h5 26. Kc2 Kc7 27. a4 b4 28.
+a5 g5 29. Kb3 g4 30. Qh2 Ng7 31. Qg1 Nxe6 32. Qe1 Nd8 33. Qe4 Nc6 34. Qc4 Rf4
+35. Qxa6 Rb8 36. c4 Nd4+ 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "ajedrez2021"]
+[Black "sutcunuri"]
+[Result "1-0"]
+[ECO "A10"]
+[WhiteElo "2591"]
+[BlackElo "2522"]
+[PlyCount "131"]
+[EventDate "2020.??.??"]
+
+1. c4 b6 2. Nf3 Bb7 3. Nc3 f5 4. d4 e6 5. e3 Bb4 6. Bd2 Nf6 7. Be2 O-O 8. O-O
+d6 9. Qb3 Bxc3 10. Bxc3 Nbd7 11. c5 Bd5 12. Qc2 bxc5 13. dxc5 Nxc5 14. Rfd1
+Nfe4 15. b4 Nxc3 16. Qxc3 Ne4 17. Qc2 a5 18. b5 a4 19. Nd4 Qf6 20. Rac1 a3 21.
+Bf3 Ra7 22. Nc6 Rb7 23. Qa4 h6 24. Qxa3 Rxb5 25. Nd4 Rb7 26. Qa6 Rfb8 27. Nc6
+Rb6 28. Nxb8 Rxa6 29. Nxa6 c5 30. Nc7 Bxa2 31. Bxe4 fxe4 32. Rxd6 c4 33. Nxe6
+Qb2 34. Rdd1 Bb3 35. Re1 c3 36. Nd4 Ba4 37. h3 Qd2 38. Ra1 c2 39. Rf1 Kh7 40.
+Rxa4 c1=Q 41. Rxc1 Qxc1+ 42. Kh2 Qf1 43. Ra2 Qc4 44. Rc2 Qf7 45. g4 Qa7 46. Kg3
+Qb8+ 47. Kg2 Qf8 48. Rc6 Qf6 49. Rxf6 gxf6 50. Kg3 Kg6 51. Kf4 h5 52. gxh5+
+Kxh5 53. Kxe4 Kh4 54. Kf5 Kxh3 55. Kxf6 Kg2 56. e4 Kxf2 57. e5 Ke3 58. e6 Kxd4
+59. e7 Kd5 60. e8=Q Kc5 61. Qe6 Kd4 62. Qd6+ Kc3 63. Qc6+ Kd3 64. Qd5+ Ke3 65.
+Qc5+ Kd3 66. Qd4+ 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "BorisBulto"]
+[Black "burpcow"]
+[Result "0-1"]
+[ECO "B13"]
+[WhiteElo "2383"]
+[BlackElo "2303"]
+[PlyCount "40"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 c6 2. d4 d5 3. exd5 cxd5 4. c4 Nf6 5. Nc3 Nc6 6. Bg5 e6 7. Nf3 Bb4 8. Rc1
+h6 9. Bxf6 Qxf6 10. Qa4 O-O 11. a3 Bxc3+ 12. bxc3 Bd7 13. Qc2 Rfe8 14. Be2 dxc4
+15. Bxc4 e5 16. d5 e4 17. Nd2 e3 18. Nf3 exf2+ 19. Kf1 Ne5 20. Nxe5 Rxe5 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "zpxocivubyntmraeswdq"]
+[Black "Club-Jaque-al-Rey"]
+[Result "1-0"]
+[ECO "A20"]
+[WhiteElo "2692"]
+[BlackElo "2522"]
+[PlyCount "40"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. c4 e5 2. g3 d6 3. Bg2 f5 4. d4 Nf6 5. Nc3 Be7 6. Nf3 e4 7. Ng5 c6 8. d5 h6
+9. Nh3 Nbd7 10. f3 exf3 11. exf3 O-O 12. O-O Ne5 13. b3 c5 14. Re1 Bd7 15. Bb2
+Nh5 16. Rxe5 dxe5 17. f4 exf4 18. Qxh5 fxg3 19. hxg3 Bd6 20. Ne2 Qf6 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "drop_stone"]
+[Black "C9C9C9C9C9"]
+[Result "0-1"]
+[ECO "B00"]
+[WhiteElo "2929"]
+[BlackElo "2981"]
+[PlyCount "128"]
+[EventDate "2020.??.??"]
+
+1. e4 b6 2. d4 Bb7 3. Nc3 e6 4. Bd3 g6 5. h4 Bg7 6. Be3 h6 7. Qd2 d6 8. O-O-O
+a6 9. Nge2 Nd7 10. h5 g5 11. f4 g4 12. Ng3 Ngf6 13. f5 e5 14. d5 Nc5 15. Kb1
+Bc8 16. Nce2 Bd7 17. c4 a5 18. Bc2 a4 19. Nc3 Kf8 20. Qe2 Rg8 21. Qd2 Rh8 22.
+Qe2 Ra5 23. Bd2 Ra6 24. Nf1 Ke7 25. Ne3 Qg8 26. Rh4 Nh7 27. Rxg4 Nf6 28. Rg3
+Qh7 29. Ng4 Rg8 30. Be3 Raa8 31. Qd2 Nxg4 32. Rxg4 Bf6 33. Rxg8 Rxg8 34. Bxh6
+Rg4 35. Rh1 a3 36. b4 Na6 37. Nb5 Kd8 38. Be3 Nb8 39. h6 Bxb5 40. cxb5 Nd7 41.
+Qe2 Rg8 42. g4 Bg5 43. Rh5 Bxe3 44. Qxe3 Nf6 45. Rg5 Ke7 46. Rxg8 Nxg8 47. g5
+f6 48. Qg3 Kf8 49. Qxa3 fxg5 50. Qa8+ Kf7 51. Bd1 Qxh6 52. Qc6 Kg7 53. Qxc7+
+Kh8 54. Qd8 Qh4 55. f6 Qxe4+ 56. Bc2 Qxb4+ 57. Kc1 Qe1+ 58. Kb2 Qb4+ 59. Kc1
+Qf4+ 60. Kb2 Qxf6 61. Kb1 Qxd8 62. Bd3 Qc7 63. Be4 Qc5 64. Bf5 Qb4+ 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "irakliberadze"]
+[Black "dimochka_tsoi"]
+[Result "0-1"]
+[ECO "C41"]
+[WhiteElo "2654"]
+[BlackElo "2644"]
+[PlyCount "60"]
+[EventDate "2020.??.??"]
+
+1. e4 e5 2. Nf3 d6 3. Nc3 Nf6 4. d4 exd4 5. Nxd4 Be7 6. Bd3 O-O 7. O-O Nc6 8.
+Nxc6 bxc6 9. Bg5 Rb8 10. Rb1 Be6 11. Qf3 Nd7 12. Bxe7 Qxe7 13. Qg3 Ne5 14. f4
+Nxd3 15. cxd3 Qf6 16. f5 Bd7 17. Kh1 a5 18. Ne2 Rxb2 19. Rxb2 Qxb2 20. f6 g6
+21. Ng1 Ra8 22. Qg5 Qb8 23. e5 dxe5 24. Qxe5 Be6 25. Nf3 Qb5 26. Qf4 Qh5 27.
+Qxc7 Bd5 28. Rb1 Qh6 29. Ne5 Re8 30. Rb8 Qc1# 0-1
+
+[Event "Rated Blitz tournament OxRShNHO"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "luisangel1808"]
+[Black "FanDeGranda"]
+[Result "0-1"]
+[ECO "B38"]
+[WhiteElo "2385"]
+[BlackElo "2370"]
+[PlyCount "102"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 c5 2. Nf3 Nc6 3. d4 cxd4 4. Nxd4 g6 5. c4 Bg7 6. Be3 Nf6 7. Nc3 d6 8. Be2
+O-O 9. O-O Bd7 10. h3 Nxd4 11. Bxd4 Bc6 12. Qc2 Qa5 13. Rfd1 Nd7 14. Bxg7 Kxg7
+15. a3 Qe5 16. Nd5 Bxd5 17. Rxd5 Qf6 18. Rad1 a5 19. b4 axb4 20. axb4 Ra1 21.
+Bf1 Rxd1 22. Qxd1 Ne5 23. Qd2 Rc8 24. Qd4 Nc6 25. Qxf6+ Kxf6 26. Rb5 Rc7 27. f4
+e5 28. g3 Nd4 29. Rd5 Ke7 30. fxe5 dxe5 31. Rxe5+ Kf6 32. Rd5 Ne6 33. Kf2 b6
+34. g4 Ke7 35. Ke3 g5 36. Be2 h6 37. Bd3 Nf4 38. Rf5 Nxh3 39. Rb5 Rc6 40. c5
+bxc5 41. bxc5 Nf4 42. Rb7+ Kf6 43. Rb6 Re6 44. Bc4 Ng6 45. Bxe6 fxe6 46. c6 Ne5
+47. c7 Nc4+ 48. Kd4 Nxb6 49. Kc5 Nc8 50. Kc6 Ke5 51. Kd7 Nd6 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "profaVa"]
+[Black "JiangoFett"]
+[Result "0-1"]
+[ECO "B22"]
+[WhiteElo "2382"]
+[BlackElo "2382"]
+[PlyCount "50"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 c5 2. c3 Nf6 3. e5 Nd5 4. d4 cxd4 5. Nf3 Nc6 6. Bc4 Nb6 7. Bb3 d6 8. exd6
+Qxd6 9. Na3 dxc3 10. Qe2 cxb2 11. Bxb2 Qb4+ 12. Kf1 Bg4 13. Nc2 Qf4 14. Re1 e6
+15. Ne3 Bxf3 16. gxf3 O-O-O 17. Rc1 Bb4 18. Kg2 Rd2 19. Qb5 Qxe3 20. Rxc6+ bxc6
+21. Qxc6+ Kb8 22. Rf1 Rxb2 23. Kg1 Qg5+ 24. Kh1 Rd8 25. Rc1 Rc8 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Klaksidee"]
+[Black "EPThompson"]
+[Result "0-1"]
+[ECO "E62"]
+[WhiteElo "2606"]
+[BlackElo "2529"]
+[PlyCount "52"]
+[EventDate "2020.??.??"]
+
+1. Nf3 d6 2. g3 Nf6 3. d4 g6 4. Bg2 Bg7 5. O-O O-O 6. c4 c6 7. Nc3 Bf5 8. Ne1
+e5 9. e4 Bg4 10. f3 exd4 11. Qxd4 Be6 12. Qd3 Na6 13. Be3 Nb4 14. Qe2 d5 15.
+Rd1 Qa5 16. a3 Na6 17. cxd5 cxd5 18. exd5 Nxd5 19. Nxd5 Bxd5 20. b4 Qxa3 21.
+Rxd5 Nxb4 22. Rd1 Rfe8 23. Kf2 Rac8 24. Nd3 Nd5 25. Bc1 Qc3 26. Qd2 Qd4+ 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "locelsiano"]
+[Black "lewisbort"]
+[Result "0-1"]
+[ECO "A04"]
+[WhiteElo "2355"]
+[BlackElo "2378"]
+[PlyCount "100"]
+[EventDate "2020.??.??"]
+
+1. Nf3 c5 2. g3 Nc6 3. Bg2 g6 4. O-O Bg7 5. e3 Nf6 6. c3 O-O 7. d4 cxd4 8. exd4
+d5 9. Re1 Bg4 10. Bf4 e6 11. Qb3 Qc8 12. Nbd2 Na5 13. Qc2 Bf5 14. Qd1 b5 15. a3
+Nc4 16. Nxc4 bxc4 17. Ne5 Be4 18. Bxe4 Nxe4 19. Qe2 Qb7 20. f3 Nf6 21. h3 a5
+22. a4 h6 23. h4 Ra6 24. Qe3 h5 25. Bh6 Kh7 26. Bxg7 Kxg7 27. Kg2 Rb6 28. Re2
+Rxb2 29. Rae1 Qb6 30. g4 hxg4 31. fxg4 Rh8 32. g5 Ne4 33. Rxb2 Qxb2+ 34. Re2
+Qxc3 35. Qf4 Rf8 36. Nd7 Rh8 37. Ne5 Rf8 38. h5 gxh5 39. Qh4 Qxd4 40. Nf3 Qd3
+41. Re1 Rh8 42. Qf4 Qc2+ 43. Kg1 c3 44. Qe5+ Kg8 45. g6 fxg6 46. Qxe6+ Kh7 47.
+Ng5+ Kh6 48. Nf7+ Kg7 49. Ne5 Qf2+ 50. Kh1 Ng3# 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "alphonsea"]
+[Black "LordGrim2500"]
+[Result "1-0"]
+[ECO "B25"]
+[WhiteElo "2307"]
+[BlackElo "2456"]
+[PlyCount "49"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 c5 2. Nc3 d6 3. g3 g6 4. Bg2 Bg7 5. d3 Nc6 6. Nge2 Nf6 7. O-O O-O 8. f4
+Bg4 9. h3 Bxe2 10. Nxe2 Nd7 11. c3 Rb8 12. Be3 b5 13. d4 Na5 14. b3 b4 15. c4
+cxd4 16. Bxd4 Bxd4+ 17. Nxd4 Qb6 18. Kh1 Nb7 19. Nc2 Nbc5 20. Qg4 Nf6 21. Qh4
+Ncxe4 22. Rae1 Nf2+ 23. Kh2 Rbe8 24. g4 Kg7 25. Rxf2 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Paanoos"]
+[Black "WildBreath"]
+[Result "1/2-1/2"]
+[ECO "C47"]
+[WhiteElo "2407"]
+[BlackElo "2398"]
+[PlyCount "99"]
+[EventDate "2020.??.??"]
+
+1. e4 e5 2. Nc3 Nc6 3. Nf3 Nf6 4. d4 exd4 5. Nxd4 Bb4 6. Nxc6 bxc6 7. Bd3 d5 8.
+exd5 O-O 9. O-O Bg4 10. f3 Bh5 11. dxc6 Qd4+ 12. Kh1 Bxc3 13. bxc3 Qxc3 14. Rb1
+Qxc6 15. Bb2 Bg6 16. Bxg6 hxg6 17. Qd4 Rfd8 18. Qc3 Qxc3 19. Bxc3 Rab8 20. Ba5
+Rxb1 21. Rxb1 Rd7 22. Kg1 Nd5 23. Rb7 a6 24. Ra7 Ne3 25. Rxa6 Nxc2 26. Rc6 Rd1+
+27. Kf2 Nd4 28. Rxc7 Ra1 29. Bc3 Rxa2+ 30. Kg3 Ne6 31. Rc8+ Kh7 32. Rc4 Ra8 33.
+h4 Kg8 34. Rb4 Re8 35. Rb7 Nf8 36. Bb4 Nh7 37. Bc5 Nf6 38. Bd4 Nh5+ 39. Kf2 Nf6
+40. Bxf6 gxf6 41. g4 Kg7 42. Kg3 Rh8 43. Rb5 Rd8 44. h5 gxh5 45. Rxh5 Rd1 46.
+Rf5 Rg1+ 47. Kf2 Rd1 48. Kg3 Rd2 49. Rf4 Rd1 50. Rf5 1/2-1/2
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "MiroMiljkovic"]
+[Black "estocastico"]
+[Result "1-0"]
+[ECO "E38"]
+[WhiteElo "2599"]
+[BlackElo "2560"]
+[PlyCount "63"]
+[EventDate "2020.??.??"]
+
+1. d4 Nf6 2. c4 e6 3. Nc3 Bb4 4. Qc2 c5 5. dxc5 Na6 6. Nf3 O-O 7. Bd2 Nxc5 8.
+a3 Bxc3 9. Bxc3 b6 10. g3 Bb7 11. Bg2 Rc8 12. O-O Nce4 13. Bxf6 Qxf6 14. Qa4
+Qxb2 15. Qxa7 Nc5 16. Rab1 Qxe2 17. Rfe1 Qc2 18. Nd4 Qc3 19. Bxb7 Nxb7 20. Qxb6
+Nc5 21. Nb5 Qxc4 22. Nd6 Qd5 23. Nxc8 Rxc8 24. Red1 Qf3 25. Rbc1 h5 26. Rd4
+Qxa3 27. Rdc4 Rc6 28. Qb8+ Kh7 29. Qb1+ g6 30. Qb5 Qf3 31. Rxc5 Rd6 32. Qf1 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "LRgenius"]
+[Black "Lawton25"]
+[Result "1-0"]
+[ECO "B53"]
+[WhiteElo "2435"]
+[BlackElo "2479"]
+[PlyCount "49"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Qxd4 Nc6 5. Bb5 Bd7 6. Bxc6 Bxc6 7. Nc3 Nf6 8.
+Bg5 e6 9. O-O-O Be7 10. Rhe1 O-O 11. Kb1 h6 12. Bh4 Qa5 13. g4 g5 14. Bg3 e5
+15. Qd2 Qd8 16. Nxg5 hxg5 17. Qxg5+ Kh7 18. Bxe5 Rg8 19. Qh4+ Kg6 20. f4 dxe5
+21. Rxd8 Raxd8 22. f5+ Kg7 23. g5 Rh8 24. gxf6+ Bxf6 25. Rg1+ 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "NEKI_NOVI_KLINAC"]
+[Black "Abouyahya1983"]
+[Result "0-1"]
+[ECO "B45"]
+[WhiteElo "2456"]
+[BlackElo "2561"]
+[PlyCount "68"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 c5 2. Nf3 e6 3. Nc3 Nc6 4. d4 cxd4 5. Nxd4 Nf6 6. Nxc6 bxc6 7. Be3 d5 8.
+exd5 exd5 9. Be2 Bd6 10. O-O O-O 11. h3 h6 12. Qd2 Re8 13. Bd3 Bc7 14. Bxh6 Qd6
+15. g3 gxh6 16. Qxh6 Ne4 17. Qxd6 Bxd6 18. Bxe4 dxe4 19. Rfe1 f5 20. h4 Bb4 21.
+a3 Bxc3 22. bxc3 Be6 23. Rad1 Rad8 24. Rxd8 Rxd8 25. f3 Bd5 26. c4 Bxc4 27.
+fxe4 fxe4 28. Rxe4 Rd1+ 29. Kh2 Bd5 30. Rg4+ Kh7 31. Rg7+ Kxg7 32. g4 Rd2+ 33.
+Kg3 Rxc2 34. h5 Rc3+ 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "RigelStar"]
+[Black "metalkingGT"]
+[Result "0-1"]
+[ECO "E60"]
+[WhiteElo "2394"]
+[BlackElo "2464"]
+[PlyCount "130"]
+[EventDate "2020.??.??"]
+
+1. d4 Nf6 2. Nf3 g6 3. c4 Bg7 4. Nc3 O-O 5. Bf4 d6 6. h3 Nbd7 7. e3 Re8 8. Be2
+e6 9. O-O Qe7 10. Nb5 Nf8 11. Qb3 a6 12. Nc3 h6 13. Qa3 g5 14. Bh2 Ng6 15. b4
+g4 16. hxg4 Nxg4 17. Bg3 f5 18. c5 d5 19. b5 h5 20. bxa6 bxa6 21. Qa4 h4 22.
+Bf4 Nxf4 23. exf4 Bd7 24. c6 Bc8 25. Ne5 Nxe5 26. dxe5 Kh8 27. Rfd1 Rg8 28. Rd3
+Bh6 29. Kf1 Bxf4 30. Qxf4 Qg5 31. Qxg5 Rxg5 32. Na4 Rb8 33. f4 Rg7 34. Rh3 Rh7
+35. g3 Rb4 36. Nc3 a5 37. Kf2 d4 38. Nb5 Rb2 39. Kf3 Ba6 40. a4 Rb3+ 41. Kf2
+hxg3+ 42. Rxg3 Rb2 43. Rg2 d3 44. Ke3 Rxe2+ 45. Rxe2 dxe2 46. Kxe2 Rh2+ 47. Ke3
+Rh3+ 48. Kd4 Rb3 49. Kc5 Rb4 50. Rd1 Rxa4 51. Rd8+ Kg7 52. Nxc7 Kh6 53. Nxe6
+Rc4+ 54. Kd6 Rc3 55. Ke7 Rd3 56. Rh8+ Kg6 57. Rg8+ Kh6 58. Rf8 Kh5 59. Rxf5+
+Kg4 60. Nf8 Kf3 61. Rg5 Rd7+ 62. Kxd7 Ke4 63. Ke7 Bc8 64. c7 Kd4 65. Kd8 Kc3
+0-1
+
+[Event "Rated Blitz tournament nLsDCFvz"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "ElPeinador"]
+[Black "spidernv"]
+[Result "1-0"]
+[ECO "A21"]
+[WhiteElo "2359"]
+[BlackElo "2428"]
+[PlyCount "119"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. c4 e5 2. Nc3 g6 3. Nf3 Bg7 4. d4 d6 5. dxe5 dxe5 6. Qxd8+ Kxd8 7. e4 h6 8.
+Be3 c6 9. O-O-O+ Kc7 10. Nd2 Na6 11. f4 Nf6 12. fxe5 Ng4 13. Bg1 Nxe5 14. Nf3
+Be6 15. Nxe5 Bxe5 16. Be3 g5 17. Be2 Rhd8 18. a3 b6 19. Kc2 Kb7 20. b4 Nc7 21.
+Rhf1 Bxh2 22. Rh1 Be5 23. Rxh6 g4 24. Rh4 Rxd1 25. Bxd1 Bxc4 26. Bxg4 Rd8 27.
+Be2 Be6 28. Rh7 Rg8 29. Bf3 Ne8 30. Ne2 Nd6 31. Nd4 Bd7 32. a4 Nc4 33. Bf2 Nd6
+34. b5 cxb5 35. axb5 Rg7 36. Rxg7 Bxg7 37. e5+ Kc7 38. exd6+ Kxd6 39. Nc6 a6
+40. Bg3+ Kc5 41. bxa6 Bxc6 42. a7 Bh6 43. Bxc6 Kxc6 44. a8=Q+ Kb5 45. Qe4 Kc5
+46. Qf5+ Kb4 47. Qxf7 Ka5 48. Qa2+ Kb5 49. Qb3+ Kc6 50. Qf7 b5 51. Qg6+ Kc5 52.
+Qxh6 Kb4 53. Qd6+ Ka5 54. Qd3 Ka4 55. Qb3+ Ka5 56. Be1+ Kb6 57. Qe6+ Kc5 58.
+Bf2+ Kb4 59. Qb3+ Ka5 60. Qa3# 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "panicOttack"]
+[Black "CarlosMontenegro"]
+[Result "0-1"]
+[ECO "B06"]
+[WhiteElo "2312"]
+[BlackElo "2408"]
+[PlyCount "74"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 g6 2. d4 Bg7 3. Nc3 d6 4. f4 a6 5. Nf3 b5 6. a3 Bb7 7. e5 Nd7 8. Bd3 e6
+9. O-O Ne7 10. Qe2 O-O 11. Be3 Bxf3 12. Qxf3 d5 13. Rad1 Qc8 14. Kh1 c5 15. g4
+cxd4 16. Bxd4 Nc5 17. Rde1 Nxd3 18. cxd3 Nc6 19. Bf2 Qb7 20. Bh4 b4 21. Na4 Qb5
+22. Qd1 bxa3 23. bxa3 Rab8 24. Nc3 Qb3 25. Qd2 Qb2 26. Re2 Qxd2 27. Rxd2 Rb3
+28. Nd1 Rxa3 29. Rc2 Nd4 30. Rc7 Rxd3 31. Nf2 Rf3 32. Bg3 Ra8 33. Rd1 Ne2 34.
+Kg2 Rb3 35. Ra1 g5 36. fxg5 Nxg3 37. hxg3 Bxe5 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "wizardbar"]
+[Black "robikan"]
+[Result "1-0"]
+[ECO "C11"]
+[WhiteElo "2523"]
+[BlackElo "2371"]
+[PlyCount "91"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 e6 2. d4 d5 3. Nc3 Nf6 4. Bg5 h6 5. Bxf6 gxf6 6. exd5 exd5 7. Bd3 Be6 8.
+Nge2 Bd6 9. Qd2 Nd7 10. Nf4 c6 11. O-O-O Qc7 12. Nxe6 fxe6 13. Bg6+ Ke7 14. g3
+e5 15. Kb1 Rag8 16. Bf5 Kd8 17. dxe5 fxe5 18. Nxd5 cxd5 19. Qxd5 Rf8 20. Bxd7
+Kxd7 21. Qxe5 Qc6 22. Rhe1 Kc7 23. Qg7+ Kb8 24. Re6 Rhg8 25. Qxh6 Rxf2 26. c3
+Qb5 27. Rd2 Rxd2 28. Qxd2 Bc7 29. Re1 Rd8 30. Qc2 a6 31. a3 Rf8 32. g4 Rf2 33.
+Qxf2 Qg5 34. Qf5 Qd2 35. Rc1 Bf4 36. Rc2 Qd1+ 37. Ka2 Bc7 38. g5 Qd8 39. g6
+Qg8+ 40. Qf7 Qh8 41. g7 Qh6 42. g8=Q+ Ka7 43. Qxc7 Qe6+ 44. Qxe6 Ka8 45. Qeb6
+a5 46. Qbxb7# 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Cebuanochessking"]
+[Black "FedaMaster"]
+[Result "1-0"]
+[ECO "B01"]
+[WhiteElo "2417"]
+[BlackElo "2548"]
+[PlyCount "93"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 d5 2. exd5 Qxd5 3. Nc3 Qd6 4. d4 Nf6 5. Bc4 Bg4 6. f3 Bh5 7. Nge2 Nc6 8.
+Bf4 Qd8 9. d5 Nb8 10. Bb5+ Nbd7 11. Qd2 a6 12. Ba4 b5 13. Bb3 Bg6 14. O-O Nc5
+15. Rfe1 c6 16. dxc6 Qxd2 17. Bxd2 e6 18. Nd4 O-O-O 19. Be3 Kc7 20. Rad1 Be7
+21. Bf4+ Kb6 22. c7 Rd7 23. a4 Nxb3 24. cxb3 b4 25. a5+ Kb7 26. Na4 Nd5 27. Nb6
+Nxb6 28. axb6 Kxb6 29. Rc1 Bc5 30. Rxc5 Kxc5 31. Nxe6+ fxe6 32. Rc1+ Kb6 33.
+c8=Q Rxc8 34. Rxc8 e5 35. Bxe5 Bf7 36. Bxg7 Bxb3 37. Rb8+ Ka5 38. Bf8 Rd1+ 39.
+Kf2 Rd4 40. Bc5 Rc4 41. Bf8 Rc2+ 42. Kg3 Rc4 43. h4 Ba4 44. h5 Bb5 45. Be7 Rc2
+46. b3 Rb2 47. Bd8# 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Frogkiller"]
+[Black "Obito2016"]
+[Result "0-1"]
+[ECO "C01"]
+[WhiteElo "2392"]
+[BlackElo "2326"]
+[PlyCount "36"]
+[EventDate "2020.??.??"]
+
+1. e4 e6 2. d4 d5 3. exd5 exd5 4. Nf3 Nf6 5. Bd3 Bd6 6. O-O O-O 7. Bg5 c6 8. c3
+Nbd7 9. Nbd2 Qc7 10. Qc2 h6 11. Bh4 Re8 12. Rae1 Be7 13. Bg3 Bd6 14. Ne5 Nxe5
+15. dxe5 Bxe5 16. Bxe5 Rxe5 17. Rxe5 Qxe5 18. Re1 Qxe1+ 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "imdejong"]
+[Black "alireza3700"]
+[Result "0-1"]
+[ECO "C10"]
+[WhiteElo "2343"]
+[BlackElo "2334"]
+[PlyCount "116"]
+[EventDate "2020.??.??"]
+
+1. e4 e6 2. d4 d5 3. Nc3 dxe4 4. Nxe4 Bd7 5. Nf3 Bc6 6. Bd3 Nd7 7. O-O Ngf6 8.
+Nxf6+ Qxf6 9. Bg5 Bxf3 10. Qd2 Qxd4 11. gxf3 f6 12. Be3 Qh4 13. Rad1 Bd6 14. f4
+O-O-O 15. Rfe1 e5 16. Bf5 exf4 17. Bxf4 Qxf4 18. Qxf4 Bxf4 19. Re7 Bd6 20. Rxg7
+Rhg8 21. Bxd7+ Kb8 22. Rxg8 Rxg8+ 23. Kf1 Bxh2 24. Be6 Rg1+ 25. Ke2 Rxd1 26.
+Kxd1 Be5 27. c3 h6 28. Bg4 c6 29. Bh5 Kc7 30. Ke2 Kd6 31. Ke3 Kc5 32. f4 b5 33.
+fxe5 fxe5 34. Ke4 Kd6 35. Be8 a6 36. b4 c5 37. a3 cxb4 38. axb4 Ke6 39. Bh5 Kd6
+40. Be2 Ke6 41. Bg4+ Kd6 42. Bh3 h5 43. Bc8 h4 44. Bxa6 h3 45. Bb7 Kc7 46. Bd5
+Kd6 47. Ba8 h2 48. Kd3 Ke6 49. Bh1 Kf5 50. Ke3 Ke6 51. Ke4 Kd6 52. Kd3 Ke6 53.
+c4 bxc4+ 54. Kxc4 Kd7 55. Kc5 Kc7 56. b5 Kb8 57. b6 Kc8 58. Be4 Kb8 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "dimochka_tsoi"]
+[Black "irakliberadze"]
+[Result "0-1"]
+[ECO "B11"]
+[WhiteElo "2650"]
+[BlackElo "2648"]
+[PlyCount "96"]
+[EventDate "2020.??.??"]
+
+1. e4 c6 2. Nc3 d5 3. Nf3 Bg4 4. Bd3 Bxf3 5. Qxf3 e6 6. O-O Nf6 7. b3 Nbd7 8.
+Bb2 Ne5 9. Qg3 Nxd3 10. Qxd3 dxe4 11. Nxe4 Qxd3 12. Nxf6+ gxf6 13. cxd3 Be7 14.
+Rfe1 O-O-O 15. Re3 Rhg8 16. g3 f5 17. Kf1 Bg5 18. Rf3 Bxd2 19. Ke2 Bg5 20. h4
+Be7 21. Rc1 h5 22. d4 Bf6 23. Rc4 Rg4 24. Rd3 Re4+ 25. Kd2 Rg4 26. Ke2 Kb8 27.
+a4 f4 28. Kf3 fxg3 29. fxg3 Rd5 30. Bc3 Rf5+ 31. Ke2 Re4+ 32. Kd1 Rf1+ 33. Kd2
+Bg7 34. Kc2 Bh6 35. Bb2 Re2+ 36. Kc3 Rff2 37. Ba3 a5 38. Rd1 Rf3+ 39. Rd3 Bd2+
+40. Kc2 Bb4+ 41. Kd1 Rxd3+ 42. Kxe2 Rxb3 43. Bxb4 axb4 44. Rc5 Rxg3 45. Rxh5 b3
+46. Kd2 Rg2+ 47. Kc3 b2 48. Rh8+ Ka7 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Club-Jaque-al-Rey"]
+[Black "Derrotado"]
+[Result "0-1"]
+[ECO "B00"]
+[WhiteElo "2519"]
+[BlackElo "2401"]
+[PlyCount "7"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 a5 2. d4 g6 3. Bd3 Bg7 4. Bh6 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "EPThompson"]
+[Black "Klaksidee"]
+[Result "1-0"]
+[ECO "B12"]
+[WhiteElo "2536"]
+[BlackElo "2599"]
+[PlyCount "121"]
+[EventDate "2020.??.??"]
+
+1. e4 c6 2. d4 d5 3. e5 c5 4. dxc5 Nc6 5. a3 Nxe5 6. Bb5+ Bd7 7. Qxd5 Bxb5 8.
+Qxe5 Rc8 9. Nc3 Nf6 10. Nxb5 Qa5+ 11. Nc3 e6 12. b4 Qd8 13. Nf3 Be7 14. O-O O-O
+15. Rd1 Qe8 16. Bg5 b6 17. cxb6 axb6 18. Ne4 Nd7 19. Qd4 Nb8 20. Bxe7 Qxe7 21.
+Qd6 Qb7 22. Qf4 Rc4 23. Qe3 Rxe4 24. Qd3 Rg4 25. h3 Rg6 26. a4 h6 27. a5 bxa5
+28. bxa5 Na6 29. Rab1 Qa7 30. Ne5 Rg5 31. Nc6 Qa8 32. Rb6 Rc8 33. Qxa6 Qxa6 34.
+Rxa6 Kh7 35. Rd8 Rc7 36. Rb8 Rc5 37. Rbb6 Rxc2 38. g4 Rc1+ 39. Kg2 Rc2 40. Kg3
+f6 41. f3 e5 42. h4 Rc3 43. Kf2 e4 44. fxe4 Rc2+ 45. Ke3 Rc3+ 46. Kf4 Rd7 47.
+h5 Rc1 48. Kf5 Rf1+ 49. Ke6 Rd2 50. e5 Re1 51. Ra7 Rde2 52. Rbb7 Rxe5+ 53. Nxe5
+Rxe5+ 54. Kf7 Rg5 55. Kf8 Rxg4 56. Rxg7+ Kh8 57. Rxg4 f5 58. Rg6 f4 59. Rag7 f3
+60. Rg8+ Kh7 61. R6g7# 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Adrian_DelaCruz"]
+[Black "Xabaka"]
+[Result "1-0"]
+[ECO "E98"]
+[WhiteElo "2368"]
+[BlackElo "2436"]
+[PlyCount "73"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 Nf6 2. c4 g6 3. Nf3 Bg7 4. Nc3 O-O 5. e4 d6 6. Be2 e5 7. O-O Nc6 8. d5
+Ne7 9. Ne1 Nd7 10. Nd3 f5 11. f3 f4 12. Bd2 g5 13. Rc1 Rf7 14. c5 Nf6 15. cxd6
+cxd6 16. Nf2 Ng6 17. Nb5 a6 18. Na3 b5 19. Nc2 h5 20. h3 Bf8 21. Nb4 g4 22.
+fxg4 hxg4 23. hxg4 Rh7 24. Nc6 Qe8 25. Rc3 f3 26. Rxf3 Nxg4 27. Nxg4 Bxg4 28.
+Rxf8+ Nxf8 29. Bxg4 Qg6 30. Bf5 Qxg2+ 31. Kxg2 Rh2+ 32. Kxh2 Ng6 33. Qg4 Ra7
+34. Qxg6+ Kh8 35. Qh6+ Kg8 36. Be6+ Rf7 37. Bxf7# 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Lil_D"]
+[Black "vassiukov"]
+[Result "0-1"]
+[ECO "A00"]
+[WhiteElo "2314"]
+[BlackElo "2333"]
+[PlyCount "84"]
+[EventDate "2020.??.??"]
+
+1. g3 d5 2. Bg2 Nf6 3. d3 Bf5 4. Nd2 e6 5. e3 h5 6. Ne2 h4 7. h3 hxg3 8. fxg3
+Bh7 9. g4 Bd6 10. O-O c6 11. Nf4 e5 12. g5 exf4 13. gxf6 Qxf6 14. exf4 Nd7 15.
+Qe2+ Kf8 16. Nf3 Re8 17. Ne5 Nxe5 18. fxe5 Qxe5 19. Qxe5 Bxe5 20. a4 Bg6 21. a5
+a6 22. Ra4 Re6 23. Rb4 Re7 24. Bg5 f6 25. Bd2 Bf7 26. Rg4 g5 27. Bb4 Ke8 28.
+Bxe7 Kxe7 29. Rb4 Rb8 30. h4 Bd6 31. Ra4 Be6 32. hxg5 fxg5 33. Re1 Kf6 34. Rf1+
+Ke7 35. Raa1 Kd7 36. c3 Rg8 37. Rae1 g4 38. Rf6 Re8 39. Rg6 g3 40. Rg7+ Re7 41.
+Rxe7+ Bxe7 42. Re3 Bd6 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "hungzhao"]
+[Black "Betovsky"]
+[Result "1-0"]
+[ECO "B01"]
+[WhiteElo "2627"]
+[BlackElo "2623"]
+[PlyCount "31"]
+[EventDate "2020.??.??"]
+
+1. e4 d5 2. exd5 Nf6 3. Bb5+ Bd7 4. Be2 Nxd5 5. d4 Bf5 6. a3 Nb6 7. Nf3 c5 8.
+Be3 cxd4 9. Nxd4 Be4 10. f3 Bd5 11. c4 Bxc4 12. Bxc4 Nxc4 13. Qa4+ Qd7 14. Qxc4
+Nc6 15. Nxc6 bxc6 16. Nc3 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Molot_ua"]
+[Black "Aisen_Mestnikov"]
+[Result "0-1"]
+[ECO "A00"]
+[WhiteElo "2380"]
+[BlackElo "2400"]
+[PlyCount "64"]
+[EventDate "2020.??.??"]
+
+1. d3 Nf6 2. c3 g6 3. Nd2 Bg7 4. h3 d6 5. g4 O-O 6. Bg2 c6 7. Nf1 e5 8. Ng3 d5
+9. g5 Ne8 10. h4 f5 11. gxf6 Nxf6 12. h5 gxh5 13. Nxh5 Nxh5 14. Rxh5 Bg4 15.
+Rg5 h5 16. f3 Be6 17. Rxh5 Nd7 18. Qa4 Bf7 19. Rg5 Nf6 20. Qh4 Nh7 21. Nh3 Nxg5
+22. Nxg5 Bg6 23. Bh3 Re8 24. Be6+ Rxe6 25. Qh3 Rf6 26. Bd2 e4 27. dxe4 dxe4 28.
+O-O-O Qa5 29. a3 exf3 30. exf3 Raf8 31. Rh1 Qa4 32. Be3 Qc2# 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "BlueGreensun"]
+[Black "Kidefence"]
+[Result "1-0"]
+[ECO "B02"]
+[WhiteElo "2772"]
+[BlackElo "2695"]
+[PlyCount "111"]
+[EventDate "2020.??.??"]
+
+1. e4 Nf6 2. d3 d5 3. Nd2 g6 4. g3 Bg7 5. Bg2 O-O 6. e5 Nfd7 7. f4 c5 8. Ngf3
+Nc6 9. O-O Nb6 10. Kh1 Bg4 11. h3 Bxf3 12. Nxf3 e6 13. g4 Rc8 14. c3 d4 15. c4
+Nd7 16. Qe2 a6 17. Bd2 b5 18. Rae1 bxc4 19. dxc4 Qb6 20. b3 a5 21. Rb1 Ra8 22.
+Ne1 Qc7 23. Nd3 Rac8 24. Rbe1 Nb4 25. Bxb4 axb4 26. f5 exf5 27. gxf5 Rfe8 28.
+e6 Nf6 29. exf7+ Qxf7 30. fxg6 Qxg6 31. Ne5 Qh6 32. Qf3 Rcd8 33. Qg3 d3 34.
+Nxd3 Rxe1 35. Rxe1 Qd2 36. Re3 Nh5 37. Qf3 Nf6 38. Kh2 Kh8 39. Ne5 Qd6 40. Qg3
+Qf8 41. Rd3 Rxd3 42. Nxd3 Nh5 43. Qf3 Qb8+ 44. Kg1 Nf6 45. Ne5 Qa7 46. Qc6 h6
+47. Qc8+ Kh7 48. Qf5+ Kg8 49. Bd5+ Nxd5 50. cxd5 Qxa2 51. Qe6+ Kh7 52. Qg6+ Kg8
+53. Ng4 Qa1+ 54. Kg2 Qd4 55. Nxh6+ Kf8 56. Qf7# 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "gmmitkov"]
+[Black "Club-Jaque-al-Rey"]
+[Result "1/2-1/2"]
+[ECO "B11"]
+[WhiteElo "2520"]
+[BlackElo "2512"]
+[PlyCount "127"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 c6 2. Nc3 d5 3. Nf3 Bg4 4. h3 Bxf3 5. Qxf3 e6 6. Be2 Nd7 7. d4 Bb4 8. O-O
+Bxc3 9. bxc3 dxe4 10. Qxe4 Ngf6 11. Qf3 O-O 12. Rb1 Nb6 13. Rd1 Qd5 14. Rb3
+Qxf3 15. Bxf3 Nfd5 16. Be2 Rab8 17. c4 Nc7 18. Bf4 Rfc8 19. Bg3 Nd7 20. c5 b5
+21. cxb6 Rxb6 22. Rxb6 axb6 23. Bf3 Nd5 24. c4 N5f6 25. Bd6 Ne8 26. Bf4 Kf8 27.
+d5 cxd5 28. cxd5 e5 29. Be3 f5 30. Rb1 Rb8 31. g3 Nd6 32. Be2 Ke7 33. a4 h6 34.
+h4 Ne4 35. Bd3 Nd6 36. f4 e4 37. Be2 Ra8 38. Bd1 Ra6 39. Bd4 g6 40. Rb4 Nf6 41.
+Be2 Ra5 42. Bxb6 Ra8 43. Rd4 Nd7 44. a5 Nxb6 45. axb6 Rb8 46. Rb4 Nc8 47. b7
+Nd6 48. Ba6 Kd7 49. Kf2 Kc7 50. h5 gxh5 51. Rb1 Nxb7 52. Bxb7 Rxb7 53. d6+ Kc6
+54. Rd1 Rd7 55. Rh1 Rxd6 56. Rxh5 Rf6 57. Ke3 Kd6 58. Kd4 Ke6 59. Rh4 Rg6 60.
+Rh5 Kf6 61. Rh3 Ke6 62. Rh5 Rf6 63. Rh3 Rg6 64. Rh5 1/2-1/2
+
+[Event "Rated Bullet tournament H3UwNQec"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "RhenzRheann_Auza98"]
+[Black "Zuritadas"]
+[Result "1-0"]
+[ECO "A07"]
+[WhiteElo "2373"]
+[BlackElo "2393"]
+[PlyCount "99"]
+[EventDate "2020.??.??"]
+
+1. Nf3 d5 2. g3 Nd7 3. Bg2 e5 4. O-O Ngf6 5. c4 dxc4 6. Na3 Bxa3 7. bxa3 O-O 8.
+Qc2 Nb6 9. a4 a5 10. Nxe5 Be6 11. Bxb7 Qd6 12. Bxa8 Rxa8 13. Nf3 Ng4 14. Bb2
+Qd5 15. Rad1 Qh5 16. Qc3 f6 17. Qc2 Re8 18. h4 Nd5 19. d3 c3 20. Bxc3 Nxc3 21.
+Qxc3 Bd5 22. Qxa5 c6 23. e4 Bf7 24. Qxh5 Bxh5 25. Kg2 Ne5 26. Nxe5 Bxd1 27.
+Rxd1 fxe5 28. Rc1 Ra8 29. Rxc6 Rxa4 30. Rc5 Rxa2 31. Rxe5 Rd2 32. Rd5 h6 33.
+Kf3 Kf7 34. Ke3 Rd1 35. f4 Re1+ 36. Kd4 Rg1 37. f5 Rxg3 38. Ke5 Re3 39. Rd7+
+Ke8 40. Rxg7 Rxd3 41. Rg6 Rh3 42. Rxh6 Rxh4 43. Rxh4 Kf7 44. Rh7+ Kg8 45. Rb7
+Kf8 46. Kf6 Ke8 47. Ke6 Kd8 48. f6 Kc8 49. Re7 Kd8 50. f7 1-0
+
+[Event "Rated Blitz tournament te4AhseI"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "alekhinnemanaba"]
+[Black "Mr-Anonymous-Killer"]
+[Result "1-0"]
+[ECO "B00"]
+[WhiteElo "2344"]
+[BlackElo "2339"]
+[PlyCount "51"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 Nh6 2. d4 g6 3. Nc3 Bg7 4. Bc4 c5 5. Nf3 cxd4 6. Nxd4 Nc6 7. Be3 d6 8. f3
+Qa5 9. Qd2 Nxd4 10. Bxd4 O-O 11. Bxg7 Kxg7 12. O-O-O Be6 13. Bb3 Bxb3 14. cxb3
+Rac8 15. Kb1 b5 16. h4 b4 17. Nd5 e6 18. h5 Ng8 19. Qd4+ f6 20. hxg6 hxg6 21.
+Nf4 Rfe8 22. Qxd6 e5 23. Ne6+ Rxe6 24. Qxe6 Rc7 25. Rd7+ Kf8 26. Qf7# 1-0
+
+[Event "Rated Blitz tournament te4AhseI"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "MiracleEcu"]
+[Black "chesslismab"]
+[Result "1/2-1/2"]
+[ECO "B03"]
+[WhiteElo "2356"]
+[BlackElo "2426"]
+[PlyCount "138"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 Nf6 2. e5 Nd5 3. c4 Nb6 4. d4 d6 5. exd6 cxd6 6. Be3 g6 7. Nc3 Bg7 8. Rc1
+O-O 9. Nf3 Bg4 10. h3 Bxf3 11. Qxf3 Nc6 12. Qd1 d5 13. c5 Nc4 14. Bxc4 dxc4 15.
+d5 Nb4 16. O-O Bxc3 17. Rxc3 Qxd5 18. Qxd5 Nxd5 19. Rxc4 Rfc8 20. Rd1 e6 21.
+Bg5 Rc6 22. a3 Rac8 23. b4 b6 24. Rdc1 bxc5 25. Rxc5 Rxc5 26. bxc5 Rc6 27. f3
+f6 28. Bh4 Kf7 29. Bf2 e5 30. Rb1 Ke6 31. Rb7 Rc7 32. Rb8 Nf4 33. Ra8 Nd3 34.
+Be3 f5 35. Kf1 f4 36. Bg1 Kd5 37. Rd8+ Kc4 38. Re8 a5 39. Ke2 a4 40. Ra8 Nb2
+41. Kd2 Kb3 42. Rb8+ Kxa3 43. Kc3 Nd1+ 44. Kd2 Ne3 45. Bxe3 fxe3+ 46. Kxe3 Rxc5
+47. Rb7 Rc2 48. g4 Rb2 49. Rxh7 Ka2 50. h4 a3 51. h5 gxh5 52. gxh5 Rh2 53. Ke4
+Kb1 54. Rb7+ Rb2 55. Ra7 a2 56. Kxe5 Rb5+ 57. Ke6 a1=Q 58. Rxa1+ Kxa1 59. f4
+Kb2 60. f5 Kc3 61. h6 Kd4 62. h7 Rb6+ 63. Kf7 Rb7+ 64. Kg6 Rb8 65. f6 Ke5 66.
+f7 Ke6 67. Kg7 Ke7 68. h8=Q Rxh8 69. Kxh8 Kxf7 1/2-1/2
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Opperkip"]
+[Black "Guga1606"]
+[Result "0-1"]
+[ECO "A48"]
+[WhiteElo "2300"]
+[BlackElo "2367"]
+[PlyCount "98"]
+[EventDate "2020.??.??"]
+
+1. d4 Nf6 2. Nf3 g6 3. Bg5 Bg7 4. Nbd2 O-O 5. e3 c5 6. Be2 cxd4 7. exd4 Nc6 8.
+c3 d5 9. O-O Bg4 10. Re1 Qc7 11. h3 Bxf3 12. Bxf3 Rae8 13. Bh4 e5 14. Bg3 Nh5
+15. Bxh5 gxh5 16. Qxh5 Qb6 17. b3 exd4 18. cxd4 Qxd4 19. Nf3 Rxe1+ 20. Rxe1 Qb2
+21. Ng5 h6 22. Nxf7 Rxf7 23. Re8+ Rf8 24. Qxd5+ Kh8 25. Qf7 Qc1+ 26. Kh2 Qc5
+27. Qg6 Rxe8 28. Qxe8+ Qf8 29. Qe4 Qe7 30. Qf5 a6 31. Qg4 b5 32. Qf3 Nd4 33. b4
+Nxf3+ 34. gxf3 Qxb4 35. Kg2 Qa3 36. Be5 Bxe5 37. f4 Bxf4 38. h4 h5 39. f3 Qxa2+
+40. Kh3 Bh6 41. f4 Kg7 42. Kg3 Kf6 43. Kf3 Kf5 44. Ke3 Qb3+ 45. Kf2 Bxf4 46.
+Kg1 Qc2 47. Kh1 Kg4 48. Kg1 Kg3 49. Kf1 Qf2# 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "C9C9C9C9C9"]
+[Black "drop_stone"]
+[Result "0-1"]
+[ECO "A48"]
+[WhiteElo "2986"]
+[BlackElo "2924"]
+[PlyCount "46"]
+[EventDate "2020.??.??"]
+
+1. d4 Nf6 2. Nf3 g6 3. Bg5 Bg7 4. Nbd2 O-O 5. e4 d5 6. e5 Ne4 7. Bf4 c5 8. c3
+cxd4 9. cxd4 Nc6 10. Bd3 Bg4 11. Nxe4 dxe4 12. Bxe4 Bxf3 13. Bxf3 Nxd4 14. O-O
+Qd7 15. Be4 Rfd8 16. Rc1 Qe6 17. Rc3 Bxe5 18. Bg3 Bxg3 19. Bxb7 Rab8 20. hxg3
+Rxb7 21. Re1 Nf3+ 22. Qxf3 Qxe1+ 23. Kh2 Rxb2 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Tematico"]
+[Black "Derrotado"]
+[Result "0-1"]
+[ECO "B00"]
+[WhiteElo "2395"]
+[BlackElo "2409"]
+[PlyCount "102"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 a5 2. d4 g6 3. Nc3 Bg7 4. f4 d6 5. Nf3 Nd7 6. Bd3 c6 7. O-O e5 8. fxe5
+dxe5 9. Bc4 Qe7 10. Bxf7+ Qxf7 11. Nxe5 Qe6 12. Nf7 Ngf6 13. Nxh8 Bxh8 14. d5
+Qe7 15. Bg5 Bg7 16. Qf3 h6 17. Bh4 g5 18. Bg3 Ne5 19. Qe2 Bg4 20. Qe3 Nc4 21.
+Qd4 Nd7 22. Qxc4 Be5 23. dxc6 bxc6 24. Qg8+ Nf8 25. Rxf8+ Qxf8 26. Qxf8+ Kxf8
+27. Bxe5 Ke7 28. Rf1 Be6 29. Bf6+ Ke8 30. e5 Rb8 31. b3 Rb4 32. Rd1 g4 33. Rd6
+Bf5 34. Rxc6 Rd4 35. Kf2 Rd2+ 36. Ke3 Rxc2 37. Rc8+ Bxc8 38. Kd4 Rxg2 39. Ne4
+Rxh2 40. Nd6+ Kd7 41. Ne4 Rxa2 42. Nc5+ Kc6 43. e6 Bxe6 44. Nxe6 g3 45. Kc4 a4
+46. b4 g2 47. b5+ Kd6 48. Bd4 Kxe6 49. b6 Rb2 50. Kc5 Rxb6 51. Kxb6 a3 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "sutcunuri"]
+[Black "ajedrez2021"]
+[Result "0-1"]
+[ECO "A04"]
+[WhiteElo "2517"]
+[BlackElo "2596"]
+[PlyCount "128"]
+[EventDate "2020.??.??"]
+
+1. Nf3 g6 2. e4 Bg7 3. Nc3 c5 4. Be2 Nc6 5. O-O Nf6 6. Re1 O-O 7. Bf1 d6 8. b3
+Bg4 9. h3 Bxf3 10. Qxf3 Nd7 11. Qd1 a6 12. Bb2 b5 13. Qc1 Rc8 14. a4 b4 15. Nd1
+Qb6 16. Bxg7 Kxg7 17. Ne3 e6 18. Qb2+ f6 19. Nc4 Qc7 20. c3 a5 21. Rad1 Nde5
+22. Ne3 Rcd8 23. Nc2 Qb6 24. d4 bxc3 25. Qxc3 cxd4 26. Nxd4 Nxd4 27. Rxd4 Rc8
+28. Qd2 Rfd8 29. Rd1 Qxb3 30. Rxd6 Nf7 31. Rd4 Rxd4 32. Qxd4 Rd8 33. Qxd8 Nxd8
+34. Rxd8 Qxa4 35. Rb8 Qa1 36. Ra8 a4 37. g3 Kh6 38. Kg2 a3 39. Bc4 Qe5 40. Kf3
+Qc3+ 41. Kg2 Qxc4 42. Rxa3 Qxe4+ 43. Kg1 Qd5 44. Re3 f5 45. h4 Qd1+ 46. Kg2
+Qd5+ 47. Kg1 g5 48. Re2 g4 49. Re3 Kg6 50. Rd3 Kf6 51. Rxd5 exd5 52. Kf1 d4 53.
+Ke2 f4 54. Kd3 f3 55. Kxd4 Ke6 56. Ke3 h5 57. Kf4 Kf6 58. Ke4 Kg6 59. Ke5 Kg7
+60. Kf5 Kf7 61. Kg5 Ke6 62. Kxh5 Kf5 63. Kh6 Ke4 64. Kh5 Kf5 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Kelevra90"]
+[Black "Tigerscot"]
+[Result "0-1"]
+[ECO "C41"]
+[WhiteElo "2451"]
+[BlackElo "2471"]
+[PlyCount "64"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 d6 2. d4 Nf6 3. Nc3 e5 4. Nf3 Nbd7 5. g4 g6 6. g5 Nh5 7. Bh3 Bg7 8. Bg4
+exd4 9. Nxd4 Bxd4 10. Qxd4 Ne5 11. Be2 O-O 12. f4 Nc6 13. Qf2 Ng7 14. Be3 f6
+15. h4 Be6 16. O-O-O Qe7 17. Qg3 Kf7 18. Rhg1 f5 19. h5 Ke8 20. h6 Nh5 21. Bxh5
+gxh5 22. Qh4 Bf7 23. Rge1 Kd7 24. exf5 Rae8 25. f6 Qe6 26. Bxa7 Qf5 27. Bf2 Bg6
+28. Rd2 Nb4 29. Qh2 Nxc2 30. Rxe8 Rxe8 31. Bg1 Ne3 32. Rd1 Nxd1 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Betovsky"]
+[Black "hungzhao"]
+[Result "0-1"]
+[ECO "A45"]
+[WhiteElo "2618"]
+[BlackElo "2633"]
+[PlyCount "54"]
+[EventDate "2020.??.??"]
+
+1. d4 Nf6 2. Bg5 Ne4 3. Bf4 c5 4. f3 Nf6 5. dxc5 Qa5+ 6. c3 Qxc5 7. e4 d6 8.
+Nd2 g6 9. Nc4 Bg7 10. Be3 Qc7 11. a4 O-O 12. Qd2 Nc6 13. Bd3 Be6 14. Ne2 d5 15.
+Bf4 Qd8 16. Ne5 dxe4 17. Bxe4 Nxe4 18. fxe4 Qxd2+ 19. Kxd2 Nxe5 20. Bxe5 Bxe5
+21. Ke3 Rfd8 22. Rhd1 Rxd1 23. Rxd1 Bg4 24. Rd2 Bxe2 25. Kxe2 Bd6 26. Rd5 Rc8
+27. e5 Rc5 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "lord_barre"]
+[Black "MrMania"]
+[Result "0-1"]
+[ECO "A04"]
+[WhiteElo "2419"]
+[BlackElo "2376"]
+[PlyCount "96"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. Nf3 c5 2. g3 d6 3. Bg2 Nf6 4. O-O g6 5. e3 Bg7 6. d4 cxd4 7. exd4 O-O 8. Re1
+d5 9. Ne5 Nc6 10. Nxc6 bxc6 11. b3 Bf5 12. Ba3 Re8 13. Nc3 e6 14. Na4 h5 15.
+Rc1 Bh6 16. f4 Be4 17. c4 Bxg2 18. Kxg2 Ne4 19. Nc3 Nxc3 20. Rxc3 h4 21. Bc1
+Qa5 22. Rc2 dxc4 23. bxc4 Rad8 24. Be3 Bg7 25. Qd2 Qf5 26. Bf2 h3+ 27. Kg1 Bxd4
+28. Bxd4 Rxd4 29. Qxd4 Qxc2 30. Qf2 Qxc4 31. g4 Rd8 32. f5 Qxg4+ 33. Qg3 Qxg3+
+34. hxg3 gxf5 35. Kh2 Rd2+ 36. Kxh3 Rxa2 37. Rc1 Kg7 38. Rxc6 a5 39. Kh4 a4 40.
+Kg5 Rg2 41. Kf4 a3 42. Ra6 a2 43. Kf3 Rb2 44. Kf4 Kf6 45. Ra8 Rb3 46. Ra6 a1=Q
+47. Rxe6+ fxe6 48. g4 Qe5# 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Obito2016"]
+[Black "Frogkiller"]
+[Result "0-1"]
+[ECO "A43"]
+[WhiteElo "2333"]
+[BlackElo "2385"]
+[PlyCount "82"]
+[EventDate "2020.??.??"]
+
+1. d4 c5 2. d5 d6 3. Nc3 e6 4. e4 exd5 5. exd5 Nf6 6. Nf3 a6 7. Bb5+ axb5 8.
+O-O b4 9. Nb1 Be7 10. Re1 O-O 11. Bg5 Bg4 12. h3 Bh5 13. c3 bxc3 14. Nxc3 Re8
+15. Qd2 Nbd7 16. g4 Bg6 17. Kg2 Rb8 18. Re2 b5 19. Rae1 b4 20. Nb1 Bxb1 21.
+Rxb1 Qc7 22. Rbe1 Bf8 23. Nh4 Rxe2 24. Rxe2 Re8 25. Nf5 Rxe2 26. Qxe2 Nxd5 27.
+Kg1 c4 28. h4 c3 29. bxc3 bxc3 30. h5 Ne5 31. Bh6 c2 32. Bc1 Qc3 33. f4 Nxf4
+34. Bxf4 c1=Q+ 35. Bxc1 Qxc1+ 36. Kg2 Qf4 37. Ne3 Qe4+ 38. Kf2 d5 39. Ng2 Bc5+
+40. Ke1 Nf3+ 41. Kd1 Qb1# 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Morphysher"]
+[Black "MISSISSIPPIPLAYER"]
+[Result "1/2-1/2"]
+[ECO "D74"]
+[WhiteElo "2307"]
+[BlackElo "2402"]
+[PlyCount "74"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. c4 Nf6 2. Nf3 g6 3. g3 Bg7 4. Bg2 O-O 5. O-O d5 6. cxd5 Nxd5 7. d4 Nc6 8.
+Nc3 Nxc3 9. bxc3 e5 10. dxe5 Nxe5 11. Nxe5 Bxe5 12. Bb2 Qf6 13. Qc2 Bf5 14. e4
+Be6 15. f4 Bd6 16. e5 Bc5+ 17. Kh1 Qf5 18. Be4 Qh5 19. Bf3 Bg4 20. Bxb7 Rab8
+21. Bg2 Rfd8 22. c4 Bf5 23. Qc1 Bd3 24. Rd1 Be2 25. Rxd8+ Rxd8 26. Qe1 Bf3 27.
+Bc3 Rd3 28. Rb1 Bxg2+ 29. Kxg2 Qf3+ 30. Kh3 Qxf4 31. Rb8+ Kg7 32. e6+ Kh6 33.
+exf7 Qf5+ 34. Kg2 Qf3+ 35. Kh3 Qf5+ 36. Kg2 Qf3+ 37. Kh3 Qf5+ 1/2-1/2
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Atomrod"]
+[Black "zpxocivubyntmraeswdq"]
+[Result "0-1"]
+[ECO "A80"]
+[WhiteElo "2506"]
+[BlackElo "2695"]
+[PlyCount "62"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 f5 2. Nf3 Nf6 3. Bg5 e6 4. Nbd2 Be7 5. Bxf6 Bxf6 6. e4 O-O 7. Bd3 d5 8.
+exf5 exf5 9. O-O c5 10. c3 cxd4 11. Nxd4 g6 12. N2f3 Nc6 13. Bc2 Kg7 14. Re1
+Nxd4 15. Nxd4 Qb6 16. Bb3 Rd8 17. Qd3 a5 18. Re2 a4 19. Bd1 Bd7 20. Rd2 Bg5 21.
+Rc2 Bf6 22. Bf3 Rac8 23. Rd1 Rc5 24. Re2 Bb5 25. Nxb5 Rxb5 26. Rdd2 Rc5 27. a3
+d4 28. c4 Qb3 29. Bd5 Rdxd5 30. g4 Qxd3 31. Rxd3 Rxc4 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Routmund1976"]
+[Black "titan_twelve"]
+[Result "0-1"]
+[ECO "D00"]
+[WhiteElo "2363"]
+[BlackElo "2392"]
+[PlyCount "88"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 d5 2. Bf4 Nf6 3. e3 e6 4. Nf3 c5 5. c3 Bd6 6. Bg3 O-O 7. Bd3 Qc7 8. Nbd2
+Nbd7 9. O-O e5 10. dxe5 Nxe5 11. Nxe5 Bxe5 12. Qc2 b6 13. Nf3 Bxg3 14. hxg3 Bb7
+15. Rad1 Rad8 16. c4 h6 17. a3 Ba6 18. cxd5 Bxd3 19. Rxd3 Nxd5 20. Rfd1 Nf6 21.
+Rxd8 Rxd8 22. Rxd8+ Qxd8 23. Qd2 Qxd2 24. Nxd2 b5 25. Kf1 Kf8 26. e4 Ke7 27.
+Ke2 Kd6 28. Kd3 Kc6 29. b3 Ng4 30. f3 Nf6 31. Nf1 Nh5 32. f4 g5 33. Ke3 a5 34.
+e5 Kd5 35. Kf3 gxf4 36. gxf4 Kd4 37. g4 Ng7 38. Ne3 c4 39. bxc4 bxc4 40. Ke2 c3
+41. Nf5+ Nxf5 42. gxf5 Kd5 43. Kd3 h5 44. Kxc3 h4 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "estocastico"]
+[Black "MiroMiljkovic"]
+[Result "0-1"]
+[ECO "A43"]
+[WhiteElo "2555"]
+[BlackElo "2604"]
+[PlyCount "62"]
+[EventDate "2020.??.??"]
+
+1. d4 c5 2. Nf3 cxd4 3. Nxd4 Nf6 4. Nc3 e5 5. Nb3 d5 6. Bg5 d4 7. Nb1 Be7 8.
+N1d2 O-O 9. e4 Nc6 10. Bd3 h6 11. Bh4 Bg4 12. f3 Be6 13. O-O Nh5 14. Bg3 Nxg3
+15. hxg3 a5 16. a4 Nb4 17. f4 Nxd3 18. cxd3 f6 19. Nc4 b6 20. Nbd2 Qc7 21. Qh5
+Bb4 22. Rac1 Bxd2 23. Nxd2 Qd6 24. Nc4 Bxc4 25. Rxc4 Rac8 26. Rfc1 Rxc4 27.
+Rxc4 exf4 28. gxf4 Qxf4 29. Qd5+ Kh8 30. Qxd4 Re8 31. Rc7 Qxc7 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "mandarria"]
+[Black "i_love_lubimka"]
+[Result "0-1"]
+[ECO "C51"]
+[WhiteElo "2310"]
+[BlackElo "2357"]
+[PlyCount "84"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 e5 2. Nf3 Nc6 3. Bc4 Bc5 4. b4 Bxb4 5. c3 Be7 6. d4 Na5 7. Bxf7+ Kxf7 8.
+Nxe5+ Kf8 9. O-O d6 10. Nd3 Nf6 11. Nd2 g6 12. f4 Kg7 13. e5 Nd5 14. Ne4 Bf5
+15. Ndf2 Nc4 16. Qe2 b5 17. a4 a6 18. g4 Be6 19. Rb1 Rb8 20. axb5 axb5 21. h3
+Rf8 22. Nd3 Qd7 23. Bd2 dxe5 24. fxe5 Rxf1+ 25. Rxf1 Rf8 26. Rxf8 Bxf8 27. Ndc5
+Bxc5 28. Nxc5 Qf7 29. Ne4 Nf4 30. Bxf4 Qxf4 31. Nc5 Bd5 32. e6 Qg3+ 33. Kf1
+Qxh3+ 34. Ke1 Qh1+ 35. Qf1 Qxf1+ 36. Kxf1 Kf6 37. g5+ Ke7 38. Ke2 Bxe6 39. Kf3
+Nd6 40. Kf4 Bd5 41. Ke5 Bc6 42. Ne6 Nf7+ 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Rama75"]
+[Black "Mia_Khaliffa"]
+[Result "0-1"]
+[ECO "C98"]
+[WhiteElo "2470"]
+[BlackElo "2435"]
+[PlyCount "94"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 O-O 8. h3
+d6 9. c3 Na5 10. Bc2 c5 11. d4 Qc7 12. Nbd2 Nc6 13. d5 Nd8 14. a4 Rb8 15. axb5
+axb5 16. b4 c4 17. Nf1 Ne8 18. Ng3 g6 19. Bh6 Ng7 20. Ra5 f6 21. Qd2 Nf7 22.
+Be3 Bd7 23. Rea1 Rb7 24. Ra7 Rfb8 25. Nh2 Qc8 26. f3 f5 27. Ne2 f4 28. Bf2 h5
+29. R1a3 Bd8 30. Qe1 g5 31. Qa1 g4 32. Rxb7 Rxb7 33. Ra8 Rb8 34. Rxb8 Qxb8 35.
+hxg4 hxg4 36. fxg4 Nh6 37. Qa6 Nxg4 38. Nxg4 Bxg4 39. Kf1 Nh5 40. Ba7 Bxe2+ 41.
+Kxe2 Qc7 42. Qxb5 Ng3+ 43. Kf3 Qxa7 44. Qe8+ Kg7 45. Qxd8 Qe3+ 46. Kg4 Qe2+ 47.
+Kg5 Qh5# 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "irakliberadze"]
+[Black "dimochka_tsoi"]
+[Result "0-1"]
+[ECO "C41"]
+[WhiteElo "2654"]
+[BlackElo "2644"]
+[PlyCount "140"]
+[EventDate "2020.??.??"]
+
+1. e4 e5 2. Nf3 d6 3. Bc4 Be7 4. O-O Nf6 5. d4 exd4 6. Qe1 O-O 7. Nxd4 Nc6 8.
+Nxc6 bxc6 9. Nc3 Rb8 10. Bd3 Be6 11. e5 dxe5 12. Qxe5 Bd6 13. Qg5 Ng4 14. h3
+Qxg5 15. Bxg5 Ne5 16. Rab1 Nxd3 17. cxd3 Bf5 18. Rfd1 Rfe8 19. f3 Bc5+ 20. Kf1
+Bd4 21. Bh4 a5 22. Bf2 Bf6 23. g4 Be6 24. h4 g6 25. Rd2 a4 26. Ne4 Bg7 27. b3
+axb3 28. axb3 Rxb3 29. Rxb3 Bxb3 30. Re2 Bd5 31. Nf6+ Bxf6 32. Rxe8+ Kg7 33.
+Be3 Bxh4 34. Ke2 h6 35. Rc8 Bg3 36. f4 Bh4 37. Rxc7 Bf6 38. Ra7 g5 39. fxg5
+hxg5 40. Rb7 Be6 41. Rb6 Bxg4+ 42. Kd2 Bd7 43. Rb7 Be6 44. Rc7 Bd5 45. Rd7 Kg6
+46. Rd6 Kf5 47. Rd7 Be5 48. Ra7 g4 49. Ra4 g3 50. Ra1 Kg4 51. Re1 g2 52. Bc5
+Bg3 53. Kc2 Bxe1 54. Kd1 g1=Q 55. Ke2 Qg2+ 56. Kxe1 Bf3 57. Bf2 Kf4 58. Kd2
+Qxf2+ 59. Kc3 Ke3 60. Kc4 Qd2 61. Kc5 Qxd3 62. Kb6 Qd5 63. Kc7 c5 64. Kb6 c4
+65. Ka6 c3 66. Kb6 Qc4 67. Ka7 Qb4 68. Ka6 c2 69. Ka7 c1=Q 70. Ka6 Qa1# 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "hungzhao"]
+[Black "Betovsky"]
+[Result "0-1"]
+[ECO "B01"]
+[WhiteElo "2638"]
+[BlackElo "2612"]
+[PlyCount "102"]
+[EventDate "2020.??.??"]
+
+1. e4 d5 2. exd5 Nf6 3. Bb5+ Bd7 4. Be2 Nxd5 5. d4 Nb6 6. a3 Bf5 7. Nf3 e6 8.
+O-O Be7 9. c4 O-O 10. Nc3 Nc6 11. Be3 Bf6 12. b4 h6 13. Qb3 Bg4 14. Rad1 Qe7
+15. h3 Bh5 16. Ne4 Rad8 17. Nxf6+ Qxf6 18. Qc3 Rd7 19. Rd2 Rfd8 20. Rfd1 Na4
+21. Qa1 Nb6 22. Qc3 Na4 23. Qc2 Nb6 24. Qc3 Bg6 25. Ne5 Nxe5 26. dxe5 Qe7 27.
+Bc5 Qe8 28. Rxd7 Rxd7 29. Rxd7 Nxd7 30. Be3 a6 31. a4 Qe7 32. b5 axb5 33. axb5
+Nc5 34. Qb4 b6 35. Bxc5 bxc5 36. Qd2 Qh4 37. Kh2 Qe4 38. Qe3 Qd4 39. Qxd4 cxd4
+40. f4 d3 41. Bd1 d2 42. Kg3 Bd3 43. c5 Bxb5 44. Kf3 Bc6+ 45. Kf2 g5 46. g3
+gxf4 47. gxf4 f6 48. Ke3 fxe5 49. fxe5 Kf7 50. Kxd2 Kg6 51. Ke3 Kf5 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "drop_stone"]
+[Black "C9C9C9C9C9"]
+[Result "1-0"]
+[ECO "B01"]
+[WhiteElo "2931"]
+[BlackElo "2979"]
+[PlyCount "61"]
+[EventDate "2020.??.??"]
+
+1. e4 d5 2. exd5 Qxd5 3. Nc3 Qa5 4. d4 Nf6 5. Nf3 Bf5 6. Bc4 Nbd7 7. O-O e6 8.
+Nh4 Bg4 9. Qd3 O-O-O 10. h3 Ne5 11. dxe5 Rxd3 12. Bxd3 Qxe5 13. hxg4 Nxg4 14.
+Nf3 Qh5 15. Bf4 Bc5 16. Ne4 Bb6 17. a4 a5 18. b4 f6 19. bxa5 Qxa5 20. Bd2 Qd5
+21. a5 Ba7 22. a6 f5 23. Nc3 Qc5 24. Nb5 Bb6 25. a7 Kd7 26. a8=Q Rxa8 27. Rxa8
+Nxf2 28. Rxf2 Qxf2+ 29. Kh2 Ke7 30. Bg5+ Kd7 31. Ne5# 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Glig"]
+[Black "camilomunoz0107"]
+[Result "1-0"]
+[ECO "A17"]
+[WhiteElo "2445"]
+[BlackElo "2372"]
+[PlyCount "75"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. Nf3 Nf6 2. c4 e6 3. Nc3 b6 4. d3 Bb7 5. e3 Be7 6. Be2 O-O 7. O-O d6 8. b3
+Nbd7 9. Bb2 e5 10. Nd2 c6 11. d4 Qc7 12. Rc1 Rad8 13. Bf3 Rfe8 14. h3 Nf8 15.
+Nde4 Nxe4 16. Bxe4 Bc8 17. Qf3 g6 18. Bxc6 Bd7 19. Bd5 Ne6 20. Ne4 Kg7 21. c5
+dxc5 22. dxe5 Bb5 23. Nd6 Rf8 24. Rfd1 Ba6 25. Ne4 Rxd5 26. Rxd5 Bb7 27. Nf6
+Bxd5 28. Nxd5 Qb7 29. Rd1 Rd8 30. e4 b5 31. Qe3 c4 32. f4 Bc5 33. Rd4 Nxd4 34.
+Bxd4 Bxd4 35. Qxd4 Kf8 36. e6 Kg8 37. Nf6+ Kg7 38. Qxd8 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "matsuiy"]
+[Black "metalkingGT"]
+[Result "0-1"]
+[ECO "A04"]
+[WhiteElo "2377"]
+[BlackElo "2468"]
+[PlyCount "74"]
+[EventDate "2020.??.??"]
+
+1. Nf3 g6 2. g3 Bg7 3. Bg2 c5 4. O-O Nc6 5. d3 e5 6. Nbd2 Nge7 7. e4 d6 8. a4
+O-O 9. c3 f5 10. Re1 f4 11. Ng5 h6 12. Qb3+ Kh8 13. Nf7+ Rxf7 14. Qxf7 Bd7 15.
+Qb3 g5 16. Qxb7 Rb8 17. Qa6 Rb6 18. Qc4 Qc8 19. f3 Be6 20. Qxe6 Qxe6 21. Nc4
+Rb8 22. a5 h5 23. a6 Rg8 24. Kf2 Bh6 25. Rg1 g4 26. Rh1 d5 27. Nd2 c4 28. exd5
+Nxd5 29. Ne4 cxd3 30. Rd1 Ne3 31. Rxd3 Nxg2 32. Kxg2 gxf3+ 33. Kxf3 fxg3 34.
+hxg3 Rf8+ 35. Kg2 Bxc1 36. Rxc1 Qg4 37. Rc2 Qxe4+ 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Aisen_Mestnikov"]
+[Black "RigelStar"]
+[Result "0-1"]
+[ECO "D11"]
+[WhiteElo "2405"]
+[BlackElo "2390"]
+[PlyCount "126"]
+[EventDate "2020.??.??"]
+
+1. d4 c6 2. c4 d5 3. Nf3 e6 4. g3 Nf6 5. Bg2 Nbd7 6. O-O Bb4 7. Nc3 O-O 8. Qd3
+Qe7 9. a3 Bd6 10. e4 dxc4 11. Qxc4 e5 12. d5 Nb6 13. Qb3 Bg4 14. Bg5 h6 15. Be3
+Rac8 16. Bxb6 axb6 17. Qxb6 cxd5 18. exd5 Bc5 19. Qb5 e4 20. Rfe1 Rfe8 21. Nd2
+e3 22. fxe3 Bxe3+ 23. Kh1 Qe5 24. Nf1 Qg5 25. h4 Qh5 26. Nxe3 Bd7 27. Qe2 Ng4
+28. Bf3 f5 29. Nxg4 fxg4 30. Qxe8+ Rxe8 31. Bg2 Rxe1+ 32. Rxe1 Qg6 33. Be4 Qd6
+34. Kg1 Qc7 35. Kg2 Qd6 36. Bd3 Qa6 37. Ne4 Qb6 38. Bc2 Qxb2 39. Re2 Qd4 40.
+Bd3 Qe5 41. Nf6+ Qxf6 42. Rf2 Qg6 43. Bxg6 Be8 44. d6 Bxg6 45. Re2 Be8 46. Rd2
+Bd7 47. Kf2 Be6 48. Ke3 Kf8 49. Kf4 Bd7 50. Ke5 Ke8 51. Rf2 Kd8 52. Rd2 g6 53.
+Rf2 g5 54. Rf8+ Be8 55. Rf6 gxh4 56. Rxh6 Kd7 57. Rh8 hxg3 58. Rh7+ Kc6 59. Rg7
+Bd7 60. Rxg4 b6 61. Rxg3 b5 62. Rb3 Kb7 63. Rc3 Bc6 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "yaguigor"]
+[Black "Elhlwagy11"]
+[Result "1-0"]
+[ECO "B43"]
+[WhiteElo "2458"]
+[BlackElo "2302"]
+[PlyCount "95"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 c5 2. Nf3 e6 3. d4 cxd4 4. Nxd4 a6 5. Nc3 b5 6. Bd3 Qc7 7. O-O Bb7 8. Re1
+Nf6 9. Bg5 Nc6 10. Nxc6 Qxc6 11. Nd5 Nxd5 12. exd5 Qxd5 13. Be4 Qxg5 14. Bxb7
+Rb8 15. Bf3 Bc5 16. c3 O-O 17. Qxd7 Rfd8 18. Qc6 Rd2 19. Re2 Rb6 20. Qc8+ Rd8
+21. Qc7 Rbd6 22. Rf1 h5 23. h4 Qf5 24. Be4 Qf4 25. Qxc5 Qxh4 26. Bf3 Rd1 27.
+Rfe1 g6 28. Qe3 R8d3 29. Qe5 Kh7 30. Re3 R3d2 31. Rxd1 Qxf2+ 32. Kh1 Rxd1+ 33.
+Bxd1 Qf1+ 34. Kh2 Qxd1 35. Qf6 Kg8 36. Rf3 Qd6+ 37. Kh1 Qd1+ 38. Rf1 Qd7 39.
+Qd4 Qe7 40. Rd1 Qh4+ 41. Qxh4 Kg7 42. Rd7 e5 43. Qg5 a5 44. g3 a4 45. Qxe5+ Kh6
+46. Qf6 a3 47. Rd8 axb2 48. Rh8# 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "MiroMiljkovic"]
+[Black "estocastico"]
+[Result "1-0"]
+[ECO "D85"]
+[WhiteElo "2609"]
+[BlackElo "2550"]
+[PlyCount "97"]
+[EventDate "2020.??.??"]
+
+1. d4 Nf6 2. c4 g6 3. Nc3 d5 4. cxd5 Nxd5 5. Nf3 Bg7 6. e4 Nxc3 7. bxc3 c5 8.
+Be3 Nc6 9. Rc1 O-O 10. d5 Na5 11. Be2 Bg4 12. O-O Rc8 13. c4 b6 14. Qd2 e5 15.
+Bh6 Nb7 16. Bxg7 Kxg7 17. Nxe5 Bxe2 18. Qxe2 Nd6 19. Nd3 Re8 20. e5 Nf5 21. f4
+Nd4 22. Qf2 b5 23. f5 Nxf5 24. g4 Qg5 25. h3 bxc4 26. Rxc4 h5 27. Qf4 Qxf4 28.
+Rcxf4 hxg4 29. hxg4 Nh6 30. d6 c4 31. d7 cxd3 32. dxc8=Q Rxc8 33. Rd4 Re8 34.
+Rxd3 Nxg4 35. Rd7 Nxe5 36. Rxa7 Rc8 37. Kg2 Rc2+ 38. Rf2 Rc3 39. a4 Ra3 40. Rc2
+g5 41. a5 Kg6 42. a6 f5 43. Ra8 f4 44. a7 Kf5 45. Rf8+ Kg4 46. a8=Q Rg3+ 47.
+Kf1 Nd3 48. Qc8+ Kh4 49. Rh8# 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Klaksidee"]
+[Black "EPThompson"]
+[Result "0-1"]
+[ECO "A04"]
+[WhiteElo "2592"]
+[BlackElo "2543"]
+[PlyCount "97"]
+[EventDate "2020.??.??"]
+
+1. Nf3 d6 2. g3 g6 3. d4 Bg7 4. Bg2 Nf6 5. O-O O-O 6. Re1 d5 7. c3 a5 8. Nbd2
+a4 9. e4 dxe4 10. Nxe4 Nc6 11. Bg5 h6 12. Nxf6+ exf6 13. Bf4 g5 14. Bd2 Be6 15.
+Qc2 Na5 16. Rad1 Nc4 17. Bc1 Bd5 18. h3 Nd6 19. b3 axb3 20. axb3 b5 21. Nd2
+Bxg2 22. Kxg2 Qd7 23. c4 bxc4 24. bxc4 Qc6+ 25. d5 Qc5 26. Bb2 f5 27. Bxg7 Kxg7
+28. Qc3+ Kg8 29. Rc1 Ra4 30. Qc2 Rfa8 31. Qd3 Ra3 32. Rc3 Rxc3 33. Qxc3 Ra3 34.
+Qc2 Qa5 35. Rc1 Ra2 36. Qd3 Qxd2 37. Qxd2 Rxd2 38. c5 Ne4 39. d6 cxd6 40. cxd6
+Rxd6 41. f3 Rd2+ 42. Kg1 Nxg3 43. Rc2 Rxc2 44. f4 Nh5 45. fxg5 hxg5 46. h4 g4
+47. Kf1 f4 48. Ke1 g3 49. Kd1 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "EzWin78"]
+[Black "mixo23"]
+[Result "0-1"]
+[ECO "B10"]
+[WhiteElo "2491"]
+[BlackElo "2422"]
+[PlyCount "48"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 c6 2. Nf3 d5 3. Nc3 g6 4. h3 Bg7 5. d4 Nf6 6. e5 Ne4 7. Nxe4 dxe4 8. Ng5
+c5 9. Bc4 O-O 10. c3 cxd4 11. cxd4 Nc6 12. Be3 Qa5+ 13. Kf1 h6 14. Nxe4 Rd8 15.
+f4 b5 16. Bb3 Nxd4 17. Bxd4 Qb4 18. Qe1 Rxd4 19. Qxb4 Rxb4 20. Bd5 Rb8 21. Nd6
+exd6 22. Kg1 dxe5 23. Kf2 Rxf4+ 24. Ke2 b4 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "CheKarloz"]
+[Black "Vereterra"]
+[Result "1-0"]
+[ECO "C67"]
+[WhiteElo "2328"]
+[BlackElo "2301"]
+[PlyCount "79"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 e5 2. Nf3 Nc6 3. Bb5 Nf6 4. O-O Nxe4 5. d4 exd4 6. Re1 d5 7. Nxd4 Bd6 8.
+Nxc6 Bxh2+ 9. Kh1 Qh4 10. Rxe4+ dxe4 11. Qd8+ Qxd8 12. Nxd8+ Kxd8 13. Kxh2 Be6
+14. Nd2 f5 15. Nb3 c6 16. Be2 Kc7 17. Bf4+ Kb6 18. Be3+ Kc7 19. Bf4+ Kb6 20.
+Nd4 Bd7 21. Rd1 Rad8 22. b4 a6 23. Be5 Rhg8 24. a4 Ka7 25. Bc4 Rge8 26. Bxg7 c5
+27. bxc5 Bxa4 28. Ra1 Bd7 29. Bh6 Rc8 30. Be3 f4 31. Bxf4 Rxc5 32. Bb3 Rh5+ 33.
+Kg1 Rf8 34. Be3 Kb8 35. Rd1 a5 36. Ne2 a4 37. Rxd7 axb3 38. cxb3 Rb5 39. Nd4
+Rc8 40. Rxh7 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Kidefence"]
+[Black "BlueGreensun"]
+[Result "0-1"]
+[ECO "D00"]
+[WhiteElo "2690"]
+[BlackElo "2777"]
+[PlyCount "96"]
+[EventDate "2020.??.??"]
+
+1. e4 d5 2. d4 dxe4 3. Nc3 Nf6 4. f3 c5 5. d5 e6 6. fxe4 exd5 7. exd5 Bd6 8.
+Nf3 O-O 9. Be2 Re8 10. O-O Nbd7 11. Bg5 h6 12. Bh4 Qb6 13. Rb1 Ng4 14. Qd2 Ndf6
+15. h3 Ne3 16. Rfe1 c4 17. Bf2 Bc5 18. Na4 Qb4 19. Qxb4 Bxb4 20. c3 Bf8 21. b3
+b5 22. Nb2 Nfxd5 23. bxc4 Nxc3 24. Rbc1 b4 25. Bd3 Bc5 26. Kh1 Bb7 27. Bxe3
+Rxe3 28. Rxe3 Bxe3 29. Re1 Re8 30. Nd1 Nxd1 31. Rxd1 Rd8 32. Bh7+ Kxh7 33. Rxd8
+a5 34. Rb8 Be4 35. Re8 Bxf3 36. gxf3 Bd4 37. Ra8 Bc3 38. Rxa5 Kg6 39. Rb5 Kf6
+40. Kg2 Ke6 41. Kf1 Kd6 42. Ke2 g5 43. Kd3 f5 44. Rxf5 Ke6 45. Rb5 Kf6 46. Ke4
+h5 47. f4 g4 48. hxg4 hxg4 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "alireza3700"]
+[Black "alwaysplanahead"]
+[Result "0-1"]
+[ECO "C11"]
+[WhiteElo "2340"]
+[BlackElo "2337"]
+[PlyCount "126"]
+[EventDate "2020.??.??"]
+
+1. d4 Nf6 2. Nc3 e6 3. e4 d5 4. Bg5 h6 5. Bxf6 gxf6 6. exd5 exd5 7. Qf3 Be7 8.
+Qxd5 Qxd5 9. Nxd5 Kd8 10. O-O-O Be6 11. Nxe7 Kxe7 12. b3 Nd7 13. Nf3 c6 14. Bd3
+Rhg8 15. Rhe1 Rxg2 16. Rd2 Rag8 17. Bf5 Nf8 18. Nh4 Rxh2 19. Bxe6 fxe6 20. Nf5+
+Kd7 21. Ne3 Ng6 22. c4 Nf4 23. d5 cxd5 24. cxd5 e5 25. Nf5 Rg5 26. Ng3 h5 27.
+Ne4 Rgg2 28. Nxf6+ Kd6 29. Rde2 Rxf2 30. Ne4+ Kxd5 31. Rxf2 Nd3+ 32. Kd2 Nxf2
+33. Nc3+ Kd4 34. Re2 Ng4 35. Nb5+ Kc5 36. Nc3 Rxe2+ 37. Kxe2 h4 38. Kf3 h3 39.
+Ne4+ Kd5 40. Nf6+ Nxf6 41. Kg3 Ne4+ 42. Kxh3 Nc3 43. Kg4 Nxa2 44. Kf3 Nb4 45.
+Ke2 Nc2 46. Kd3 Na1 47. Kc3 Nxb3 48. Kb2 e4 49. Kxb3 e3 50. Kc2 e2 51. Kd2 Kc4
+52. Kxe2 Kc3 53. Kd1 b5 54. Kc1 a5 55. Kb1 a4 56. Ka1 b4 57. Kb1 a3 58. Ka1 b3
+59. Kb1 b2 60. Ka2 Kc2 61. Kxa3 b1=Q 62. Ka4 Qb6 63. Ka3 Qb3# 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "alphonsea"]
+[Black "Smoky1"]
+[Result "1-0"]
+[ECO "B03"]
+[WhiteElo "2315"]
+[BlackElo "2343"]
+[PlyCount "129"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 Nf6 2. e5 Nd5 3. d4 Nb6 4. c4 d6 5. exd6 cxd6 6. Nc3 g6 7. h3 Bg7 8. Nf3
+O-O 9. Be2 e5 10. Bg5 f6 11. Be3 Be6 12. d5 Bf7 13. O-O N8d7 14. b4 Rc8 15. Qb3
+Qc7 16. Nb5 Qb8 17. Rac1 a6 18. Na3 f5 19. Ng5 f4 20. Bd2 Rc7 21. Nxf7 Rxf7 22.
+Bg4 Nf8 23. c5 Nc8 24. Rfd1 f3 25. Nc4 Kh8 26. Bxc8 Qxc8 27. Nxd6 Qd8 28. Nxf7+
+Rxf7 29. d6 Qf6 30. g3 h5 31. h4 Qf5 32. Kh2 e4 33. Be3 Be5 34. Bd4 Nd7 35. Qd5
+g5 36. Bxe5+ Nxe5 37. hxg5 h4 38. Qd4 hxg3+ 39. fxg3 Rh7+ 40. Kg1 f2+ 41. Qxf2
+Qxf2+ 42. Kxf2 Ng4+ 43. Ke2 Rh2+ 44. Ke1 e3 45. Rd5 Nf2 46. Ke2 Ne4+ 47. Kxe3
+Nxg5 48. d7 Nf7 49. d8=Q+ Nxd8 50. Rxd8+ Kg7 51. Rd7+ Kf6 52. Rxb7 Kg5 53. Rb6
+Kg4 54. c6 Kh3 55. Ke4 Rh1 56. c7 Rxc1 57. Kd5 Rxc7 58. Rb7 Rg7 59. Rc7 Rxc7
+60. Kd6 Rg7 61. b5 Rxg3 62. b6 Rg4 63. b7 Rg5 64. b8=Q Rg6+ 65. Kc5 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "vassiukov"]
+[Black "Lil_D"]
+[Result "0-1"]
+[ECO "A40"]
+[WhiteElo "2339"]
+[BlackElo "2309"]
+[PlyCount "90"]
+[EventDate "2020.??.??"]
+
+1. d4 g6 2. Nf3 Bg7 3. Bf4 d6 4. e3 h6 5. h3 e6 6. Nbd2 Ne7 7. Bd3 O-O 8. c3 a6
+9. Qc2 b5 10. a4 bxa4 11. Rxa4 Bb7 12. e4 Nd7 13. O-O Nb6 14. Raa1 a5 15. c4 c5
+16. dxc5 dxc5 17. Rfd1 Nc6 18. Bf1 Nd4 19. Nxd4 cxd4 20. c5 Rc8 21. Bd6 Qxd6
+22. cxd6 Rxc2 23. Rxa5 Rxb2 24. e5 Bd5 25. f4 Rc8 26. Ra7 g5 27. g3 gxf4 28.
+gxf4 Rcc2 29. d7 Nxd7 30. Rxd7 Rxd2 31. Rxd2 Rxd2 32. h4 Bf8 33. Rc7 d3 34. Rc3
+Be4 35. Rc4 Bf5 36. Rc8 Kg7 37. h5 Be7 38. Rc7 Bh4 39. Rc4 Bf2+ 40. Kh1 Bb6 41.
+Rc6 Be3 42. Rc4 Rf2 43. Kg1 Rxf4+ 44. Kh1 Rxc4 45. Kg2 Rg4+ 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Guga1606"]
+[Black "fullchola"]
+[Result "1/2-1/2"]
+[ECO "B00"]
+[WhiteElo "2371"]
+[BlackElo "2435"]
+[PlyCount "150"]
+[EventDate "2020.??.??"]
+
+1. e4 e6 2. Nf3 Nc6 3. d4 Bb4+ 4. c3 Be7 5. d5 Nb8 6. dxe6 dxe6 7. Qxd8+ Bxd8
+8. Be2 Ne7 9. O-O O-O 10. Be3 c5 11. Nbd2 b6 12. a4 Bb7 13. a5 Nbc6 14. axb6
+Bxb6 15. Nc4 Rfc8 16. Rfd1 Kf8 17. Nd6 Rc7 18. Nxb7 Rxb7 19. Nd2 Rc7 20. Nc4
+Rac8 21. f3 f6 22. Kf2 Ne5 23. Nd6 Rd8 24. Nc4 Rxd1 25. Rxd1 Kf7 26. Nxe5+ fxe5
+27. Ra1 Ng6 28. g3 Kf6 29. h4 Ne7 30. Rd1 Kf7 31. Rd8 Nc6 32. Ra8 c4 33. Rh8
+Bxe3+ 34. Kxe3 h6 35. Bxc4 Na5 36. Bd3 Rb7 37. b4 Nc6 38. Rc8 Ne7 39. Ra8 Rc7
+40. c4 g5 41. hxg5 hxg5 42. c5 Nc6 43. b5 Nd4 44. b6 axb6 45. cxb6 Rc3 46. b7
+Nc6 47. b8=Q Nxb8 48. Rxb8 Kf6 49. Rf8+ Ke7 50. Rg8 Kf6 51. Rb8 Ra3 52. Rb5 g4
+53. fxg4 Ra7 54. g5+ Kxg5 55. Rxe5+ Kf6 56. Rh5 Rg7 57. g4 Rxg4 58. Kf3 Rg7 59.
+Rh3 Ke5 60. Be2 Rf7+ 61. Ke3 Ra7 62. Rh5+ Kf6 63. Bd3 Ra3 64. e5+ Ke7 65. Rh4
+Kf7 66. Rd4 Ke7 67. Rd6 Ra5 68. Rd4 Rxe5+ 69. Re4 Rxe4+ 70. Bxe4 Kd6 71. Bd3 e5
+72. Be4 Ke6 73. Bd3 Kd6 74. Be4 Ke6 75. Bd3 Kd6 1/2-1/2
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "CarlosMontenegro"]
+[Black "panicOttack"]
+[Result "1-0"]
+[ECO "A00"]
+[WhiteElo "2413"]
+[BlackElo "2307"]
+[PlyCount "87"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. g3 g6 2. Bg2 Bg7 3. d3 c6 4. c4 d5 5. Nf3 e6 6. O-O Ne7 7. Nc3 O-O 8. e4 d4
+9. Ne2 c5 10. Nd2 Nbc6 11. f4 f5 12. e5 Rb8 13. a3 a6 14. Rb1 b5 15. b3 Qc7 16.
+Qc2 b4 17. a4 Bb7 18. Nf3 Nd8 19. Kh1 Nf7 20. Neg1 h6 21. Qe2 Bc6 22. Bd2 Qb7
+23. Rf2 Kh7 24. h4 Rg8 25. Nh3 Bf8 26. Kh2 Rg7 27. Rg1 Kg8 28. Qd1 Nc8 29. Qc1
+Be7 30. Ne1 Qc7 31. Bxc6 Qxc6 32. Nf3 Qc7 33. g4 fxg4 34. Rxg4 Kh7 35. Rfg2 Bd8
+36. Qg1 Ne7 37. h5 g5 38. fxg5 Nxe5 39. g6+ N7xg6 40. hxg6+ Rxg6 41. Nxe5 Rxg4
+42. Rxg4 Qxe5+ 43. Bf4 Qe2+ 44. Rg2 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Phutressniak"]
+[Black "PimponNicois"]
+[Result "1/2-1/2"]
+[ECO "D10"]
+[WhiteElo "2419"]
+[BlackElo "2341"]
+[PlyCount "130"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 d5 2. c4 c6 3. Nc3 Nf6 4. cxd5 cxd5 5. Bf4 Nc6 6. e3 Bf5 7. Qb3 Na5 8.
+Qa4+ Bd7 9. Bb5 Nc6 10. Nf3 a6 11. Bxc6 Bxc6 12. Qd1 e6 13. O-O Bd6 14. Ne5 Rc8
+15. Rc1 O-O 16. Bg5 h6 17. Bh4 Be7 18. f4 Nd7 19. Bxe7 Qxe7 20. Qf3 Nf6 21. f5
+exf5 22. Qxf5 Qe6 23. Qf3 Nd7 24. Nd3 Rfe8 25. Rce1 b6 26. Nf4 Qd6 27. Nfxd5
+Rf8 28. e4 b5 29. e5 Qe6 30. a3 a5 31. b4 axb4 32. axb4 Nb6 33. Nf4 Bxf3 34.
+Nxe6 fxe6 35. Nxb5 Bd5 36. Nd6 Rc2 37. Rxf8+ Kxf8 38. Rf1+ Kg8 39. Rf2 Rxf2 40.
+Kxf2 Nc4 41. Nb5 Kf7 42. Nc3 Ke7 43. g3 Kd7 44. Ke2 Kc6 45. Kd3 Na3 46. Ne2
+Bc4+ 47. Ke3 Bxe2 48. Kxe2 Kd5 49. Ke3 Nb5 50. Kf4 Nxd4 51. g4 Nc6 52. b5 Nxe5
+53. h4 Nd7 54. h5 e5+ 55. Kf5 e4 56. Kf4 Kd4 57. g5 e3 58. gxh6 gxh6 59. Kf3
+Kd3 60. b6 e2 61. b7 Nb8 62. Kf4 Kd2 63. Kf5 e1=Q 64. Kg6 Qg3+ 65. Kxh6 Qg8
+1/2-1/2
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "aidenzhouu"]
+[Black "Rookdom"]
+[Result "0-1"]
+[ECO "E11"]
+[WhiteElo "2439"]
+[BlackElo "2426"]
+[PlyCount "40"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 Nf6 2. c4 e6 3. Nf3 Bb4+ 4. Nbd2 a5 5. a3 Bxd2+ 6. Qxd2 a4 7. e3 d6 8.
+Bd3 Nc6 9. O-O Bd7 10. Qc2 h6 11. b4 axb3 12. Qxb3 b6 13. Bb2 O-O 14. d5 Na5
+15. Qc2 e5 16. e4 Nb7 17. Nd2 Nc5 18. f3 Nh5 19. g3 Qg5 20. Bc1 Qe3+ 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "oldpatzer7"]
+[Black "AlemaniaRik"]
+[Result "0-1"]
+[ECO "C07"]
+[WhiteElo "2427"]
+[BlackElo "2464"]
+[PlyCount "50"]
+[EventDate "2020.??.??"]
+
+1. Nf3 e6 2. d4 d5 3. Nbd2 c5 4. e4 cxd4 5. exd5 Qxd5 6. Bc4 Qd6 7. O-O Nc6 8.
+Nb3 Nf6 9. Nbxd4 Be7 10. Nb5 Qb8 11. g3 a6 12. Bf4 e5 13. Nxe5 Nxe5 14. Re1
+axb5 15. Bxb5+ Bd7 16. Bxe5 Bxb5 17. Bxb8 Rxb8 18. Qd6 O-O 19. Rxe7 Bc6 20. Qf4
+Nd5 21. Qh4 Nxe7 22. Qxe7 Rfe8 23. Qc5 Re2 24. a4 Rbe8 25. a5 Re1+ 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "ajedrez2021"]
+[Black "sutcunuri"]
+[Result "1-0"]
+[ECO "A04"]
+[WhiteElo "2601"]
+[BlackElo "2513"]
+[PlyCount "46"]
+[EventDate "2020.??.??"]
+
+1. Nf3 c5 2. c4 Nc6 3. g3 Nf6 4. Bg2 d5 5. O-O dxc4 6. d4 e6 7. Qa4 cxd4 8.
+Qxc4 Bd7 9. Rd1 Rc8 10. Nxd4 Nxd4 11. Qxd4 Qb6 12. Qxb6 axb6 13. Nc3 Bc6 14.
+Bg5 Be7 15. Rac1 h6 16. Be3 b5 17. Nxb5 O-O 18. Bxc6 bxc6 19. Na7 Ra8 20. Nxc6
+Rfe8 21. a3 Bf8 22. Bd4 Nd5 23. e4 Rec8 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "NearSMA"]
+[Black "AbdAlQadir"]
+[Result "1-0"]
+[ECO "A00"]
+[WhiteElo "2423"]
+[BlackElo "2327"]
+[PlyCount "127"]
+[EventDate "2020.??.??"]
+
+1. g3 d5 2. Bg2 c6 3. e3 Bf5 4. Ne2 e6 5. d3 h5 6. c3 h4 7. e4 h3 8. Bf3 dxe4
+9. dxe4 Qxd1+ 10. Kxd1 Bg6 11. Kc2 Nf6 12. Kb3 Nxe4 13. Bxe4 Bxe4 14. Re1 Nd7
+15. Nd4 Bd5+ 16. c4 Nc5+ 17. Kc3 Be4 18. b3 Be7 19. Be3 Bf6 20. Nd2 Bg6 21. Kb4
+Nd3+ 22. Ka3 Nxe1 23. Rxe1 O-O-O 24. N2f3 Bh5 25. c5 Bxf3 26. Nxf3 Rd5 27. Rc1
+Rhd8 28. Rc3 Rd3 29. Rc2 Rxe3 30. fxe3 Rd3 31. Ng1 Rxe3 32. Nxh3 Re5 33. Nf4
+Rf5 34. Nd3 Be7 35. b4 Rd5 36. Rc3 Rd4 37. Rb3 a5 38. b5 Rd5 39. bxc6 bxc6 40.
+Ka4 Bxc5 41. Nxc5 Rxc5 42. Rf3 Kd7 43. Rxf7+ Kd6 44. Rxg7 Rc2 45. a3 Rxh2 46.
+Kxa5 Rg2 47. Kb4 c5+ 48. Kc4 Rc2+ 49. Kb3 Re2 50. Ka4 Re3 51. g4 Ke5 52. g5 c4
+53. Kb4 c3 54. Kb3 Rf3 55. a4 Rg3 56. a5 Kd4 57. a6 Rg2 58. Rd7+ Kc5 59. a7
+Rb2+ 60. Kxc3 Ra2 61. g6 Ra3+ 62. Kd2 Kc6 63. Rf7 Kd6 64. g7 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "petr_matyukov"]
+[Black "corwinifred"]
+[Result "0-1"]
+[ECO "D07"]
+[WhiteElo "2489"]
+[BlackElo "2315"]
+[PlyCount "110"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 Nc6 2. Nf3 d5 3. c4 Bg4 4. cxd5 Bxf3 5. gxf3 Qxd5 6. e3 e5 7. Nc3 Bb4 8.
+Bd2 Bxc3 9. bxc3 O-O-O 10. Be2 Nf6 11. Qb3 exd4 12. Qxd5 Nxd5 13. cxd4 f5 14.
+Rb1 Rhe8 15. Bb5 Re6 16. O-O a6 17. Bc4 Rg6+ 18. Kh1 Nb6 19. Bd3 Rf6 20. Rg1 g6
+21. f4 Rfd6 22. Be2 Nd5 23. Be1 Nf6 24. h3 Ne4 25. Bf3 Ne7 26. Bb4 R6d7 27.
+Bxe7 Rxe7 28. Bxe4 Rxe4 29. Kg2 Re6 30. Kf3 Kb8 31. h4 Rd5 32. h5 Ra5 33. hxg6
+hxg6 34. Rb2 c5 35. dxc5 Rxc5 36. Rgb1 b5 37. Rd2 Kc7 38. Rbd1 Kc6 39. Rd8 b4
+40. Ra8 Kb5 41. Rd7 a5 42. Rda7 Ka4 43. Kg3 Rd6 44. Kh4 Rd2 45. Kg5 Rxf2 46.
+Kxg6 Re2 47. Re7 Rxa2 48. Re5 Rxe5 49. fxe5 Re2 50. e6 Rxe3 51. Kf7 b3 52. e7
+b2 53. Rb8 Ka3 54. Rb6 Rxe7+ 55. Kxe7 f4 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "C9C9C9C9C9"]
+[Black "drop_stone"]
+[Result "1-0"]
+[ECO "A08"]
+[WhiteElo "2973"]
+[BlackElo "2937"]
+[PlyCount "121"]
+[EventDate "2020.??.??"]
+
+1. Nf3 d5 2. g3 Nf6 3. Bg2 e6 4. O-O Be7 5. d3 O-O 6. Nbd2 Nc6 7. e4 e5 8. Re1
+dxe4 9. dxe4 Be6 10. c3 a5 11. Qe2 a4 12. h3 Nd7 13. Nc4 b5 14. Ne3 Qb8 15. Nd5
+Bd6 16. Be3 f6 17. Rad1 a3 18. b3 Qb7 19. Rd2 b4 20. c4 Bc5 21. Red1 Bxe3 22.
+Qxe3 Rfd8 23. Nh4 Nd4 24. f4 c6 25. fxe5 fxe5 26. Ne7+ Kh8 27. Qg5 Nf6 28. Qxe5
+Ne2+ 29. Kh2 Rxd2 30. Rxd2 Qxe7 31. Rxe2 Re8 32. Rd2 g6 33. Qd6 Kg7 34. Qxc6
+Rc8 35. Qd6 Qxd6 36. Rxd6 Kf7 37. Nf3 Nxe4 38. Rd4 Nc3 39. Rd2 Ke7 40. Ng5 Bf5
+41. Nxh7 Bb1 42. Ng5 Bxa2 43. Rf2 Bxb3 44. Rf7+ Kd6 45. Rf6+ Kc5 46. Ne6+ Kxc4
+47. Rf4+ Kd3 48. Rd4+ Kc2 49. Nf4 a2 50. Nd3 a1=Q 51. Nxb4+ Kb2 52. Rd2+ Ka3
+53. Nd3 Qe1 54. Nxe1 Nb1 55. Rd3 Nd2 56. Rxd2 Bc4 57. Rc2 Bd3 58. Rc3+ Kb4 59.
+Nxd3+ Kxc3 60. Ne5 Kd4 61. Ng4 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Bulingot"]
+[Black "terminator-t800"]
+[Result "1-0"]
+[ECO "A13"]
+[WhiteElo "2356"]
+[BlackElo "2313"]
+[PlyCount "51"]
+[EventDate "2020.??.??"]
+
+1. Nf3 d5 2. c4 e6 3. cxd5 exd5 4. d3 Nf6 5. Nbd2 Bd6 6. g3 O-O 7. Bg2 c5 8.
+O-O Nc6 9. e4 dxe4 10. Nxe4 Nxe4 11. dxe4 Re8 12. Re1 Bg4 13. h3 Bh5 14. Be3
+Rxe4 15. Qb3 Rb4 16. Qc2 Bg6 17. Qc3 Qb6 18. Rad1 Bc7 19. b3 Re8 20. Bxc5 Rxe1+
+21. Rxe1 Qxc5 22. Qxc5 h5 23. Re8+ Kh7 24. Ng5+ Kh6 25. h4 Bb6 26. Rh8+ 1-0
+
+[Event "Rated Blitz tournament uAQ2oGqy"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "HelgaDj"]
+[Black "Roma_Kondra"]
+[Result "0-1"]
+[ECO "B08"]
+[WhiteElo "2365"]
+[BlackElo "2304"]
+[PlyCount "104"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 d6 2. d4 Nf6 3. Nc3 g6 4. Nf3 Bg7 5. Bd3 O-O 6. O-O Bg4 7. h3 Bxf3 8.
+Qxf3 Nc6 9. Be3 e5 10. Ne2 exd4 11. Nxd4 Ne5 12. Qe2 Re8 13. f3 Nh5 14. Qf2 c5
+15. Nb5 Nxd3 16. cxd3 f5 17. Nc3 f4 18. Ne2 fxe3 19. Qxe3 Qf6 20. Rab1 g5 21.
+Kh1 Qe5 22. Rfd1 Ng3+ 23. Nxg3 Qxg3 24. Qe1 Qxe1+ 25. Rxe1 Be5 26. Re2 a5 27.
+Kg1 a4 28. Kf2 b5 29. g3 b4 30. Ke3 Rf8 31. Rh1 Bxg3 32. Rg2 Bf4+ 33. Ke2 Kh8
+34. h4 Rg8 35. Rg4 Raf8 36. Rh3 gxh4 37. Rgxh4 Rf7 38. Kf2 Be5 39. Ke3 Bxb2 40.
+f4 Bd4+ 41. Kf3 b3 42. axb3 axb3 43. f5 b2 44. Rh1 Rg1 45. Rxg1 Bxg1 46. Rh1
+b1=Q 47. Kf4 Be3+ 48. Kxe3 Qxh1 49. Kf4 Qh2+ 50. Kg5 h6+ 51. Kg6 Rg7+ 52. Kf6
+Qe5# 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "metalkingGT"]
+[Black "elpepinillo14"]
+[Result "1-0"]
+[ECO "A04"]
+[WhiteElo "2473"]
+[BlackElo "2547"]
+[PlyCount "55"]
+[EventDate "2020.??.??"]
+
+1. Nf3 e6 2. g3 d5 3. Bg2 Nf6 4. O-O Be7 5. d3 O-O 6. Nbd2 b6 7. e4 Bb7 8. e5
+Nfd7 9. Re1 c5 10. Nf1 Nc6 11. h4 Qc7 12. Bf4 Rfc8 13. N1h2 Qd8 14. Ng4 Bf8 15.
+Qd2 Ne7 16. Bg5 d4 17. h5 h6 18. Bxh6 gxh6 19. Nxh6+ Bxh6 20. Qxh6 Nf5 21. Qf4
+Bxf3 22. Bxf3 Rab8 23. g4 Qh4 24. Kg2 Ng7 25. Rh1 Nxh5 26. Qh6 Nf4+ 27. Qxf4
+Qe7 28. Qh6 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "matsuiy"]
+[Black "WildBreath"]
+[Result "0-1"]
+[ECO "A08"]
+[WhiteElo "2373"]
+[BlackElo "2391"]
+[PlyCount "94"]
+[EventDate "2020.??.??"]
+
+1. Nf3 d5 2. g3 e6 3. Bg2 Nf6 4. O-O Be7 5. d3 O-O 6. Nbd2 c5 7. e4 Nc6 8. Re1
+Qc7 9. exd5 exd5 10. d4 c4 11. b3 b5 12. a4 cxb3 13. axb5 Nb4 14. cxb3 Nc2 15.
+Bb2 Nxe1 16. Qxe1 Bb4 17. Qd1 Bd7 18. Rc1 Qb6 19. Ne5 Bxb5 20. Ndf3 Ne4 21. h4
+Rac8 22. Ra1 a5 23. Nd3 Bxd3 24. Qxd3 h6 25. Ne5 Nf6 26. g4 Bd6 27. g5 hxg5 28.
+hxg5 Bxe5 29. dxe5 Ne4 30. Qxd5 Qxf2+ 31. Kh2 Qh4+ 32. Kg1 Qf2+ 33. Kh2 Qf4+
+34. Kg1 Nxg5 35. Qd3 Ne6 36. Rf1 Qg4 37. Qf3 Qxf3 38. Rxf3 Rcd8 39. Kh2 Rd1 40.
+Ba3 Rd2 41. Bxf8 Kxf8 42. Kg3 Ke7 43. Re3 Rd4 44. Rd3 Rxd3+ 45. Kf2 Rxb3 46.
+Bf3 Rb5 47. Be2 Rxe5 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "JiangoFett"]
+[Black "HerPerelman"]
+[Result "0-1"]
+[ECO "A58"]
+[WhiteElo "2388"]
+[BlackElo "2427"]
+[PlyCount "132"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 Nf6 2. c4 c5 3. d5 b5 4. cxb5 a6 5. bxa6 d6 6. Nc3 g6 7. e4 Qa5 8. Bd2
+Bxa6 9. Nf3 Bg7 10. a4 O-O 11. Nb5 Qb6 12. Bd3 Nbd7 13. O-O Ne8 14. Qc2 Nc7 15.
+Nxc7 Bxd3 16. Qxd3 Qxc7 17. Bc3 Rfb8 18. Bxg7 Kxg7 19. Rfc1 Qb7 20. Rc2 Qb3 21.
+Qxb3 Rxb3 22. Nd2 Rb4 23. b3 Nf6 24. f3 Nd7 25. Kf2 f5 26. Rc4 Rb7 27. a5 fxe4
+28. fxe4 Ne5 29. Rca4 Rf8+ 30. Ke2 Ra7 31. Nf3 Ng4 32. a6 Rb8 33. R1a3 Rb6 34.
+Nd2 Ne5 35. Nc4 Nxc4 36. bxc4 Kf6 37. Kd3 Ke5 38. Kc3 Rb1 39. Ra2 Kxe4 40. Re2+
+Kf5 41. Rb2 Rc1+ 42. Kd2 Rg1 43. Rb7 Rxg2+ 44. Kc3 Ra8 45. a7 Rxh2 46. Rb8 Rh3+
+47. Kb2 Rh2+ 48. Ka3 Rxa7 49. Rxa7 Ke5 50. Rxe7+ Kd4 51. Rd8 Kxc4 52. Rxd6 Rh3+
+53. Kb2 Rh1 54. Kc2 Rh2+ 55. Kd1 Kc3 56. Re1 c4 57. Rc6 Ra2 58. d6 Ra1+ 59. Ke2
+Ra6 60. Kf1 Rxc6 61. d7 Rd6 62. Rc1+ Kb2 63. Rd1 Rxd1+ 64. Ke2 Rxd7 65. Kf3 c3
+66. Kg4 c2 0-1
+
+[Event "Rated Bullet tournament H3UwNQec"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "digitalengineer"]
+[Black "Bob_Fletcher"]
+[Result "0-1"]
+[ECO "A40"]
+[WhiteElo "2348"]
+[BlackElo "2578"]
+[PlyCount "46"]
+[EventDate "2020.??.??"]
+
+1. d4 g6 2. Nf3 Bg7 3. c4 b6 4. g3 Bb7 5. Bg2 d6 6. O-O Nd7 7. Nc3 e6 8. e4 Ne7
+9. d5 e5 10. Nd2 O-O 11. f4 f5 12. Qc2 exf4 13. gxf4 fxe4 14. Ndxe4 Nf5 15. Ng5
+Nc5 16. Ne6 Nxe6 17. dxe6 Qh4 18. Bxb7 Bd4+ 19. Kg2 Qg4+ 20. Kh1 Qh3 21. Qg2
+Ng3+ 22. Qxg3 Qxf1+ 23. Qg1 Qxg1# 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Evgen_88"]
+[Black "NEKI_NOVI_KLINAC"]
+[Result "1-0"]
+[ECO "D35"]
+[WhiteElo "2528"]
+[BlackElo "2452"]
+[PlyCount "67"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 e6 2. c4 d5 3. Nc3 Nf6 4. cxd5 exd5 5. Bg5 Nc6 6. e3 Be6 7. Bd3 Bd6 8.
+Nge2 h6 9. Bh4 Qd7 10. a3 g5 11. Bg3 a6 12. Na4 Ne4 13. Bxe4 dxe4 14. Bxd6 cxd6
+15. Nb6 Qd8 16. Nxa8 Qxa8 17. d5 Ne5 18. dxe6 Nd3+ 19. Kf1 Qc8 20. Rc1 Nxc1 21.
+Qxc1 Qxc1+ 22. Nxc1 fxe6 23. Ke2 Kd7 24. Nb3 Rc8 25. Rc1 Rxc1 26. Nxc1 Kc6 27.
+Kd2 b5 28. Kc3 d5 29. b4 e5 30. Nb3 Kd6 31. Nc5 g4 32. Nxa6 h5 33. g3 Kc6 34.
+Nc5 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "sutcunuri"]
+[Black "ajedrez2021"]
+[Result "1-0"]
+[ECO "A40"]
+[WhiteElo "2509"]
+[BlackElo "2605"]
+[PlyCount "115"]
+[EventDate "2020.??.??"]
+
+1. d4 g6 2. c4 Bg7 3. Nc3 c5 4. dxc5 Nf6 5. e4 O-O 6. Be3 Qa5 7. Qa4 Qxa4 8.
+Nxa4 Nxe4 9. O-O-O Na6 10. Bd3 Nf6 11. Nf3 d6 12. cxd6 exd6 13. h3 Be6 14. b3
+Rfc8 15. Kb1 d5 16. Nd4 Bd7 17. Nc3 Nb4 18. Be2 dxc4 19. Bxc4 a6 20. Nce2 b5
+21. Bd3 Nfd5 22. Be4 f5 23. Bf3 Be8 24. a3 Nxe3 25. fxe3 Nc6 26. Nxc6 Bxc6 27.
+Bxc6 Rxc6 28. Nd4 Rd6 29. Rd2 Rad8 30. Rhd1 Kf7 31. Kc2 Bxd4 32. Rxd4 Rc6+ 33.
+Kb2 Re8 34. Rd7+ Re7 35. R7d3 Rce6 36. Rc1 Kf6 37. Rcc3 Kg5 38. a4 Re4 39. axb5
+axb5 40. b4 Kh4 41. Rb3 Kg3 42. Kc3 Kxg2 43. Rd4 Kg3 44. Rxe4 Rxe4 45. Kd3 g5
+46. Rb1 h5 47. Rg1+ Kh4 48. Rh1 Re7 49. Rg1 Rd7+ 50. Ke2 Rc7 51. Kf3 Rc2 52.
+Rxg5 Rc3 53. Rxf5 Kxh3 54. Rf4 Kh2 55. Rf5 Kg1 56. Rxb5 Rxe3+ 57. Kxe3 h4 58.
+Kf3 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "dimochka_tsoi"]
+[Black "irakliberadze"]
+[Result "1-0"]
+[ECO "A03"]
+[WhiteElo "2650"]
+[BlackElo "2648"]
+[PlyCount "81"]
+[EventDate "2020.??.??"]
+
+1. f4 d5 2. Nf3 Nc6 3. e3 Bg4 4. d4 Nf6 5. Bd3 e6 6. O-O Be7 7. Nbd2 O-O 8. c3
+Nb8 9. h3 Bxf3 10. Qxf3 c5 11. Kh2 Nc6 12. dxc5 Bxc5 13. e4 dxe4 14. Nxe4 Nxe4
+15. Bxe4 g6 16. Bxc6 bxc6 17. Qxc6 Rc8 18. Qf3 Qe7 19. Be3 Rfd8 20. Rae1 Rd3
+21. Qe4 Rxe3 22. Rxe3 Bxe3 23. Qxe3 Qb7 24. Rf2 Rd8 25. Rd2 Rxd2 26. Qxd2 Qe4
+27. b4 h5 28. a4 h4 29. a5 Qc4 30. Qe3 a6 31. Qd4 Qf1 32. Qd8+ Kg7 33. Qxh4 Qc4
+34. Qg3 Qe4 35. Qf3 Qc4 36. Qe3 Kg8 37. Qd4 Qf1 38. c4 Qe2 39. b5 axb5 40. a6
+bxc4 41. a7 1-0
+
+[Event "Rated Blitz tournament te4AhseI"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "joseag1303"]
+[Black "mux77"]
+[Result "0-1"]
+[ECO "B12"]
+[WhiteElo "2328"]
+[BlackElo "2445"]
+[PlyCount "76"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 c6 2. d4 d5 3. e5 Bf5 4. Nd2 e6 5. Nb3 Nd7 6. Nf3 Ne7 7. Be2 Bg6 8. O-O
+Nf5 9. c3 Be7 10. a4 O-O 11. a5 a6 12. g4 Nh4 13. Nxh4 Bxh4 14. f4 Be4 15. Nd2
+Be7 16. Nxe4 dxe4 17. f5 Bg5 18. Qc2 e3 19. Qe4 c5 20. Bxe3 cxd4 21. cxd4 Rc8
+22. fxe6 Bxe3+ 23. Qxe3 fxe6 24. Rxf8+ Nxf8 25. Bf3 Rc2 26. g5 Rxb2 27. Rf1 Rb4
+28. d5 exd5 29. e6 Qe7 30. Bh5 g6 31. Rf7 Rb1+ 32. Kg2 Rb2+ 33. Kg1 Qd6 34. Rf4
+Nxe6 35. Rh4 gxh5 36. g6 hxg6 37. Qh6 Qc5+ 38. Kf1 Qb5+ 0-1
+
+[Event "Rated Blitz tournament te4AhseI"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Alberto_Santos"]
+[Black "LeninGuerra"]
+[Result "0-1"]
+[ECO "D37"]
+[WhiteElo "2319"]
+[BlackElo "2443"]
+[PlyCount "142"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 Nf6 2. Nf3 e6 3. c4 d5 4. Nc3 Be7 5. Bf4 c6 6. e3 O-O 7. c5 b6 8. b4 a5
+9. a3 axb4 10. axb4 Rxa1 11. Qxa1 bxc5 12. bxc5 Nbd7 13. Bd3 Bb7 14. h3 Qa8 15.
+O-O Qxa1 16. Rxa1 Ra8 17. Rb1 Ba6 18. Ra1 Bb7 19. Rxa8+ Bxa8 20. Ne5 Nxe5 21.
+Bxe5 Nd7 22. Bf4 e5 23. Bg3 g6 24. Kf1 f5 25. Ba6 f4 26. Bh2 fxe3 27. fxe3 exd4
+28. exd4 Bf6 29. Ne2 Kf7 30. Bd6 Nf8 31. Bxf8 Kxf8 32. Kf2 Ke7 33. Ke3 Kd7 34.
+Kd3 Kc7 35. Nf4 Kb8 36. Ne6 Ka7 37. Bc8 Kb8 38. Bd7 Bb7 39. Nf8 Ba6+ 40. Ke3
+Kc7 41. Bg4 Be7 42. Nxh7 Bf1 43. g3 g5 44. Bf5 Kd8 45. Kf3 Ke8 46. Kf2 Bb5 47.
+Bg6+ Kd7 48. Bf5+ Ke8 49. Bg6+ Kd8 50. Kf3 Kc7 51. Bf5 Kb7 52. Kf2 Ka6 53. Bg4
+Ka5 54. Ke3 Kb4 55. Be2 Ba4 56. Bd3 Bd1 57. Be2 Bc2 58. Kf3 Kc3 59. Nxg5 Bxg5
+60. h4 Bh6 61. g4 Kxd4 62. g5 Bf8 63. h5 Ke5 64. Ke3 Bxc5+ 65. Kd2 Be4 66. g6
+Kf6 67. Bd3 Bxd3 68. Kxd3 Bd6 69. Kd4 Bf8 70. Kd3 Kg5 71. Kd4 Kxh5 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "EPThompson"]
+[Black "Klaksidee"]
+[Result "1-0"]
+[ECO "D00"]
+[WhiteElo "2550"]
+[BlackElo "2586"]
+[PlyCount "167"]
+[EventDate "2020.??.??"]
+
+1. d4 d5 2. Bf4 c5 3. e3 Nc6 4. c3 Nf6 5. Nd2 Qb6 6. Qb3 c4 7. Qc2 g6 8. e4 e6
+9. e5 Nh5 10. Be3 h6 11. Be2 Ng7 12. Ngf3 Qc7 13. O-O Rb8 14. a4 a6 15. b3 b5
+16. axb5 axb5 17. b4 Nf5 18. g4 Nxe3 19. fxe3 Be7 20. h3 O-O 21. Kg2 Kg7 22.
+Rf2 f6 23. exf6+ Rxf6 24. e4 Bd7 25. e5 Rf7 26. Raf1 Rbf8 27. Qb1 Be8 28. Bd1
+Qd7 29. Bc2 Rf4 30. Kg3 Qd8 31. Re1 Bh4+ 32. Nxh4 Rxf2 33. Ndf3 R2xf3+ 34. Nxf3
+Qe7 35. Rf1 Qc7 36. Qc1 g5 37. Qe3 Bf7 38. h4 gxh4+ 39. Nxh4 Qe7 40. Nf3 Bg6
+41. Bxg6 Kxg6 42. Rh1 Qg7 43. Nh4+ Kh7 44. Nf3 Rg8 45. Qf4 Ne7 46. g5 Nf5+ 47.
+Kg4 Qg6 48. Nh4 Nxh4 49. Rxh4 Qxg5+ 50. Qxg5 Rxg5+ 51. Kf4 Rf5+ 52. Ke3 Kg6 53.
+Rg4+ Rg5 54. Rf4 Rf5 55. Rg4+ Rg5 56. Rf4 Rf5 57. Rh4 h5 58. Rh1 Kg5 59. Rg1+
+Kh6 60. Rg8 Rg5 61. Rh8+ Kg7 62. Re8 Kg6 63. Rxe6+ Kf5 64. Rf6+ Kg4 65. e6 h4
+66. Rf4+ Kh5 67. Rxh4+ Kxh4 68. e7 Rg7 69. Kf4 Rxe7 70. Kf5 Rd7 71. Kf6 Rd8 72.
+Ke5 Rc8 73. Ke6 Rc7 74. Kd6 Rb7 75. Kxd5 Rb8 76. Kc5 Ra8 77. d5 Ra7 78. Kd4 Ra8
+79. Kc5 Rc8+ 80. Kd4 Rd8 81. d6 Re8 82. Kc5 Re7 83. Kxb5 Rd7 84. Kxc4 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Betovsky"]
+[Black "hungzhao"]
+[Result "0-1"]
+[ECO "C01"]
+[WhiteElo "2618"]
+[BlackElo "2632"]
+[PlyCount "90"]
+[EventDate "2020.??.??"]
+
+1. d4 e6 2. e4 d5 3. exd5 exd5 4. Bd3 Nc6 5. c3 Qf6 6. Qf3 Qxf3 7. Nxf3 Bd6 8.
+Nbd2 Bg4 9. O-O O-O-O 10. h3 Bh5 11. Re1 Bg6 12. Bxg6 hxg6 13. Nf1 Nge7 14. Bg5
+f6 15. Bd2 g5 16. Ne3 Bf4 17. Rad1 Bxe3 18. Bxe3 Nf5 19. Bd2 Kd7 20. Re2 Rde8
+21. Rde1 Rxe2 22. Rxe2 b6 23. g4 Nd6 24. Kg2 Ne4 25. Be1 a5 26. Ng1 a4 27. f3
+Nd6 28. b3 axb3 29. axb3 Ra8 30. Rb2 Ra1 31. Bd2 Ne7 32. Ne2 Ng6 33. f4 Ne4 34.
+Be3 Nh4+ 35. Kh2 Re1 36. fxg5 fxg5 37. c4 c6 38. cxd5 cxd5 39. b4 b5 40. Rc2
+Rb1 41. Nc3 Nf3+ 42. Kg2 Ne1+ 43. Kh2 Nxc2 44. Nxb1 Nxe3 45. Nd2 Nxd2 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "TorresBlancas64"]
+[Black "Paanoos"]
+[Result "0-1"]
+[ECO "B02"]
+[WhiteElo "2303"]
+[BlackElo "2404"]
+[PlyCount "52"]
+[EventDate "2020.??.??"]
+
+1. e4 Nf6 2. Nc3 d5 3. e5 Nfd7 4. d4 c5 5. Nf3 cxd4 6. Nb5 Nc6 7. e6 fxe6 8.
+Nbxd4 Nc5 9. Nxc6 bxc6 10. Bd3 Ba6 11. Bxa6 Qa5+ 12. c3 Qxa6 13. Be3 Nd3+ 14.
+Kd2 e5 15. Kc2 e4 16. Nd4 e5 17. Qh5+ g6 18. Qh3 exd4 19. Qe6+ Be7 20. Bg5 Qb7
+21. Bxe7 Qxb2+ 22. Kd1 Qxa1+ 23. Kd2 Qxc3+ 24. Kd1 Qc1+ 25. Ke2 Qc2+ 26. Kf1
+Qxf2# 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "BlueGreensun"]
+[Black "Kidefence"]
+[Result "0-1"]
+[ECO "B04"]
+[WhiteElo "2781"]
+[BlackElo "2686"]
+[PlyCount "156"]
+[EventDate "2020.??.??"]
+
+1. e4 Nf6 2. e5 Nd5 3. d4 d6 4. Nf3 g6 5. Bc4 c6 6. Bb3 Bg7 7. O-O dxe5 8. Nxe5
+O-O 9. Re1 Nd7 10. c4 Nxe5 11. cxd5 Ng4 12. h3 Nf6 13. dxc6 bxc6 14. Nc3 Nd5
+15. Qf3 e6 16. Ne4 Ba6 17. Bg5 Qb6 18. Rac1 Bxd4 19. Red1 Bxb2 20. Rb1 Bg7 21.
+Bxd5 cxd5 22. Rxb6 dxe4 23. Qxe4 axb6 24. Qf4 Bb7 25. Rd7 Bd5 26. Be7 Rfc8 27.
+Bf6 Bxf6 28. Qxf6 Rf8 29. h4 h5 30. f3 Rxa2 31. Rd8 Rxd8 32. Qxd8+ Kg7 33. Qxb6
+Ra4 34. Qb2+ Kg8 35. Qf2 Rc4 36. Kh2 Ra4 37. Qg3 Ra2 38. Qb8+ Kg7 39. Qe5+ Kg8
+40. Qf6 Rf2 41. Kg3 Ra2 42. Qe5 Ra4 43. Qb2 Rc4 44. Qb8+ Kg7 45. Qe5+ Kg8 46.
+Qf6 Kf8 47. Kf2 Kg8 48. Ke3 Kf8 49. g4 hxg4 50. fxg4 Rxg4 51. Qh8+ Ke7 52. Qe5
+Re4+ 53. Qxe4 Bxe4 54. Kxe4 f6 55. Kf4 e5+ 56. Kg4 Kf7 57. Kf3 Kg7 58. Kg4 Kh6
+59. Kg3 Kh5 60. Kh3 f5 61. Kg3 g5 62. Kh3 gxh4 63. Kg2 Kg5 64. Kf2 e4 65. Kg2
+Kg4 66. Kf2 f4 67. Ke2 e3 68. Kf1 h3 69. Ke1 h2 70. Kf1 h1=Q+ 71. Ke2 Qh2+ 72.
+Kd3 Qf2 73. Kd4 Qd2+ 74. Kc5 e2 75. Kc6 e1=Q 76. Kc5 Qec1+ 77. Kb5 Qdb2+ 78.
+Ka4 Qca1# 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "LordGrim2500"]
+[Black "Brocha"]
+[Result "0-1"]
+[ECO "B95"]
+[WhiteElo "2448"]
+[BlackElo "2455"]
+[PlyCount "40"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. Qd2 Nbd7 8. f3
+Qc7 9. O-O-O b5 10. Kb1 Bb7 11. Bd3 Rc8 12. g4 Be7 13. h4 Nb6 14. h5 h6 15. Be3
+Nfd7 16. g5 Ne5 17. gxh6 Nbc4 18. hxg7 Nxd2+ 19. Rxd2 Bf6 20. h6 Bxg7 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "hanysayed"]
+[Black "SuperDonald"]
+[Result "0-1"]
+[ECO "D37"]
+[WhiteElo "2304"]
+[BlackElo "2330"]
+[PlyCount "46"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 d5 2. Nf3 Nf6 3. c4 e6 4. Nc3 Be7 5. Bd2 O-O 6. e3 b6 7. Nxd5 exd5 8.
+cxd5 Bb7 9. Bd3 Bxd5 10. O-O c5 11. Rc1 Nc6 12. dxc5 Bxc5 13. Be2 Ne4 14. Bc3
+Nxc3 15. Rxc3 Bxf3 16. Bxf3 Qxd1 17. Rxd1 Rad8 18. Kf1 Rxd1+ 19. Bxd1 Rd8 20.
+Ba4 Ne7 21. Ke2 Kf8 22. h4 Nd5 23. a3 Nxc3+ 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "drdrunckenstein"]
+[Black "Nurdin_Abubakar"]
+[Result "1-0"]
+[ECO "A00"]
+[WhiteElo "2533"]
+[BlackElo "2375"]
+[PlyCount "81"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. g3 d5 2. Bg2 e5 3. d3 Nc6 4. Nf3 Nf6 5. O-O Bd6 6. Nc3 O-O 7. e4 d4 8. Ne2
+h6 9. Nd2 Be6 10. h3 Qd7 11. Kh2 Rae8 12. a4 Nh7 13. f4 f5 14. exf5 Bxf5 15. g4
+Bxg4 16. hxg4 Qxg4 17. Bh3 Qh4 18. Nf3 Qf6 19. Ng3 exf4 20. Ne4 Qf7 21. Rg1 Kh8
+22. Bd2 Ne5 23. Nxe5 Bxe5 24. Qf3 c5 25. b3 b6 26. Rg2 Bb8 27. Rag1 g5 28. Bg4
+Nf6 29. Kh1 Nxe4 30. dxe4 Be5 31. Rh2 Bg7 32. Bf5 c4 33. Rxg5 cxb3 34. cxb3 Re5
+35. Bxf4 Rc5 36. Rgh5 Rc3 37. Rxh6+ Bxh6 38. Rxh6+ Kg8 39. Qg4+ Qg7 40. Be6+
+Rf7 41. Rg6 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "estocastico"]
+[Black "MiroMiljkovic"]
+[Result "1-0"]
+[ECO "B30"]
+[WhiteElo "2545"]
+[BlackElo "2614"]
+[PlyCount "77"]
+[EventDate "2020.??.??"]
+
+1. e4 c5 2. Nf3 Nc6 3. Bb5 e6 4. Bxc6 dxc6 5. d3 Ne7 6. O-O Ng6 7. a3 Bd6 8.
+Be3 Qc7 9. Nbd2 b6 10. Nc4 Bf4 11. Bxf4 Nxf4 12. e5 O-O 13. Qd2 Ng6 14. h4 Ba6
+15. Qc3 Bxc4 16. dxc4 Rad8 17. Rad1 Nf4 18. Qe3 Ng6 19. h5 Ne7 20. h6 Nf5 21.
+Qe4 gxh6 22. g4 Nd4 23. Nxd4 Rxd4 24. Rxd4 cxd4 25. Qxd4 Rd8 26. Qf4 c5 27. Re1
+Rd4 28. Qxh6 Rxg4+ 29. Kf1 Rg6 30. Qd2 Qc6 31. Qd6 Qf3 32. Re3 Qh1+ 33. Ke2
+Qh5+ 34. Rf3 Kg7 35. Qe7 Qxe5+ 36. Kd2 h5 37. Rxf7+ Kh8 38. Rh7+ Kg8 39. Qf7#
+1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Filemon64"]
+[Black "pro100still"]
+[Result "0-1"]
+[ECO "A20"]
+[WhiteElo "2346"]
+[BlackElo "2353"]
+[PlyCount "108"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. c4 e5 2. a3 c5 3. Nc3 Nc6 4. g3 d6 5. Bg2 Be6 6. d3 Qd7 7. e3 h5 8. h3 f5 9.
+Nd5 h4 10. Bd2 hxg3 11. fxg3 Nf6 12. Ne2 Ne7 13. Nec3 Nh5 14. Kf2 Nc6 15. b4 f4
+16. exf4 Nd4 17. Ne4 Bxd5 18. cxd5 exf4 19. Bxf4 Nxf4 20. gxf4 Qf7 21. Qg4 Be7
+22. Rhe1 Rh4 23. Ng5 Rxg4 24. Nxf7 Rxf4+ 25. Kg1 Kxf7 26. bxc5 Nc2 27. Rxe7+
+Kxe7 28. Rb1 Rb8 29. c6 Kd8 30. Be4 Kc7 31. Rc1 Nd4 32. Rc4 Ne2+ 33. Kg2 b5 34.
+Rc2 Nd4 35. Rc1 Rbf8 36. Kg3 g5 37. Rb1 Ne2+ 38. Kh2 Rf2+ 39. Kh1 Ng3+ 40. Kg1
+Rd2 41. a4 Rff2 42. axb5 Nxe4 43. dxe4 Rg2+ 44. Kh1 Rdf2 45. Ra1 Rh2+ 46. Kg1
+Rfg2+ 47. Kf1 Rh1+ 48. Kxg2 Rxa1 49. Kg3 Ra5 50. Kg4 Rxb5 51. Kxg5 Rb3 52. h4
+Rg3+ 53. Kf4 Rg1 54. h5 a5 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "RigelStar"]
+[Black "Aisen_Mestnikov"]
+[Result "1-0"]
+[ECO "D11"]
+[WhiteElo "2396"]
+[BlackElo "2399"]
+[PlyCount "111"]
+[EventDate "2020.??.??"]
+
+1. d4 d5 2. e3 c6 3. Nf3 Nf6 4. c4 e6 5. cxd5 exd5 6. Nc3 Be7 7. Bd3 O-O 8. h3
+c5 9. Qd2 Nc6 10. dxc5 Bxc5 11. a3 d4 12. Na4 dxe3 13. Bxh7+ Nxh7 14. Qxd8
+exf2+ 15. Ke2 Rxd8 16. Nxc5 b6 17. Na4 f1=Q+ 18. Kxf1 Rd1+ 19. Ne1 Ba6+ 20. Kf2
+Re8 21. Nc3 Rd6 22. Nf3 Nf6 23. b4 Nd4 24. Bf4 Rdd8 25. Rhe1 Ne6 26. Be5 Nd5
+27. Nxd5 Rxd5 28. Rad1 Red8 29. Rxd5 Rxd5 30. Rc1 f6 31. Bg3 Nd4 32. Rd1 Be2
+33. Rd2 Bxf3 34. gxf3 Rd8 35. Bc7 Rd7 36. Bb8 a5 37. bxa5 bxa5 38. Bf4 a4 39.
+Be3 Kf7 40. Rxd4 Ke6 41. Rxa4 Rd5 42. Rb4 Kf5 43. Rf4+ Ke6 44. Re4+ Kf5 45. Rb4
+g5 46. Rb2 Re5 47. h4 g4 48. fxg4+ Kxg4 49. Rb4+ Re4 50. Rxe4+ Kh5 51. Rf4 f5
+52. a4 Kg6 53. Rxf5 Kxf5 54. h5 Kf6 55. h6 Kg6 56. a5 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "bonsitorus"]
+[Black "imdejong"]
+[Result "0-1"]
+[ECO "C11"]
+[WhiteElo "2309"]
+[BlackElo "2340"]
+[PlyCount "120"]
+[EventDate "2020.??.??"]
+
+1. Nc3 e6 2. d4 d5 3. e4 Nf6 4. e5 Nfd7 5. Nf3 c5 6. Bb5 Nc6 7. O-O Nxd4 8.
+Nxd4 cxd4 9. Qxd4 a6 10. Bxd7+ Bxd7 11. f4 Rc8 12. Kh1 Bc5 13. Qd3 Qb6 14. a3
+Bb5 15. Rd1 Bxd3 16. cxd3 Bd4 17. Ne2 Qb3 18. Rf1 Qxd3 19. Ng3 Rc2 20. f5 Bxe5
+21. Bf4 Bxf4 22. Rxf4 e5 23. Rf3 Qxf3 24. gxf3 Rxb2 25. Re1 f6 26. Nh5 Kf7 27.
+Rg1 Rg8 28. Rc1 Re8 29. Rg1 g6 30. fxg6+ hxg6 31. Ng3 d4 32. Rc1 Re7 33. Ne4
+Rd7 34. Nc5 Rc7 35. f4 b6 36. fxe5 Rxc5 37. e6+ Ke7 38. Re1 Re5 39. Rc1 Ree2
+40. Rc7+ Kxe6 41. Rh7 Rxh2+ 42. Rxh2 Rxh2+ 43. Kxh2 Kd5 44. Kg2 Kc4 45. Kf3 Kb3
+46. Ke4 Kxa3 47. Kxd4 b5 48. Kc5 b4 49. Kc4 b3 50. Kc3 b2 51. Kc2 Ka2 52. Kc3
+b1=Q 53. Kc4 Qb5+ 54. Kd4 Qe5+ 55. Kc4 g5 56. Kb4 g4 57. Kc4 g3 58. Kb4 g2 59.
+Kc4 g1=Q 60. Kb4 Qg4# 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Chesscoach46"]
+[Black "Bentery"]
+[Result "0-1"]
+[ECO "B28"]
+[WhiteElo "2320"]
+[BlackElo "2433"]
+[PlyCount "52"]
+[EventDate "2020.??.??"]
+
+1. e4 c5 2. d4 a6 3. Nf3 cxd4 4. c3 dxc3 5. Nxc3 Nc6 6. Bf4 d6 7. e5 dxe5 8.
+Qxd8+ Nxd8 9. Nxe5 f6 10. Nd3 e5 11. Bg3 Ne7 12. f4 Nec6 13. fxe5 Bf5 14. exf6
+gxf6 15. O-O-O Bh6+ 16. Kc2 Rc8 17. Kb3 Nd4+ 18. Ka3 Bf8+ 19. Ka4 b5+ 20. Ka5
+N8c6+ 21. Kb6 Be7 22. Nd5 Bd8+ 23. Kc5 O-O 24. N3f4 Nc2 25. Bd3 N6d4+ 26. Kd6
+Rc6# 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Lopez09"]
+[Black "KingoFish"]
+[Result "0-1"]
+[ECO "B06"]
+[WhiteElo "2398"]
+[BlackElo "2399"]
+[PlyCount "34"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 g6 2. d4 Bg7 3. Nf3 d6 4. Bc4 Nf6 5. Qe2 O-O 6. e5 dxe5 7. dxe5 Nd5 8. h3
+Nb6 9. Bb3 a5 10. a3 a4 11. Ba2 Nc6 12. O-O Nd4 13. Nxd4 Qxd4 14. Re1 Be6 15.
+Nc3 Bxa2 16. Nxa2 Nc4 17. Nc3 Qxe5 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Maybach77"]
+[Black "aidenzhouu"]
+[Result "0-1"]
+[ECO "C11"]
+[WhiteElo "2382"]
+[BlackElo "2433"]
+[PlyCount "54"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 e6 2. d4 d5 3. Nc3 Nf6 4. e5 Nfd7 5. f4 c5 6. Nf3 Nc6 7. Be3 cxd4 8. Nxd4
+Bc5 9. Qd2 a6 10. O-O-O O-O 11. Kb1 Nxd4 12. Bxd4 b5 13. f5 b4 14. Ne2 a5 15.
+f6 gxf6 16. exf6 Kh8 17. Qh6 Rg8 18. Bxc5 Nxc5 19. Nf4 Ne4 20. Bd3 Qxf6 21. Qh3
+Qxf4 22. Rhf1 Qg4 23. Qe3 Qg5 24. Qd4+ Qg7 25. Qe3 Ba6 26. Bxa6 Rxa6 27. g3 Rc6
+0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "fusionpro"]
+[Black "Atomrod"]
+[Result "1-0"]
+[ECO "A63"]
+[WhiteElo "2447"]
+[BlackElo "2503"]
+[PlyCount "84"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 Nf6 2. c4 e6 3. g3 c5 4. d5 exd5 5. cxd5 d6 6. Nc3 g6 7. Bg2 Bg7 8. Nf3
+O-O 9. O-O Nbd7 10. h3 a6 11. a4 Re8 12. Nd2 Ne5 13. f4 Nh5 14. Kh2 Nd7 15. g4
+Nxf4 16. Rxf4 Be5 17. Nf3 Bxf4+ 18. Bxf4 Ne5 19. Bxe5 dxe5 20. e4 Bd7 21. Bf1
+Qf6 22. Bc4 b5 23. axb5 axb5 24. Rxa8 Rxa8 25. Bxb5 Bxb5 26. Nxb5 Qf4+ 27. Kg2
+Qxe4 28. Nc3 Qf4 29. Qd2 Qf6 30. Ne4 Qd8 31. Nxc5 Rc8 32. Ne4 f5 33. gxf5 gxf5
+34. Neg5 e4 35. Ne5 Qf6 36. Ngf7 f4 37. d6 f3+ 38. Kf2 Qh4+ 39. Ke3 Qxh3 40. d7
+f2+ 41. Kxf2 Rd8 42. Qg5+ Kf8 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Lil_D"]
+[Black "vassiukov"]
+[Result "0-1"]
+[ECO "A00"]
+[WhiteElo "2315"]
+[BlackElo "2333"]
+[PlyCount "88"]
+[EventDate "2020.??.??"]
+
+1. g3 d5 2. Bg2 Nf6 3. d3 Bf5 4. Nd2 e6 5. e4 dxe4 6. dxe4 Bg6 7. Ne2 c6 8. Nf4
+Be7 9. O-O Nbd7 10. a4 Qc7 11. a5 O-O 12. Qe2 Rad8 13. Nc4 Nc5 14. Nxg6 hxg6
+15. Bf4 Qc8 16. Rfd1 Na6 17. Nd6 Bxd6 18. Bxd6 Rfe8 19. e5 Nd5 20. c4 Ndb4 21.
+Rd2 Rd7 22. Rad1 Qd8 23. f4 Qxa5 24. h4 c5 25. h5 gxh5 26. Qxh5 g6 27. Qg5 Red8
+28. Be4 Nc6 29. Bxg6 fxg6 30. Qxg6+ Rg7 31. Qxe6+ Rf7 32. Rh2 Rdd7 33. Qh6 Rg7
+34. e6 Rxd6 35. Rxd6 Qe1+ 36. Kg2 Qe2+ 37. Kh3 Rh7 38. Qxh7+ Kxh7 39. Rd7+ Kg6
+40. f5+ Kxf5 41. Rf7+ Kxe6 42. Rf4 Qf1+ 43. Kg4 Qxf4+ 44. gxf4 Ne5+ 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Odirovski"]
+[Black "dalecarpio"]
+[Result "0-1"]
+[ECO "D13"]
+[WhiteElo "2468"]
+[BlackElo "2354"]
+[PlyCount "72"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. Nf3 Nf6 2. d4 c5 3. c3 cxd4 4. cxd4 d5 5. Nc3 Nc6 6. Bf4 a6 7. e3 Bf5 8. Rc1
+e6 9. Be2 Bd6 10. Bg3 O-O 11. O-O Rc8 12. a3 b5 13. Ne5 Na5 14. a4 b4 15. Nb1
+Qb6 16. Nd2 b3 17. Bd3 Bxe5 18. dxe5 Bxd3 19. exf6 Rxc1 20. Qxc1 Bxf1 21. fxg7
+Rd8 22. Kxf1 Nc4 23. Nxc4 Qc5 24. Bh4 Qxc4+ 25. Qxc4 dxc4 26. Ke2 c3 27. Bxd8
+cxb2 28. Bf6 b1=Q 29. g4 Qc2+ 30. Kf3 b2 31. g5 b1=Q 32. h4 Qbd1+ 33. Kf4 Qf5+
+34. Kg3 Qdf3+ 35. Kh2 Q5h3+ 36. Kg1 Qhh1# 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "fullchola"]
+[Black "alireza3700"]
+[Result "0-1"]
+[ECO "D00"]
+[WhiteElo "2434"]
+[BlackElo "2334"]
+[PlyCount "62"]
+[EventDate "2020.??.??"]
+
+1. d4 d5 2. Bg5 f6 3. Bf4 c5 4. e3 cxd4 5. exd4 Nc6 6. Nf3 Bg4 7. c3 e5 8. dxe5
+fxe5 9. Bg5 Bxf3 10. Bxd8 Bxd1 11. Bg5 Bc2 12. Nd2 h6 13. Bh4 g5 14. Bg3 Nf6
+15. Bb5 Bd6 16. Be2 O-O-O 17. O-O e4 18. Rfe1 Bxg3 19. hxg3 Ne5 20. Rac1 Bd3
+21. Bd1 Ba6 22. Bc2 Nd3 23. Bxd3 Bxd3 24. Red1 Kb8 25. Nb3 Rhf8 26. Nd4 Ng4 27.
+Ne6 Nxf2 28. Rd2 e3 29. Rxd3 Nxd3 30. Nxd8 Nxc1 31. Ne6 Re8 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "universe64"]
+[Black "metalkingGT"]
+[Result "0-1"]
+[ECO "A40"]
+[WhiteElo "2403"]
+[BlackElo "2480"]
+[PlyCount "54"]
+[EventDate "2020.??.??"]
+
+1. d4 g6 2. Bf4 Bg7 3. Be5 f6 4. Bg3 e5 5. dxe5 fxe5 6. e4 d6 7. Bc4 Nf6 8. Nc3
+c6 9. Qd2 Qc7 10. O-O-O Ke7 11. f4 b5 12. fxe5 dxe5 13. Bb3 Rd8 14. Qe2 Bg4 15.
+Nf3 Bxf3 16. gxf3 Na6 17. Bh4 Nc5 18. f4 a5 19. fxe5 Qxe5 20. Bg3 Qg5+ 21. Kb1
+a4 22. e5 Nh5 23. Nxb5 axb3 24. axb3 Nxg3 25. hxg3 cxb5 26. Qxb5 Qxe5 27. c3
+Qe4+ 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "dimochka_tsoi"]
+[Black "PchelkinVK"]
+[Result "1-0"]
+[ECO "A02"]
+[WhiteElo "2656"]
+[BlackElo "2694"]
+[PlyCount "95"]
+[EventDate "2020.??.??"]
+
+1. f4 e5 2. fxe5 d6 3. Nf3 Nc6 4. e4 Bg4 5. Nc3 dxe5 6. Bb5 Bc5 7. h3 Bh5 8. d3
+Nge7 9. Bg5 f6 10. Bh4 Qd6 11. Bf2 Bxf2+ 12. Kxf2 O-O-O 13. Bxc6 Nxc6 14. Re1
+Nd4 15. Qd2 Bxf3 16. gxf3 Qe6 17. Kg2 h5 18. Nd5 Rh6 19. Rh1 Rg6+ 20. Kf2 h4
+21. c3 c6 22. Ne3 Nb5 23. a4 Nd6 24. Rag1 Qf7 25. Rxg6 Qxg6 26. Rg1 Qh6 27. Nf1
+g5 28. Qe3 Kb8 29. Nd2 Qf8 30. b4 Nf7 31. b5 c5 32. a5 Qd6 33. Ke2 Rd7 34. Nc4
+Qe6 35. b6 a6 36. Qxc5 Nd6 37. Nxd6 Rxd6 38. Qc7+ Ka8 39. Rb1 Rc6 40. Qd8+ Rc8
+41. Qd5 Qxd5 42. exd5 Rxc3 43. Ke3 Rc5 44. Ke4 Rxa5 45. d6 Kb8 46. d7 Ra4+ 47.
+Kf5 Rd4 48. Ke6 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Frogkiller"]
+[Black "AbdAlQadir"]
+[Result "0-1"]
+[ECO "C53"]
+[WhiteElo "2382"]
+[BlackElo "2323"]
+[PlyCount "50"]
+[EventDate "2020.??.??"]
+
+1. e4 e5 2. Nf3 Nc6 3. Bc4 Nf6 4. d3 Bc5 5. c3 O-O 6. Nbd2 d6 7. h3 a5 8. O-O
+Be6 9. Bb5 Qe7 10. Re1 Nh5 11. Nxe5 Nxe5 12. Qxh5 c6 13. d4 cxb5 14. dxc5 Nd3
+15. cxd6 Qxd6 16. Rf1 Nxc1 17. Nf3 Ne2+ 18. Kh1 Nf4 19. Qh4 Ng6 20. Qg5 Qf4 21.
+Qxb5 Bxh3 22. Nd4 Bxg2+ 23. Kxg2 Qg4+ 24. Kh2 Nf4 25. Rg1 Qh3# 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Phoenix-20"]
+[Black "KeongDarat"]
+[Result "0-1"]
+[ECO "D37"]
+[WhiteElo "2488"]
+[BlackElo "2413"]
+[PlyCount "68"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 e6 2. c4 Nf6 3. Nf3 d5 4. Nc3 b6 5. e3 Bb7 6. Be2 dxc4 7. O-O Bd6 8. Bxc4
+O-O 9. b3 a6 10. Bb2 b5 11. Be2 b4 12. Na4 Nbd7 13. Rc1 Ne4 14. Nd2 Qh4 15. Nf3
+Qh6 16. g3 Qh3 17. Ne1 Ndf6 18. Bf3 h5 19. Bg2 Qf5 20. Nf3 g5 21. Nd2 h4 22.
+Nxe4 Bxe4 23. Bxe4 Qxe4 24. Qc2 hxg3 25. hxg3 Qf3 26. Qd1 Qf5 27. Kg2 g4 28.
+Rh1 Kg7 29. Kf1 Rh8 30. Rxh8 Rxh8 31. Ke2 Rh2 32. Qf1 Qf3+ 33. Ke1 Bxg3 34. d5
+Bxf2+ 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "drop_stone"]
+[Black "C9C9C9C9C9"]
+[Result "0-1"]
+[ECO "E77"]
+[WhiteElo "2932"]
+[BlackElo "2978"]
+[PlyCount "102"]
+[EventDate "2020.??.??"]
+
+1. d4 Nf6 2. c4 g6 3. Nc3 Bg7 4. e4 d6 5. h4 e5 6. d5 c6 7. Be2 b5 8. cxb5 cxd5
+9. exd5 Bb7 10. a4 Nbd7 11. a5 Rc8 12. a6 Ba8 13. h5 Nb6 14. h6 Bf8 15. Bf3 Be7
+16. Nge2 O-O 17. O-O Re8 18. Be3 Nc4 19. Bxa7 Nd7 20. Qb3 Bg5 21. Ne4 Bxh6 22.
+Nc5 Nd2 23. Qa4 Nxc5 24. Bxc5 Rxc5 25. Rad1 Nxf1 26. Kxf1 Qb6 27. Nc3 Rec8 28.
+Qh4 Bg7 29. Be2 h6 30. Ne4 g5 31. Qh3 Rc2 32. Bd3 R2c7 33. Nc3 Kf8 34. Qf5 Qd4
+35. Ne4 Bxd5 36. Nf6 Be6 37. Nh7+ Ke7 38. Qf3 e4 39. Qxe4 Qxe4 40. Bxe4 Bc4+
+41. Bd3 Bxd3+ 42. Rxd3 Bxb2 43. Re3+ Be5 44. g3 Rc1+ 45. Kg2 Rb1 46. Re2 Rxb5
+47. f4 gxf4 48. gxf4 Rg8+ 49. Kf3 Ra5 50. fxe5 dxe5 51. Nf6 Kxf6 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "MrMania"]
+[Black "lord_barre"]
+[Result "1-0"]
+[ECO "A00"]
+[WhiteElo "2382"]
+[BlackElo "2412"]
+[PlyCount "59"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. g3 e5 2. Bg2 Nf6 3. d4 exd4 4. Nf3 c5 5. O-O Nc6 6. c3 d5 7. cxd4 Bg4 8.
+dxc5 Bxc5 9. Bg5 O-O 10. Nc3 Be7 11. Bxf6 Bxf6 12. Nxd5 Bxb2 13. Rb1 Ba3 14.
+Rxb7 Bc5 15. Qa4 Qxd5 16. Qxg4 Ne5 17. Nxe5 Qxe5 18. h4 Rad8 19. h5 h6 20. e3
+Rd2 21. a4 Ra2 22. Qc4 Ra1 23. Rxa1 Qxa1+ 24. Kh2 Bb6 25. Bd5 Qf6 26. Kg2 Qf5
+27. g4 Qf6 28. Qf4 Qd6 29. Bxf7+ Kh8 30. Qxd6 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "mixo23"]
+[Black "Valema"]
+[Result "1-0"]
+[ECO "A02"]
+[WhiteElo "2429"]
+[BlackElo "2311"]
+[PlyCount "111"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. f4 c6 2. b3 Qa5 3. Bb2 Nf6 4. Nf3 h6 5. e3 d6 6. Bd3 Bg4 7. O-O Nbd7 8. Qe1
+Bxf3 9. Rxf3 e5 10. Rf1 e4 11. Be2 d5 12. c4 Be7 13. Kh1 g5 14. fxg5 hxg5 15.
+cxd5 cxd5 16. Bd4 g4 17. Nc3 Qc7 18. g3 a6 19. Rc1 Qb8 20. Rf5 Rh6 21. Qf2 Qd6
+22. Rf1 b5 23. Qf4 Qxf4 24. R1xf4 Rc8 25. Nxd5 Nxd5 26. Rxd5 Rc1+ 27. Kg2 Re1
+28. Bxg4 Nf6 29. Bxf6 Bxf6 30. h4 Ra1 31. Rxe4+ Kf8 32. a4 Ra2 33. Kf3 bxa4 34.
+Rxa4 Rb2 35. Rxa6 Rxb3 36. Rf5 Bg7 37. Ra8+ Ke7 38. Ra7+ Kf8 39. Rfxf7+ Ke8 40.
+Rxg7 Kf8 41. Rgf7+ Ke8 42. Rfb7 Rf6+ 43. Ke2 Rxb7 44. Rxb7 Kd8 45. h5 Rd6 46.
+e4 Rh6 47. e5 Rh8 48. e6 Re8 49. d4 Re7 50. Rxe7 Kxe7 51. h6 Kf6 52. e7 Kxe7
+53. h7 Kf7 54. h8=Q Kg6 55. Bh5+ Kg5 56. Qh6+ 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "dmitrij_IM"]
+[Black "Chess-Network"]
+[Result "1-0"]
+[ECO "A15"]
+[WhiteElo "2858"]
+[BlackElo "2708"]
+[PlyCount "95"]
+[EventDate "2020.??.??"]
+
+1. c4 Nf6 2. g3 e5 3. Bg2 Bc5 4. Nc3 O-O 5. e3 Re8 6. Nge2 d6 7. O-O Nc6 8. d4
+Bb6 9. a3 Bf5 10. b4 a6 11. c5 Ba7 12. Bb2 Qd7 13. Qb3 Rad8 14. Rad1 Qc8 15.
+Qa4 h5 16. Nd5 Nxd5 17. Bxd5 e4 18. Bxc6 bxc6 19. Qxc6 Bg4 20. Nc3 Qf5 21. f4
+d5 22. Qxa6 Bb8 23. c6 h4 24. Rd2 Rd6 25. Rff2 Rg6 26. Qf1 Rh6 27. b5 hxg3 28.
+hxg3 Ree6 29. Rh2 Bf3 30. Rxh6 Rxh6 31. Rh2 Qg4 32. Qf2 Rg6 33. Na4 Ba7 34. Nc5
+Bxc5 35. dxc5 f6 36. b6 cxb6 37. cxb6 Qc8 38. b7 Qc7 39. Bd4 f5 40. Qb2 Qxc6
+41. Kf2 Kf7 42. b8=Q Rd6 43. Q8b7+ Qxb7 44. Qxb7+ Rd7 45. Qxd7+ Kf8 46. Qxg7+
+Ke8 47. Rh6 Kd8 48. Rh8# 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "thatlime"]
+[Black "LRgenius"]
+[Result "1-0"]
+[ECO "A62"]
+[WhiteElo "2312"]
+[BlackElo "2442"]
+[PlyCount "67"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 Nf6 2. c4 e6 3. g3 c5 4. d5 exd5 5. cxd5 d6 6. Nc3 g6 7. Bg2 Bg7 8. Nf3
+O-O 9. O-O Na6 10. Nd2 Nc7 11. a4 b6 12. Re1 Rb8 13. e4 Nd7 14. Nc4 Ne5 15.
+Nxe5 Bxe5 16. f4 Bd4+ 17. Be3 Bxe3+ 18. Rxe3 b5 19. e5 dxe5 20. fxe5 b4 21. Ne4
+Bf5 22. Nf6+ Kg7 23. g4 Bc8 24. Rh3 h6 25. Qd2 Rh8 26. Qf4 Ne8 27. Nxe8+ Qxe8
+28. Qf6+ Kg8 29. Rf1 Bxg4 30. Rg3 Rb6 31. e6 Bxe6 32. dxe6 Rxe6 33. Rxg6+ fxg6
+34. Bd5 1-0
+
+[Event "Rated Blitz tournament te4AhseI"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Mr-Anonymous-Killer"]
+[Black "PetroffLRS"]
+[Result "1-0"]
+[ECO "A00"]
+[WhiteElo "2334"]
+[BlackElo "2300"]
+[PlyCount "77"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. Nh3 d5 2. g3 c6 3. Bg2 e5 4. c4 e4 5. cxd5 cxd5 6. d3 exd3 7. Qxd3 Bxh3 8.
+Bxh3 Nc6 9. Bg2 Nf6 10. Nc3 Bb4 11. O-O O-O 12. Nxd5 Nxd5 13. Qxd5 Qxd5 14.
+Bxd5 Nd4 15. e4 Rac8 16. Bxb7 Rc2 17. Be3 Ne2+ 18. Kg2 Rxb2 19. Rab1 Rxb1 20.
+Rxb1 a5 21. Rd1 Nc3 22. Ra1 Rb8 23. Bd5 Rd8 24. a3 Nxd5 25. exd5 Bc3 26. Rd1 f6
+27. Kf3 Kf7 28. Ke4 Bb2 29. a4 Rb8 30. Bd2 Re8+ 31. Kd3 Rd8 32. Kc4 Rc8+ 33.
+Kb5 Rd8 34. Bxa5 Rb8+ 35. Bb6 Ke7 36. a5 Kd7 37. a6 Be5 38. a7 Ra8 39. Rc1 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Paanoos"]
+[Black "Chesscoach46"]
+[Result "1-0"]
+[ECO "B23"]
+[WhiteElo "2408"]
+[BlackElo "2316"]
+[PlyCount "149"]
+[EventDate "2020.??.??"]
+
+1. e4 c5 2. Nc3 e6 3. g3 d5 4. Bg2 d4 5. Nce2 Nc6 6. d3 Nf6 7. f4 e5 8. Nf3 Bd6
+9. O-O Bg4 10. f5 Bxf3 11. Bxf3 Qc7 12. c3 O-O-O 13. c4 g6 14. g4 h5 15. g5 Ng4
+16. f6 Ne3 17. Qe1 Nc2 18. Qd1 Nxa1 19. Bd2 Nb4 20. Bxb4 cxb4 21. Qxa1 Kb8 22.
+b3 h4 23. h3 b6 24. Bg4 Bc5 25. Kh2 Bd6 26. Ng1 a5 27. Nf3 Qc5 28. a4 Rhe8 29.
+Rf2 Qc7 30. Qf1 Bc5 31. Rg2 Bd6 32. Qf2 Bc5 33. Qxh4 Rh8 34. Qf2 Rh7 35. Qg3
+Rdh8 36. Kg1 Bd6 37. Kf2 Rh5 38. Ke2 R5h7 39. Kd2 Kb7 40. Kc2 Ka7 41. Rh2 Kb7
+42. h4 Ka7 43. Ng1 Kb7 44. Ne2 Qc6 45. Qf2 Qc7 46. Qg3 Ka7 47. Qh3 Qc6 48. Ng3
+Qc7 49. h5 gxh5 50. Bf5 Qd8 51. Bxh7 Rxh7 52. Qf5 Qh8 53. Qd7+ Ka6 54. Qxd6 h4
+55. Nf5 h3 56. Ne7 Qa8 57. Qc7 Qb7 58. Qd6 Rh5 59. Qxe5 Ka7 60. Nd5 Rxg5 61.
+Qxg5 Qc6 62. Qe5 Qb7 63. Qe7 Ka6 64. Qxb7+ Kxb7 65. Rxh3 Kc6 66. Rh7 b5 67.
+Rxf7 bxa4 68. bxa4 Kd6 69. Kb3 Ke6 70. Ra7 Ke5 71. Rxa5 Ke6 72. Rb5 Kf7 73.
+Rxb4 Kg6 74. Rb5 Kh5 75. Rc5 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "iCe_eNerGyTeaM"]
+[Black "WarShoe"]
+[Result "1-0"]
+[ECO "D26"]
+[WhiteElo "2385"]
+[BlackElo "2341"]
+[PlyCount "29"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 e6 2. Nf3 d5 3. c4 dxc4 4. e3 Nf6 5. Bxc4 c5 6. O-O cxd4 7. exd4 Be7 8.
+Qe2 O-O 9. Nc3 b6 10. Rd1 Bb7 11. Bg5 Nd5 12. Bxd5 Bxd5 13. Bxe7 Bxf3 14. Qxf3
+Qxe7 15. Qxa8 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "hungzhao"]
+[Black "Betovsky"]
+[Result "1-0"]
+[ECO "B01"]
+[WhiteElo "2638"]
+[BlackElo "2613"]
+[PlyCount "65"]
+[EventDate "2020.??.??"]
+
+1. e4 d5 2. exd5 Nf6 3. Bb5+ Bd7 4. Be2 Nxd5 5. d4 Nb6 6. a4 Bf5 7. a5 N6d7 8.
+Nf3 e6 9. O-O Be7 10. c4 Bg6 11. Nc3 O-O 12. Bf4 Nc6 13. a6 b6 14. d5 exd5 15.
+Nxd5 Bd6 16. Bxd6 cxd6 17. Nd4 Nxd4 18. Qxd4 Ne5 19. f4 Nc6 20. Qc3 Re8 21. Bf3
+Be4 22. Rae1 Bxf3 23. Qxf3 Qd7 24. h4 h6 25. h5 Nd4 26. Qd3 Ne6 27. b4 Nc7 28.
+Nxc7 Qxc7 29. f5 Rxe1 30. Rxe1 Rd8 31. f6 Qc8 32. Qg3 g5 33. hxg6 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "elpepinillo14"]
+[Black "ahmedSulaimaniyah16"]
+[Result "1-0"]
+[ECO "B26"]
+[WhiteElo "2539"]
+[BlackElo "2408"]
+[PlyCount "43"]
+[EventDate "2020.??.??"]
+
+1. e4 c5 2. Nc3 d6 3. g3 g6 4. Bg2 Bg7 5. d3 Nc6 6. Be3 e5 7. Qd2 Nge7 8. Bh6
+O-O 9. h4 f5 10. h5 Qe8 11. Bxg7 Kxg7 12. hxg6 Qxg6 13. Nf3 Nd4 14. O-O-O Nxf3
+15. Bxf3 Rb8 16. exf5 Bxf5 17. Be4 Bxe4 18. Nxe4 h6 19. f4 exf4 20. gxf4 Kh7
+21. Rdg1 Qe6 22. Ng5+ 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Abouyahya1983"]
+[Black "Schacher101"]
+[Result "1-0"]
+[ECO "C13"]
+[WhiteElo "2566"]
+[BlackElo "2448"]
+[PlyCount "89"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 e6 2. d4 d5 3. Nc3 Nf6 4. Bg5 Be7 5. e5 Nfd7 6. h4 a6 7. Qg4 Bxg5 8. Qxg5
+Qxg5 9. hxg5 c5 10. f4 Nc6 11. Nf3 Nxd4 12. Nxd4 cxd4 13. Ne2 f6 14. exf6 gxf6
+15. Nxd4 fxg5 16. Nxe6 Ke7 17. Nc7 Rb8 18. Nxd5+ Kd6 19. O-O-O gxf4 20. Nxf4+
+Kc7 21. Bc4 b5 22. Bd5 Nb6 23. Ng6 Rd8 24. Rxh7+ Rd7 25. Rxd7+ Bxd7 26. Ne5 Bf5
+27. Bf3 Re8 28. Nd3 Nc4 29. b3 Ne3 30. Re1 Re6 31. Kd2 Ng4 32. Rxe6 Bxe6 33.
+Nc5 Bc8 34. Nxa6+ Kb6 35. Bxg4 Bxg4 36. Nb4 Kc5 37. Kc3 Bf5 38. Nd3+ Kb6 39.
+Kb4 Be4 40. g4 Bf3 41. g5 Bd1 42. g6 Bh5 43. Ne5 Kc7 44. g7 Kd6 45. g8=Q 1-0
+
+[Event "Rated Rapid game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Mukha73"]
+[Black "Tallnicke"]
+[Result "1/2-1/2"]
+[ECO "C18"]
+[WhiteElo "2393"]
+[BlackElo "2400"]
+[PlyCount "152"]
+[EventDate "2020.??.??"]
+[EventType "rapid"]
+
+1. d4 e6 2. e4 d5 3. Nc3 Bb4 4. e5 c5 5. a3 Bxc3+ 6. bxc3 Qc7 7. Nf3 Ne7 8. a4
+b6 9. Bb5+ Nd7 10. O-O O-O 11. Bg5 Re8 12. Re1 c4 13. h4 a6 14. Bxd7 Bxd7 15.
+h5 h6 16. Bc1 Rf8 17. Ba3 Rae8 18. Bd6 Qd8 19. Nh4 Bc6 20. Qg4 Qd7 21. a5 bxa5
+22. Rxa5 Bb5 23. Re3 Kh8 24. Rg3 Rg8 25. Qf4 Nc8 26. Bc5 Qc7 27. Ra1 f5 28. Rg6
+Kh7 29. g4 fxg4 30. Qxg4 Qf7 31. f4 Ne7 32. Rf1 Nf5 33. Nxf5 exf5 34. Qg2 Re6
+35. Rxe6 Qxe6 36. Kf2 Be8 37. Rh1 Bf7 38. Qh3 Rb8 39. Bb4 Kh8 40. Ra1 Rb5 41.
+Ke3 Bg8 42. Qh4 Qb6 43. Bf8 Rb2 44. Qe7 Qb7 45. Bxg7+ Kh7 46. Qxb7 Rxb7 47. Bf6
+Rb6 48. Rg1 Rb7 49. Ra1 Rb6 50. Bd8 Rc6 51. Rg1 Bf7 52. Bf6 Rxf6 53. exf6 Bxh5
+54. Ra1 Kg6 55. Rxa6 Bd1 56. Kd2 Bf3 57. f7+ Kxf7 58. Rxh6 Be4 59. Kc1 Ke7 60.
+Kb2 Kd7 61. Ka3 Ke7 62. Kb4 Bxc2 63. Kc5 Be4 64. Rd6 Kf7 65. Rxd5 Ke7 66. Re5+
+Kd7 67. d5 Bd3 68. Kd4 Kd8 69. d6 Be4 70. Rxe4 Kd7 71. Re5 Kd8 72. Rxf5 Kd7 73.
+Kxc4 Kc6 74. Kd4 Kd7 75. c4 Kc6 76. c5 Kd7 1/2-1/2
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "ajedrez2021"]
+[Black "sutcunuri"]
+[Result "1/2-1/2"]
+[ECO "A07"]
+[WhiteElo "2598"]
+[BlackElo "2516"]
+[PlyCount "255"]
+[EventDate "2020.??.??"]
+
+1. Nf3 d5 2. g3 c6 3. Bg2 Bg4 4. O-O Bxf3 5. Bxf3 e6 6. d4 Nf6 7. c4 Nbd7 8.
+Nc3 Bd6 9. e4 dxe4 10. Nxe4 Nxe4 11. Bxe4 Nf6 12. Bf3 O-O 13. Qb3 Be7 14. Be3
+Qb6 15. Rfd1 Qxb3 16. axb3 a6 17. Rd3 Rfd8 18. Rad1 Rd7 19. Kf1 Rad8 20. Ke2 g6
+21. Bf4 Bd6 22. Bg5 Be7 23. Bf4 Bd6 24. Bg5 Be7 25. Bd2 Ne8 26. Bc3 Bf6 27. d5
+Bxc3 28. bxc3 exd5 29. cxd5 cxd5 30. Rxd5 Rxd5 31. Rxd5 Rxd5 32. Bxd5 Nd6 33.
+Kd3 b6 34. Kd4 Kf8 35. Bf3 Nb5+ 36. Kd5 Nxc3+ 37. Kc6 a5 38. Kxb6 a4 39. bxa4
+Nxa4+ 40. Kc6 Nb2 41. Be2 Na4 42. Bc4 Nc3 43. f3 Nd1 44. Kc5 Ne3 45. Bd3 Ke7
+46. Kd4 Nd1 47. Be2 Nf2 48. Ke3 Nh3 49. f4 g5 50. Bg4 gxf4+ 51. gxf4 Nxf4 52.
+Kxf4 Kf6 53. Bf5 h5 54. h4 Kg7 55. Kg5 f6+ 56. Kxh5 Kh8 57. Kg4 Kg8 58. Be4 Kh8
+59. Kf5 Kg8 60. Bf3 Kh8 61. Bg4 Kg8 62. Bh3 Kh8 63. Bg2 Kg8 64. Bf3 Kh8 65. Be2
+Kg8 66. Bf1 Kh8 67. Kg4 Kg8 68. Kh5 Kh8 69. Kh6 Kg8 70. Bc4+ Kh8 71. Bd5 f5 72.
+Kg5 f4 73. Bf3 Kg7 74. Kf5 Kh8 75. Kg5 Kg8 76. Kg4 Kh8 77. Kh3 Kg8 78. Kg2 Kh8
+79. Kf2 Kg8 80. h5 Kh8 81. Ke2 Kg8 82. Kd3 Kh8 83. Kd2 Kg8 84. Kc3 Kh8 85. Kb2
+Kg8 86. Kb3 Kh8 87. Kc4 Kg8 88. Kc5 Kh8 89. Kb4 Kg8 90. Kc3 Kh8 91. Kd4 Kg8 92.
+Kd5 Kh8 93. Kd4 Kg8 94. Ke4 Kh8 95. Kf5 Kg8 96. Bd5+ Kh8 97. Be4 Kg8 98. Bf3
+Kh8 99. Bd5 Kg7 100. Kg4 Kh8 101. Bf3 Kg7 102. Kg5 Kh8 103. Kg4 Kg7 104. Bd5
+Kh8 105. Kg5 Kg7 106. h6+ Kh8 107. Kg6 f3 108. Bc4 f2 109. Bf1 Kg8 110. Kg5 Kh8
+111. Kg4 Kg8 112. Kh5 Kh8 113. Bd3 Kg8 114. Kg4 Kh8 115. Kf3 Kg8 116. Bf1 Kh8
+117. Kg2 Kg8 118. Kg3 Kh8 119. Kh4 Kg8 120. Kg5 Kh7 121. Kh4 Kh8 122. Kg3 Kg8
+123. Kxf2 Kh8 124. Kg3 Kg8 125. Kg4 Kh8 126. Kg5 Kg8 127. Kg6 Kh8 128. h7
+1/2-1/2
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Bentery"]
+[Black "fullchola"]
+[Result "1-0"]
+[ECO "D04"]
+[WhiteElo "2437"]
+[BlackElo "2427"]
+[PlyCount "85"]
+[EventDate "2020.??.??"]
+
+1. e3 Nf6 2. Nf3 d5 3. d4 Bg4 4. c4 Bxf3 5. Qxf3 dxc4 6. Nc3 c6 7. Bxc4 Nbd7 8.
+g4 e6 9. g5 Nd5 10. h4 N7b6 11. Bb3 Bb4 12. Bd2 a5 13. e4 Nxc3 14. bxc3 Be7 15.
+a4 c5 16. Rb1 cxd4 17. cxd4 Qxd4 18. Bc3 Qc5 19. Bxg7 Rg8 20. Bc3 Rc8 21. Bd2
+Rd8 22. Rc1 Qd4 23. Bc3 Qd6 24. O-O h6 25. Rfd1 Qb8 26. Rxd8+ Qxd8 27. Rd1 Qc8
+28. Bd4 Nd7 29. Qh5 hxg5 30. Bxe6 gxh4+ 31. Kh1 Rf8 32. Bg7 Qc6 33. Bxd7+ Qxd7
+34. Rxd7 Rg8 35. Bf8 Rxf8 36. Qd5 f6 37. Rxb7 Rg8 38. Rb8+ Bd8 39. Qe6+ Kf8 40.
+Rxd8+ Kg7 41. Rxg8+ Kh6 42. Qxf6+ Kh5 43. Qg5# 1-0
+
+[Event "Rated Blitz tournament nLsDCFvz"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "spidernv"]
+[Black "coventry"]
+[Result "0-1"]
+[ECO "A30"]
+[WhiteElo "2421"]
+[BlackElo "2368"]
+[PlyCount "108"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. c4 c5 2. g3 Nf6 3. Bg2 d5 4. Nc3 d4 5. Nb1 Nc6 6. e3 e5 7. exd4 Nxd4 8. d3
+Be7 9. Nc3 O-O 10. h3 Bf5 11. Be3 Rb8 12. g4 Bg6 13. h4 Nc6 14. Ne4 Nb4 15.
+Nxf6+ Bxf6 16. Ne2 Nxd3+ 17. Kf1 h5 18. Ng3 Nxb2 19. Qxd8 Rfxd8 20. gxh5 Bd3+
+21. Kg1 Nxc4 22. h6 Nxe3 23. fxe3 gxh6 24. Kh2 e4 25. Rac1 c4 26. Rhg1 Be5 27.
+Kh3 Bxg3 28. Kxg3 Rbc8 29. Kf4 Kf8 30. Bxe4 Bxe4 31. Kxe4 c3 32. Rc2 b5 33. a3
+a5 34. Rb1 Rc5 35. Rb3 Rdc8 36. Kd3 Ke7 37. Rb1 Ke6 38. Rf1 b4 39. axb4 axb4
+40. Rb1 Rb8 41. Kd4 Rcc8 42. Rb3 Kf5 43. Rf2+ Kg4 44. Rb1 Rd8+ 45. Ke4 f5+ 46.
+Ke5 Re8+ 47. Kd4 Rbd8+ 48. Kc5 Rc8+ 49. Kd5 Kg3 50. Rxf5 Red8+ 51. Ke4 Rc4+ 52.
+Ke5 Rc5+ 53. Kf6 Rxf5+ 54. Kxf5 c2 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Kidefence"]
+[Black "BlueGreensun"]
+[Result "1-0"]
+[ECO "B01"]
+[WhiteElo "2693"]
+[BlackElo "2774"]
+[PlyCount "83"]
+[EventDate "2020.??.??"]
+
+1. e4 d5 2. exd5 c6 3. dxc6 Nf6 4. Nf3 Nxc6 5. Bb5 Bd7 6. O-O e5 7. Bxc6 Bxc6
+8. Nxe5 Bd6 9. Nxc6 bxc6 10. Re1+ Be7 11. d4 O-O 12. Bf4 Nd5 13. Bg3 Qb6 14. b3
+Bb4 15. Rf1 Rfe8 16. c4 Nc3 17. Nxc3 Bxc3 18. Rc1 Bxd4 19. c5 Bxc5 20. Qf3 Rad8
+21. h3 Re6 22. Rc4 h6 23. Rfc1 Rd5 24. Kh2 a5 25. Qc3 Bb4 26. Qf3 Qb5 27. Rf4
+Re7 28. Bh4 Red7 29. Bg3 Rd2 30. Rxc6 Rxa2 31. Rc8+ Bf8 32. Rg4 Rad2 33. Bf4
+Qa6 34. Ra8 Qf6 35. Bxd2 Qxf3 36. gxf3 Rxd2 37. Kg2 g6 38. Rxa5 Kg7 39. b4 Bd6
+40. Rc4 Be5 41. Rxe5 Rc2 42. Rxc2 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "FedaMaster"]
+[Black "Kelevra90"]
+[Result "1-0"]
+[ECO "B22"]
+[WhiteElo "2540"]
+[BlackElo "2446"]
+[PlyCount "93"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 c5 2. d4 cxd4 3. c3 Nf6 4. e5 Nd5 5. Nf3 Nc6 6. Bc4 Nb6 7. Bb3 d5 8. exd6
+Qxd6 9. O-O Be6 10. Na3 dxc3 11. Qe2 Bxb3 12. Nb5 Qb8 13. axb3 e5 14. Bf4 f6
+15. Nh4 Be7 16. Qh5+ Kf8 17. Ng6+ hxg6 18. Qxh8+ Kf7 19. Qxb8 Rxb8 20. Be3 cxb2
+21. Rab1 Nd5 22. Bxa7 Nxa7 23. Nxa7 Ba3 24. Nb5 Be7 25. Rxb2 Nf4 26. Rd1 Rc8
+27. g3 Ne6 28. Nd6+ Bxd6 29. Rxd6 Rc7 30. Ra2 Nd4 31. Rb6 Nc6 32. Ra8 g5 33. h3
+Kg6 34. g4 e4 35. Re8 Ne5 36. Rxe5 Rc1+ 37. Kg2 Rc3 38. Rxe4 Rc2 39. Re7 Rc6
+40. Rxc6 bxc6 41. Rc7 f5 42. Rxc6+ Kh7 43. gxf5 g6 44. Rxg6 g4 45. hxg4 Kh8 46.
+b4 Kh7 47. b5 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "estocastico"]
+[Black "Zobbie"]
+[Result "0-1"]
+[ECO "B12"]
+[WhiteElo "2552"]
+[BlackElo "2369"]
+[PlyCount "50"]
+[EventDate "2020.??.??"]
+
+1. e4 c6 2. d4 d5 3. e5 c5 4. Nf3 Nc6 5. dxc5 Bg4 6. Bb5 e6 7. Be3 d4 8. Bxd4
+Nge7 9. c3 Nf5 10. O-O Be7 11. Nbd2 O-O 12. Bxc6 bxc6 13. h3 Bxf3 14. Nxf3 Rb8
+15. b4 a5 16. a3 Qd5 17. Qe2 Rfd8 18. Rfd1 Qb3 19. Nd2 Qc2 20. Qc4 Bg5 21. Nf3
+Bf4 22. bxa5 Rb2 23. Rf1 h6 24. a6 Ra8 25. Qa4 Qxa4 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "alireza3700"]
+[Black "kinez24"]
+[Result "1/2-1/2"]
+[ECO "C11"]
+[WhiteElo "2341"]
+[BlackElo "2319"]
+[PlyCount "101"]
+[EventDate "2020.??.??"]
+
+1. d4 d5 2. Nc3 e6 3. e4 Nf6 4. Bg5 dxe4 5. Nxe4 Be7 6. Bxf6 Bxf6 7. Nf3 Be7 8.
+Bd3 b6 9. O-O Bb7 10. Qe2 Nd7 11. c3 Nf6 12. Nxf6+ gxf6 13. Be4 Bxe4 14. Qxe4
+Qd5 15. Qxd5 exd5 16. Rfe1 Kd7 17. Nh4 Bd6 18. Nf5 Rae8 19. Rxe8 Rxe8 20. Kf1
+Re4 21. f3 Re6 22. Nxd6 Kxd6 23. Re1 c5 24. dxc5+ bxc5 25. Rxe6+ fxe6 26. Ke2
+e5 27. g4 c4 28. b3 Kc5 29. Ke3 d4+ 30. cxd4+ exd4+ 31. Kd2 c3+ 32. Kd3 Kb4 33.
+f4 Ka3 34. Kc2 Kxa2 35. h4 d3+ 36. Kxc3 d2 37. Kxd2 Kxb3 38. g5 fxg5 39. hxg5
+Kc4 40. f5 Kd5 41. f6 Ke6 42. Kc3 h6 43. gxh6 Kxf6 44. h7 Kg7 45. Kb4 Kxh7 46.
+Kb5 Kg6 47. Ka5 Kf5 48. Ka6 Ke6 49. Kb5 Kd7 50. Ka6 Kc8 51. Kxa7 1/2-1/2
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Aisen_Mestnikov"]
+[Black "RigelStar"]
+[Result "1-0"]
+[ECO "D11"]
+[WhiteElo "2393"]
+[BlackElo "2401"]
+[PlyCount "73"]
+[EventDate "2020.??.??"]
+
+1. d4 d5 2. c4 c6 3. Nf3 Nf6 4. g3 e6 5. Bg2 Nbd7 6. O-O Bb4 7. a3 Ba5 8. b3
+Bc7 9. Bb2 Kf8 10. Nbd2 h6 11. Qc2 Kg8 12. e4 dxe4 13. Nxe4 Nxe4 14. Qxe4 Nf6
+15. Qc2 b6 16. Rad1 Bb7 17. Ne5 Qe8 18. Rfe1 Rd8 19. d5 cxd5 20. cxd5 Bxe5 21.
+Rxe5 Bxd5 22. Bxd5 Rxd5 23. Rdxd5 Nxd5 24. Qe4 Qc6 25. Qg4 f5 26. Rxe6 fxg4 27.
+Rxc6 Kh7 28. Rd6 Ne7 29. Rd7 Nf5 30. Rxa7 Rc8 31. Rf7 Kg6 32. Rb7 Rc2 33. Rxb6+
+Kg5 34. Be5 Rc1+ 35. Kg2 g6 36. Bf4+ Kh5 37. Bxc1 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Klaksidee"]
+[Black "EPThompson"]
+[Result "1-0"]
+[ECO "A04"]
+[WhiteElo "2580"]
+[BlackElo "2556"]
+[PlyCount "51"]
+[EventDate "2020.??.??"]
+
+1. Nf3 b6 2. g3 Bb7 3. Bg2 g6 4. O-O Bg7 5. c4 Nf6 6. Nc3 O-O 7. Re1 c5 8. e4
+d6 9. d4 cxd4 10. Nxd4 Nfd7 11. Be3 Nc6 12. Rc1 Rc8 13. Qd2 Nce5 14. b3 Ng4 15.
+Bf4 e5 16. Bg5 f6 17. Ndb5 fxg5 18. Nxd6 Rxf2 19. Qd3 Nc5 20. Qd1 Qd7 21. Bh3
+h5 22. Nxc8 Qxc8 23. Bxg4 hxg4 24. Kxf2 Ne6 25. Nd5 Nd4 26. Ne7+ 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "imdejong"]
+[Black "Yoseqpuedo"]
+[Result "1-0"]
+[ECO "C01"]
+[WhiteElo "2346"]
+[BlackElo "2396"]
+[PlyCount "47"]
+[EventDate "2020.??.??"]
+
+1. e4 e6 2. d4 f5 3. Nc3 fxe4 4. Nxe4 d5 5. Ng3 Nf6 6. Nf3 Bd6 7. Bd3 O-O 8.
+O-O c5 9. Re1 Nc6 10. c3 cxd4 11. cxd4 Qb6 12. Bg5 Qxb2 13. Rb1 Qxa2 14. Ne5 a5
+15. Bxf6 Rxf6 16. Re2 Qa3 17. Nh5 Rh6 18. Re3 Bxe5 19. Bxh7+ Rxh7 20. Rxa3 Bxd4
+21. Rg3 Bd7 22. Qg4 Nd8 23. Qxd4 Rh6 24. Qxg7# 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Club-Jaque-al-Rey"]
+[Black "zpxocivubyntmraeswdq"]
+[Result "1-0"]
+[ECO "B55"]
+[WhiteElo "2512"]
+[BlackElo "2698"]
+[PlyCount "75"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. f3 e5 6. Bb5+ Nbd7 7. Bxd7+ Bxd7
+8. Nb3 Rc8 9. O-O Be7 10. Be3 a5 11. N3d2 b5 12. a4 b4 13. c4 O-O 14. b3 Nh5
+15. g3 g6 16. Qe2 Bg5 17. Rd1 f5 18. exf5 Bxf5 19. Nf1 Rc7 20. Nbd2 Rcf7 21.
+Ne4 Bxe4 22. fxe4 Rf3 23. Rd5 Qf6 24. Rd3 Bxe3+ 25. Nxe3 Rf2 26. Qd1 Qe6 27.
+Nf5 gxf5 28. Rxd6 Qf7 29. Kxf2 fxe4+ 30. Kg2 Qf2+ 31. Kh1 e3 32. Qxh5 e2 33.
+Qg5+ Kh8 34. Qxe5+ Kg8 35. Qd5+ Kh8 36. Qd3 e1=Q+ 37. Rxe1 Qxe1+ 38. Kg2 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "harry_p0tter"]
+[Black "MiroMiljkovic"]
+[Result "0-1"]
+[ECO "B15"]
+[WhiteElo "2629"]
+[BlackElo "2607"]
+[PlyCount "94"]
+[EventDate "2020.??.??"]
+
+1. d4 d5 2. Nc3 c6 3. e4 Nf6 4. e5 Ne4 5. Nce2 Bf5 6. f3 Qa5+ 7. c3 e6 8. fxe4
+Bxe4 9. Ng3 Nd7 10. Nxe4 dxe4 11. Qe2 O-O-O 12. Qxe4 f5 13. exf6 Nxf6 14. Qe5
+Rd5 15. Qxe6+ Kc7 16. Bf4+ Bd6 17. Qf7+ Nd7 18. Bxd6+ Rxd6 19. Be2 Rf6 20. Qb3
+Re8 21. O-O-O Qg5+ 22. Kb1 Qxg2 23. Bf3 Qf2 24. Bg4 Nb6 25. Nf3 g6 26. Ne5 h5
+27. Bf3 Rxe5 28. dxe5 Rxf3 29. Rhf1 Qxf1 30. Rxf1 Rxf1+ 31. Kc2 Nd5 32. Qa4
+Rf2+ 33. Kb3 Rf4 34. Qa5+ Nb6 35. Qc5 Nc8 36. e6 Re4 37. Qf8 Rxe6 38. Qf7+ Re7
+39. Qxg6 Nd6 40. Qxh5 Ne4 41. h4 Nd2+ 42. Ka3 Ne4 43. Qf5 Nd6 44. Qf4 Re4 45.
+h5 Rxf4 46. h6 Rf5 47. b3 Ra5+ 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "AbdAlQadir"]
+[Black "bonsitorus"]
+[Result "1-0"]
+[ECO "B01"]
+[WhiteElo "2329"]
+[BlackElo "2304"]
+[PlyCount "41"]
+[EventDate "2020.??.??"]
+
+1. e4 d5 2. exd5 c6 3. dxc6 e5 4. Nf3 e4 5. Qe2 f5 6. d3 Nf6 7. Nc3 Bb4 8. Bg5
+Bxc3+ 9. bxc3 O-O 10. Nd4 bxc6 11. dxe4 fxe4 12. Qc4+ Kh8 13. Be2 Ba6 14. Qb3
+Bxe2 15. Kxe2 c5 16. Ne6 Qe8 17. Nxf8 Qh5+ 18. Ke1 Qxg5 19. Qb7 Qxg2 20. Rf1 e3
+21. Qxg2 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Derrotado"]
+[Black "Rookdom"]
+[Result "1-0"]
+[ECO "A00"]
+[WhiteElo "2414"]
+[BlackElo "2432"]
+[PlyCount "79"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. a4 e5 2. g3 d5 3. Bg2 h5 4. h4 Nf6 5. d3 Bc5 6. e3 Nc6 7. Ne2 Bg4 8. f3 Be6
+9. e4 dxe4 10. dxe4 Qxd1+ 11. Kxd1 O-O-O+ 12. Ke1 Nb4 13. Na3 a6 14. Bh3 Rhe8
+15. Bg5 Rd6 16. Rd1 Nd7 17. Rxd6 cxd6 18. Kd2 Nb6 19. c3 Nc6 20. Bxe6+ fxe6 21.
+b4 Nxb4 22. a5 Nd7 23. Nc4 Nc6 24. Ra1 Kc7 25. Be3 Rf8 26. f4 Bxe3+ 27. Kxe3 g6
+28. Rg1 Nc5 29. g4 exf4+ 30. Nxf4 hxg4 31. Rxg4 Re8 32. Rxg6 d5 33. Nd2 Nxa5
+34. h5 dxe4 35. h6 e5 36. Nd5+ Kb8 37. h7 Ka7 38. Rg8 Nc4+ 39. Nxc4 Rxg8 40.
+hxg8=Q 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "NEKI_NOVI_KLINAC"]
+[Black "Evgen_88"]
+[Result "0-1"]
+[ECO "C00"]
+[WhiteElo "2447"]
+[BlackElo "2532"]
+[PlyCount "88"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 e6 2. Nf3 d5 3. exd5 exd5 4. d4 Bg4 5. Nc3 Bb4 6. Be3 Nf6 7. Be2 O-O 8.
+O-O Bxc3 9. bxc3 Nbd7 10. h3 Bh5 11. Ne5 Bxe2 12. Qxe2 Re8 13. f4 Ne4 14. Qd3
+f6 15. Nxd7 Qxd7 16. Rab1 Qc6 17. g4 Nxc3 18. Rbe1 Ne4 19. f5 Qc4 20. Kh2 c6
+21. Qxc4 dxc4 22. Bf4 Nc3 23. a3 Kf7 24. h4 Rad8 25. Rxe8 Rxe8 26. Kg2 Re2+ 27.
+Rf2 Rxf2+ 28. Kxf2 Nb5 29. a4 Nxd4 30. c3 Nb3 31. Bb8 a5 32. Bd6 b5 33. axb5
+cxb5 34. Ke3 g6 35. fxg6+ Kxg6 36. Kf4 Nc1 37. h5+ Kf7 38. Kf5 Ne2 39. Bc7 a4
+40. Bd8 a3 41. Bxf6 a2 42. g5 a1=Q 43. g6+ hxg6+ 44. hxg6+ Kg8 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "vassiukov"]
+[Black "Lil_D"]
+[Result "1-0"]
+[ECO "A40"]
+[WhiteElo "2338"]
+[BlackElo "2309"]
+[PlyCount "61"]
+[EventDate "2020.??.??"]
+
+1. d4 g6 2. Nf3 Bg7 3. Bf4 d6 4. e3 h6 5. h3 e6 6. Bd3 Ne7 7. c3 O-O 8. Qc2 a6
+9. h4 h5 10. e4 Nd7 11. Qd2 Nf6 12. Bh6 Ng4 13. Bxg7 Kxg7 14. Qe2 e5 15. Nbd2
+b5 16. a4 bxa4 17. Rxa4 c5 18. dxc5 dxc5 19. Nc4 Nc6 20. O-O Rb8 21. Rd1 Qe7
+22. Ne3 Be6 23. Nd5 Qb7 24. Rd2 a5 25. Ng5 Qb3 26. Rc4 a4 27. Rxc5 Rfc8 28.
+Nxe6+ fxe6 29. Bc4 Qb7 30. Rxc6 Rxc6 31. Nb4 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "ahmedSulaimaniyah16"]
+[Black "metalkingGT"]
+[Result "1-0"]
+[ECO "C05"]
+[WhiteElo "2404"]
+[BlackElo "2484"]
+[PlyCount "105"]
+[EventDate "2020.??.??"]
+
+1. e4 e6 2. d4 d5 3. Nd2 Nf6 4. e5 Nfd7 5. f4 f6 6. c3 fxe5 7. fxe5 Be7 8. Ngf3
+O-O 9. Bd3 c5 10. O-O g6 11. Bc2 Nc6 12. Nb3 cxd4 13. cxd4 Qb6 14. Bh6 Rxf3 15.
+Qxf3 Ncxe5 16. Qf2 a5 17. dxe5 Qxf2+ 18. Rxf2 Nxe5 19. Bf4 Ng4 20. Rff1 e5 21.
+Bg3 Be6 22. h3 Ne3 23. Rfc1 d4 24. Be4 a4 25. Nc5 Bd5 26. Bxd5+ Nxd5 27. Bxe5
+d3 28. Nxd3 Re8 29. Nf4 Bg5 30. Nxd5 Rxe5 31. Rc8+ Kg7 32. Rc7+ Kh6 33. Rd1 b5
+34. Rc3 Re2 35. Rg3 Rxb2 36. a3 Ra2 37. Nc7 Bf4 38. Rc3 Be5 39. Rc5 Bxc7 40.
+Rxc7 Rxa3 41. Rb7 Rb3 42. Ra1 a3 43. Kh2 b4 44. Ra2 Rb1 45. Rxa3 bxa3 46. Rxb1
+Kg5 47. Ra1 h5 48. Rxa3 Kh6 49. Ra5 h4 50. g3 g5 51. gxh4 gxh4 52. Kg2 Kg6 53.
+Kf3 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Morphysher"]
+[Black "LordGrim2500"]
+[Result "1-0"]
+[ECO "E62"]
+[WhiteElo "2309"]
+[BlackElo "2442"]
+[PlyCount "65"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. c4 Nf6 2. Nf3 g6 3. g3 Bg7 4. Bg2 O-O 5. O-O d6 6. d4 Nc6 7. Nc3 e5 8. dxe5
+Nxe5 9. Nxe5 dxe5 10. e4 c6 11. Be3 Be6 12. b3 Qe7 13. Qe2 Nd7 14. Na4 Rfd8 15.
+Rfd1 h5 16. h4 Kh7 17. Bg5 f6 18. Be3 Nf8 19. Bc5 Qe8 20. Rxd8 Qxd8 21. Rd1 Qe8
+22. Bxf8 Bxf8 23. Qd2 b5 24. cxb5 cxb5 25. Nc3 Bb4 26. Qe3 a6 27. Nd5 Bxd5 28.
+exd5 Bd6 29. Qb6 Qd8 30. Qb7+ Kh6 31. Rc1 f5 32. Rc6 Rb8 33. Qxa6 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "elpepinillo14"]
+[Black "Frogkiller"]
+[Result "1-0"]
+[ECO "B26"]
+[WhiteElo "2543"]
+[BlackElo "2376"]
+[PlyCount "45"]
+[EventDate "2020.??.??"]
+
+1. e4 c5 2. Nc3 d6 3. g3 Nc6 4. Bg2 g6 5. d3 Bg7 6. Be3 e6 7. Qd2 h6 8. Nge2
+Nge7 9. d4 b6 10. e5 cxd4 11. Nxd4 d5 12. f4 Nxd4 13. Bxd4 Ba6 14. O-O-O Rc8
+15. g4 h5 16. h3 Nc6 17. Kb1 Na5 18. f5 Nc4 19. Qf2 b5 20. fxe6 fxe6 21. Nxd5
+exd5 22. e6 Bxd4 23. Qf7# 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "camilomunoz0107"]
+[Black "Glig"]
+[Result "1-0"]
+[ECO "E06"]
+[WhiteElo "2367"]
+[BlackElo "2449"]
+[PlyCount "40"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 d5 2. c4 e6 3. Nf3 Nf6 4. g3 Be7 5. Bg2 O-O 6. O-O dxc4 7. Qc2 a6 8. Qxc4
+b5 9. Qc2 Bb7 10. Bg5 Nbd7 11. Nc3 Rc8 12. Rfd1 c5 13. dxc5 Rxc5 14. Qb3 Qa8
+15. Rxd7 Rxc3 16. Qxc3 Ne4 17. Qc7 Nxg5 18. Qxb7 Nxf3+ 19. Bxf3 Qxb7 20. Bxb7
+Bf6 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "C9C9C9C9C9"]
+[Black "drop_stone"]
+[Result "0-1"]
+[ECO "A13"]
+[WhiteElo "2983"]
+[BlackElo "2927"]
+[PlyCount "140"]
+[EventDate "2020.??.??"]
+
+1. Nf3 d5 2. c4 e6 3. e3 Nf6 4. b3 Bd6 5. Bb2 Nbd7 6. Nc3 a6 7. Be2 O-O 8. O-O
+Re8 9. h3 b6 10. Rc1 Bb7 11. d3 e5 12. cxd5 Nxd5 13. Ne4 Bf8 14. a3 h6 15. b4
+a5 16. b5 a4 17. Qc2 Nc5 18. Nxc5 Bxc5 19. Nxe5 Qg5 20. Nf3 Nxe3 21. Nxg5 Nxc2
+22. Rxc2 hxg5 23. Rfc1 Rad8 24. Bf1 Bd5 25. d4 Bd6 26. Bc4 Bxc4 27. Rxc4 Re2
+28. R4c2 Rde8 29. Kf1 R2e4 30. Rd1 f6 31. g3 Kf7 32. Rcd2 Ke6 33. d5+ Kd7 34.
+Rd4 Re2 35. R1d2 Re1+ 36. Kg2 Rb1 37. Rxa4 Ree1 38. Rc4 f5 39. a4 g4 40. hxg4
+fxg4 41. Rxg4 Rg1+ 42. Kf3 Kc8 43. Rxg7 Kb7 44. Rc2 Rbd1 45. Bc1 Rxc1 46. Rxc1
+Rxc1 47. Rg4 Rc3+ 48. Ke2 Bc5 49. Rf4 Rc2+ 50. Ke1 Ra2 51. g4 Bd6 52. Re4 Ra1+
+53. Ke2 Kc8 54. g5 Rg1 55. f4 Kd7 56. Kf3 Rf1+ 57. Kg4 Rd1 58. g6 Bf8 59. f5
+Rxd5 60. f6 Rd1 61. Kf5 Rf1+ 62. Rf4 Rg1 63. g7 Bxg7 64. fxg7 Rxg7 65. Rd4+ Kc8
+66. Ke4 Rd7 67. Kd3 Rxd4+ 68. Kxd4 Kd7 69. Kd5 Kc8 70. Ke6 Kb8 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Betovsky"]
+[Black "hungzhao"]
+[Result "0-1"]
+[ECO "C01"]
+[WhiteElo "2608"]
+[BlackElo "2643"]
+[PlyCount "76"]
+[EventDate "2020.??.??"]
+
+1. d4 e6 2. e4 d5 3. exd5 exd5 4. Bd3 c6 5. c3 Qf6 6. h3 Bd6 7. Qf3 Qxf3 8.
+Nxf3 Ne7 9. Nbd2 Bf5 10. O-O Bxd3 11. Re1 O-O 12. Re3 Bg6 13. Re1 Nf5 14. Nf1
+f6 15. g4 Ne7 16. Nh4 Nc8 17. f4 Nd7 18. f5 Bf7 19. Ng2 Ncb6 20. Bf4 Bxf4 21.
+Nxf4 Rfe8 22. Ne3 Nc4 23. Kf2 Nxe3 24. Rxe3 Rxe3 25. Kxe3 Re8+ 26. Kf2 g5 27.
+Nd3 Nb6 28. Nc1 Nc4 29. b3 Nd6 30. Ne2 Ne4+ 31. Kf3 b6 32. Rc1 Nd6 33. c4 dxc4
+34. bxc4 Bxc4 35. Kf2 Bd5 36. Nc3 Ne4+ 37. Kg2 Nxc3+ 38. Kh2 Ne2 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "terminator-t800"]
+[Black "Bulingot"]
+[Result "1-0"]
+[ECO "B33"]
+[WhiteElo "2322"]
+[BlackElo "2354"]
+[PlyCount "37"]
+[EventDate "2020.??.??"]
+
+1. e4 c5 2. Nf3 Nc6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 e5 6. Ndb5 d6 7. Bg5 a6 8.
+Na3 b5 9. Bxf6 gxf6 10. Nd5 f5 11. Bxb5 axb5 12. Nxb5 Ra4 13. Nbc7+ Kd7 14. O-O
+Rg8 15. Qh5 Qg5 16. Qxf7+ Ne7 17. g3 Rxe4 18. Rfd1 Qg7 19. Qe8# 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "aidenzhouu"]
+[Black "Maybach77"]
+[Result "0-1"]
+[ECO "D38"]
+[WhiteElo "2438"]
+[BlackElo "2377"]
+[PlyCount "72"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 Nf6 2. c4 e6 3. Nf3 d5 4. Nc3 Bb4 5. cxd5 exd5 6. Bg5 h6 7. Bh4 c5 8. e3
+Nc6 9. a3 Bxc3+ 10. bxc3 c4 11. Be2 O-O 12. O-O Re8 13. Qc2 Qd6 14. Bg3 Qe7 15.
+Ne5 Nxe5 16. Bxe5 Ne4 17. Bf3 f6 18. Bxe4 dxe4 19. Bg3 Bd7 20. Rab1 b5 21. Rfd1
+Qxa3 22. d5 a5 23. Rd4 f5 24. d6 Qc5 25. Rbd1 Rab8 26. Rd5 Qc6 27. Qd2 b4 28.
+Qd4 b3 29. Be5 b2 30. Rb1 Re6 31. Bxg7 a4 32. Bh8 Rg6 33. Rc5 Qxd6 34. Qxd6
+Rxd6 35. Be5 Rd1+ 36. Rxd1 b1=Q 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "EPThompson"]
+[Black "Klaksidee"]
+[Result "1-0"]
+[ECO "A01"]
+[WhiteElo "2551"]
+[BlackElo "2585"]
+[PlyCount "66"]
+[EventDate "2020.??.??"]
+
+1. b3 e5 2. Bb2 Nc6 3. e3 Bd6 4. Bb5 Nf6 5. Bxc6 dxc6 6. d3 Qe7 7. Nd2 O-O 8.
+Ngf3 b5 9. a4 Bb7 10. Qe2 a6 11. Nh4 g6 12. O-O c5 13. e4 Nxe4 14. Nxe4 Qxh4
+15. Qe3 f5 16. Nxd6 cxd6 17. f4 e4 18. d4 Qf6 19. Rab1 c4 20. d5 Qh4 21. Qd4
+Qh6 22. bxc4 bxc4 23. Bc3 Rab8 24. Qa7 g5 25. Rxb7 Rxb7 26. Qxb7 gxf4 27. Rxf4
+Rf7 28. Qc8+ Rf8 29. Qe6+ Qxe6 30. dxe6 Re8 31. Rxf5 Rxe6 32. Kf2 Re5 33. Bxe5
+dxe5 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "gaupasa"]
+[Black "SuperDonald"]
+[Result "1-0"]
+[ECO "B00"]
+[WhiteElo "2323"]
+[BlackElo "2335"]
+[PlyCount "67"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 Nc6 2. Nf3 d6 3. d4 Nf6 4. c3 e5 5. Bd3 d5 6. exd5 Qxd5 7. c4 Bb4+ 8. Nc3
+Qa5 9. O-O Bg4 10. d5 Nd4 11. Qe1 O-O 12. Nxe5 Rfe8 13. Bf4 Bd6 14. h3 Bh5 15.
+Qe3 c5 16. Qg3 Qc7 17. Ng4 Bxf4 18. Nxf6+ Kh8 19. Nxe8 Bxg3 20. Nxc7 Bxc7 21.
+Rae1 Bd6 22. Ne4 Bf8 23. f4 f5 24. Ng5 Bd6 25. Ne6 Kg8 26. Nxd4 cxd4 27. Bxf5
+Bb4 28. Be6+ Kf8 29. Re4 d3 30. g4 Bg6 31. f5 Be8 32. Rd1 d2 33. a3 Bc5+ 34.
+Kf1 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Chess-Network"]
+[Black "dmitrij_IM"]
+[Result "1-0"]
+[ECO "A70"]
+[WhiteElo "2704"]
+[BlackElo "2861"]
+[PlyCount "133"]
+[EventDate "2020.??.??"]
+
+1. d4 Nf6 2. Nf3 e6 3. c4 c5 4. d5 exd5 5. cxd5 d6 6. Nc3 g6 7. e4 Bg7 8. Bb5+
+Bd7 9. a4 O-O 10. O-O Bg4 11. Be2 Nbd7 12. Nd2 Bxe2 13. Qxe2 Re8 14. f3 a6 15.
+Nc4 Nb6 16. Ne3 Rc8 17. a5 Nbd7 18. Nc4 Ne5 19. Nb6 Rc7 20. Re1 Rce7 21. Qc2
+Nfd7 22. Nca4 Nxb6 23. Nxb6 Nd7 24. Nc4 Ne5 25. Ne3 Qc8 26. Bd2 h5 27. Bc3 c4
+28. Rad1 Nd3 29. Rxd3 cxd3 30. Qxd3 Bxc3 31. bxc3 Qc5 32. Qd4 Qxd4 33. cxd4 f5
+34. e5 dxe5 35. d6 Rd7 36. Nd5 Kf7 37. dxe5 Rxd6 38. Nf4 Rd4 39. g3 h4 40. Rb1
+hxg3 41. Rxb7+ Re7 42. e6+ Kf6 43. Rxe7 Kxe7 44. hxg3 g5 45. Ne2 Ra4 46. Kf2
+Kxe6 47. Ke3 Ke5 48. f4+ gxf4+ 49. gxf4+ Kf6 50. Nd4 Rxa5 51. Nc6 Rc5 52. Nb4
+Rc3+ 53. Kd4 Ra3 54. Nd5+ Ke6 55. Nb6 Kf6 56. Kc5 Ra5+ 57. Kc6 Rb5 58. Nd7+ Ke6
+59. Nf8+ Ke7 60. Nh7 Kf7 61. Ng5+ Kg6 62. Ne6 Rb3 63. Nd4 Rc3+ 64. Kb6 Kh5 65.
+Nc6 Kg4 66. Ne5+ Kg3 67. Nd7 1-0
+
+[Event "Rated Bullet tournament H3UwNQec"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Real-boy"]
+[Black "RhenzRheann_Auza98"]
+[Result "1-0"]
+[ECO "B10"]
+[WhiteElo "2582"]
+[BlackElo "2379"]
+[PlyCount "151"]
+[EventDate "2020.??.??"]
+
+1. e4 c6 2. c4 d5 3. cxd5 cxd5 4. exd5 Nf6 5. Nc3 Nxd5 6. Nf3 g6 7. Bc4 Nb6 8.
+Bb5+ Bd7 9. Ne5 Bxb5 10. Qf3 f6 11. Nxb5 fxe5 12. Qxb7 N8d7 13. Nc7+ Kf7 14.
+Nxa8 Qxa8 15. Qxa8 Nxa8 16. O-O Bg7 17. f4 Nab6 18. fxe5+ Ke6 19. d4 Nd5 20. b3
+N7b6 21. Bb2 Rc8 22. Rac1 Rd8 23. Rc6+ Kd7 24. Rfc1 Rc8 25. e6+ Kd8 26. Rxc8+
+Nxc8 27. Ba3 Nc7 28. Kh1 Nxe6 29. d5 Nc7 30. Rd1 Kd7 31. Bc5 Nd6 32. b4 Ncb5
+33. a4 Nc3 34. Rd3 Nxa4 35. Bxa7 Nb2 36. Rh3 Nbc4 37. Rxh7 Bf6 38. Bc5 g5 39.
+h4 Ne4 40. h5 Ng3+ 41. Kh2 Nf5 42. h6 Be5+ 43. Kh3 Nce3 44. g4 Nd6 45. Bxe3 Ne4
+46. Kg2 Nf6 47. Rf7 Nxg4 48. Bxg5 Nxh6 49. Rxe7+ Kd6 50. Rxe5 Kxe5 51. Bxh6
+Kxd5 52. Bf8 Kc4 53. Bc5 Kb5 54. Kf3 Kc6 55. Kf4 Kb5 56. Kf5 Kc6 57. Ke4 Kb5
+58. Kd3 Kc6 59. Kc3 Kb5 60. Kb3 Kc6 61. Kc4 Kb7 62. b5 Kb8 63. Kb4 Kb7 64. Bd4
+Kc8 65. Kc5 Kb7 66. b6 Kb8 67. Kb5 Kc8 68. Kc6 Kb8 69. Bc5 Kc8 70. Bd6 Kd8 71.
+b7 Ke8 72. b8=Q+ Kf7 73. Qf8+ Ke6 74. Qe7+ Kf5 75. Qe5+ Kg4 76. Kd5 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "MISSISSIPPIPLAYER"]
+[Black "BillyLaimbeer"]
+[Result "1-0"]
+[ECO "A45"]
+[WhiteElo "2400"]
+[BlackElo "2381"]
+[PlyCount "35"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 Nf6 2. Nc3 e6 3. e4 Bb4 4. e5 Ne4 5. Qf3 f5 6. Nge2 c5 7. d5 exd5 8. Qxf5
+Rf8 9. Qh5+ g6 10. Qxh7 Qb6 11. Bh6 Rf7 12. Qg8+ Ke7 13. O-O-O Nxc3 14. Bg5+
+Ke6 15. Qe8+ Kf5 16. Qxf7+ Kxg5 17. Qf4+ Kh5 18. Ng3# 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Mia_Khaliffa"]
+[Black "KingoFish"]
+[Result "1-0"]
+[ECO "B06"]
+[WhiteElo "2442"]
+[BlackElo "2404"]
+[PlyCount "69"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 g6 2. d4 Bg7 3. c3 Nf6 4. e5 Nd5 5. f4 d6 6. Nf3 O-O 7. Bd3 c5 8. h3 Nc6
+9. O-O cxd4 10. cxd4 Ncb4 11. Be4 f5 12. Bxd5+ Nxd5 13. Nc3 Nxc3 14. bxc3 d5
+15. Rb1 e6 16. Ba3 Rf7 17. Ng5 Rc7 18. Qb3 h6 19. Nf3 b6 20. Bd6 Rc6 21. Rbc1
+Ba6 22. Rf2 Bc4 23. Qa3 Kf7 24. Kh2 Bf8 25. Bxf8 Qxf8 26. Qxf8+ Rxf8 27. g4
+Rfc8 28. Kg3 Bd3 29. Ne1 Be4 30. gxf5 gxf5 31. Rd2 Rxc3+ 32. Rxc3 Rxc3+ 33. Kh2
+h5 34. Ng2 Rc1 35. Nh4 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Paanoos"]
+[Black "universe64"]
+[Result "0-1"]
+[ECO "B15"]
+[WhiteElo "2412"]
+[BlackElo "2398"]
+[PlyCount "40"]
+[EventDate "2020.??.??"]
+
+1. e4 c6 2. Nc3 d5 3. d4 Nf6 4. e5 Ng8 5. Nce2 Bg4 6. f3 Bf5 7. g4 Bg6 8. h4 h6
+9. h5 Bh7 10. Nf4 e6 11. Bd3 Bxd3 12. Qxd3 a5 13. c3 c5 14. Nge2 Nc6 15. Ng3
+Qb6 16. O-O cxd4 17. cxd4 Qxd4+ 18. Qxd4 Nxd4 19. Be3 Nc2 20. Rae1 Nxe3 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Zobbie"]
+[Black "Xychael27"]
+[Result "1-0"]
+[ECO "A00"]
+[WhiteElo "2378"]
+[BlackElo "2312"]
+[PlyCount "119"]
+[EventDate "2020.??.??"]
+
+1. a3 Nf6 2. b4 g6 3. Bb2 Bg7 4. d3 d6 5. Nd2 Kf8 6. Ngf3 Nc6 7. g3 e5 8. Bg2
+Kg8 9. O-O h6 10. e4 Kh7 11. Re1 Nh5 12. c3 Rf8 13. Nh4 Bf6 14. Nhf3 Bg7 15.
+Nc4 f5 16. Nh4 f4 17. d4 Bf6 18. Nf5 Bg5 19. dxe5 Nxe5 20. Nxe5 dxe5 21. Qxd8
+Rxd8 22. Nh4 Bxh4 23. gxh4 Nf6 24. Rad1 Be6 25. f3 Bc4 26. Bf1 b5 27. Bxc4 bxc4
+28. Kf2 a5 29. Ke2 axb4 30. cxb4 Rxd1 31. Rxd1 Re8 32. Rc1 Kg7 33. Rxc4 Kf7 34.
+Rxc7+ Re7 35. Rxe7+ Kxe7 36. Bxe5 Nh5 37. a4 Kd7 38. a5 Kc6 39. Bd4 Kb5 40. Bc5
+g5 41. hxg5 hxg5 42. Be7 Nf6 43. Bxf6 Ka6 44. Bxg5 Kb5 45. Bxf4 Ka6 46. e5 Kb5
+47. e6 Kc6 48. e7 Kd7 49. e8=Q+ Kxe8 50. a6 Kd7 51. a7 Kc8 52. a8=Q+ Kd7 53.
+Qd5+ Ke7 54. Qc6 Kf7 55. Qd6 Ke8 56. Qc7 Kf8 57. b5 Kg8 58. b6 Kf8 59. b7 Ke8
+60. b8=Q# 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "BlueGreensun"]
+[Black "Kidefence"]
+[Result "0-1"]
+[ECO "B03"]
+[WhiteElo "2767"]
+[BlackElo "2700"]
+[PlyCount "164"]
+[EventDate "2020.??.??"]
+
+1. e4 Nf6 2. e5 Nd5 3. d4 d6 4. c4 Nb6 5. exd6 cxd6 6. Nc3 g6 7. Be3 Bg7 8. Nf3
+O-O 9. Rc1 Bg4 10. b3 Nc6 11. d5 Ne5 12. Be2 Nxf3+ 13. Bxf3 Bxf3 14. Qxf3 Nd7
+15. O-O a6 16. Rfd1 Re8 17. Bd4 Bxd4 18. Rxd4 Nf6 19. h3 b5 20. Ne4 Nxe4 21.
+Rxe4 bxc4 22. bxc4 Qa5 23. Rce1 Qxa2 24. Rxe7 Rxe7 25. Rxe7 Rf8 26. Qf6 Qxc4
+27. Qxd6 a5 28. Ra7 a4 29. Qd7 a3 30. Kh2 a2 31. Qa4 Qxd5 32. Qxa2 Qe5+ 33. g3
+Qf5 34. Ra5 Qf6 35. Ra4 g5 36. h4 h6 37. hxg5 hxg5 38. Kg2 Kg7 39. Qd5 Rd8 40.
+Qe4 Qd6 41. Ra5 f6 42. Qf5 Rd7 43. Rc5 Re7 44. Rd5 Qe6 45. Qf3 Qe4 46. Rf5
+Qxf3+ 47. Kxf3 Kg6 48. Rc5 Ra7 49. Rc3 Ra4 50. Re3 Ra6 51. Rd3 Ra7 52. Rd2 Rg7
+53. Ke4 Rf7 54. Rc2 Re7+ 55. Kd5 Rg7 56. Ke6 Rg8 57. Ke7 Rg7+ 58. Kf8 Ra7 59.
+Rc6 Kf5 60. Rc5+ Ke6 61. Rc3 f5 62. Re3+ Kf6 63. Ke8 f4 64. gxf4 gxf4 65. Rd3
+Kf5 66. f3 Kg5 67. Kf8 Kh4 68. Rc3 Kg3 69. Rb3 Rc7 70. Ke8 Rc5 71. Ke7 Re5+ 72.
+Kf6 Re3 73. Rb2 Kxf3 74. Kf5 Ra3 75. Rc2 Ra5+ 76. Kf6 Ke3 77. Ra2 Rxa2 78. Kf5
+Rd2 79. Kg4 f3 80. Kg3 Rg2+ 81. Kh3 Kf4 82. Kh4 Rh2# 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "estocastico"]
+[Black "WildBreath"]
+[Result "1-0"]
+[ECO "E06"]
+[WhiteElo "2543"]
+[BlackElo "2400"]
+[PlyCount "91"]
+[EventDate "2020.??.??"]
+
+1. d4 Nf6 2. Nf3 e6 3. c4 d5 4. g3 Be7 5. Bg2 O-O 6. O-O dxc4 7. Qc2 a6 8. a4
+Bd7 9. Qxc4 Bc6 10. Bg5 Nbd7 11. Nc3 h6 12. Bxf6 Nxf6 13. Rfd1 Ne4 14. Qd3 Nxc3
+15. bxc3 Bf6 16. e4 Qd7 17. d5 exd5 18. exd5 Bxa4 19. Rd2 Rfd8 20. Nd4 Bxd4 21.
+Qxd4 c6 22. Qxa4 cxd5 23. Qxd7 Rxd7 24. Rxd5 Rc7 25. Rd3 Rac8 26. Ra3 g6 27.
+Bd5 Kg7 28. c4 Rd8 29. Rdb3 Rb8 30. Rb6 Rc5 31. Rf3 f5 32. Rfb3 a5 33. Rxb7+
+Rxb7 34. Rxb7+ Kf6 35. Rb5 Rxb5 36. cxb5 Ke5 37. b6 Kxd5 38. b7 a4 39. b8=Q Ke6
+40. Qb4 Kf6 41. Qxa4 Kg5 42. Qc6 Kh5 43. Qf6 g5 44. Kg2 Kg4 45. f3+ Kh5 46.
+Qf7# 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "dimochka_tsoi"]
+[Black "Tigerscot"]
+[Result "1-0"]
+[ECO "A02"]
+[WhiteElo "2662"]
+[BlackElo "2457"]
+[PlyCount "57"]
+[EventDate "2020.??.??"]
+
+1. f4 d6 2. Nf3 c6 3. e4 g6 4. g3 Bg7 5. Bg2 Nf6 6. d3 O-O 7. O-O a5 8. c3 Na6
+9. Qe2 e5 10. f5 Nc5 11. Nh4 d5 12. Be3 d4 13. cxd4 exd4 14. Bg5 Ncd7 15. e5
+Re8 16. e6 fxe6 17. fxe6 Nc5 18. Qe5 Nxe6 19. Bxf6 Bxf6 20. Qxf6 Qc7 21. Nxg6
+hxg6 22. Qxg6+ Ng7 23. Nd2 Be6 24. Ne4 Bf7 25. Nf6+ Kf8 26. Nxe8 Rxe8 27. Rxf7+
+Qxf7 28. Rf1 Re1 29. Qxf7# 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "uspanops70"]
+[Black "imdejong"]
+[Result "1-0"]
+[ECO "C15"]
+[WhiteElo "2309"]
+[BlackElo "2352"]
+[PlyCount "71"]
+[EventDate "2020.??.??"]
+
+1. e4 e6 2. d4 d5 3. Nc3 Bb4 4. Nge2 dxe4 5. a3 Bxc3+ 6. Nxc3 Nc6 7. Be3 Nf6 8.
+Qd2 b6 9. O-O-O Bb7 10. Be2 Ne7 11. f3 exf3 12. Bxf3 Bxf3 13. gxf3 Ned5 14. Bg5
+Nxc3 15. Qxc3 Qd5 16. Bxf6 gxf6 17. Qxc7 O-O 18. Rhg1+ Kh8 19. Qf4 Qf5 20. Qxf5
+exf5 21. Rge1 Rae8 22. d5 Re5 23. f4 Re4 24. d6 Rd8 25. c3 Kg7 26. Rxe4 fxe4
+27. Rd5 Kg6 28. d7 f5 29. Kd2 Kf6 30. Ke3 Ke6 31. c4 Rxd7 32. Re5+ Kf6 33. c5
+Rd3+ 34. Ke2 Rf3 35. c6 Rxf4 36. Rb5 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "hungzhao"]
+[Black "Betovsky"]
+[Result "0-1"]
+[ECO "B01"]
+[WhiteElo "2648"]
+[BlackElo "2602"]
+[PlyCount "112"]
+[EventDate "2020.??.??"]
+
+1. e4 d5 2. exd5 Nf6 3. Bb5+ Bd7 4. Be2 Bf5 5. d4 Nxd5 6. a3 c5 7. c4 Nc7 8.
+Nf3 cxd4 9. Nxd4 Bxb1 10. Rxb1 e5 11. Nf3 Qxd1+ 12. Kxd1 Nc6 13. Kc2 O-O-O 14.
+Rd1 Bc5 15. Be3 Bxe3 16. fxe3 f6 17. Rxd8+ Rxd8 18. Rd1 Rxd1 19. Kxd1 Kd7 20.
+Bd3 a5 21. Bxh7 Ke6 22. Be4 Nd8 23. b4 f5 24. Bc2 axb4 25. axb4 Na6 26. b5 Nc5
+27. Ke2 Nf7 28. h4 Nd6 29. Nd2 e4 30. g3 Ke5 31. Bb1 b6 32. Bc2 Ncb7 33. Bb1
+Na5 34. Ba2 Nab7 35. Bb1 Nc5 36. Bc2 g6 37. Bb1 Ndb7 38. Ba2 Na5 39. Bb1 Na4
+40. Bc2 Nc5 41. Bb1 Ncb7 42. Bc2 Nd6 43. Bb3 Nxb3 44. Nxb3 Nxc4 45. Nd4 Nd6 46.
+Kf2 Kd5 47. g4 Kc4 48. gxf5 gxf5 49. h5 f4 50. h6 Kd3 51. exf4 e3+ 52. Kf3 Nf7
+53. Nf5 Kd2 54. Nxe3 Kd3 55. Nd5 Kd4 56. Nxb6 Ne5+ 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "PimponNicois"]
+[Black "Phutressniak"]
+[Result "0-1"]
+[ECO "C96"]
+[WhiteElo "2342"]
+[BlackElo "2418"]
+[PlyCount "68"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3
+O-O 9. h3 Na5 10. Bc2 c5 11. d4 cxd4 12. cxd4 Nc6 13. Nc3 Bd7 14. Be3 Rc8 15.
+a4 Nb4 16. Bb1 Qc7 17. Qb3 Qc4 18. Qxc4 bxc4 19. dxe5 dxe5 20. Nxe5 Be6 21. Nf3
+Rfd8 22. Nd4 Bd7 23. e5 Ne8 24. Be4 Rb8 25. Re2 Nc7 26. Rd1 Ne6 27. Red2 Nc5
+28. Bb1 Nxa4 29. Nxa4 Bxa4 30. Rc1 Bb5 31. Nf5 Bf8 32. Nd6 Bxd6 33. exd6 Nd3
+34. b3 Nxc1 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "RigelStar"]
+[Black "Aisen_Mestnikov"]
+[Result "1-0"]
+[ECO "D43"]
+[WhiteElo "2396"]
+[BlackElo "2399"]
+[PlyCount "37"]
+[EventDate "2020.??.??"]
+
+1. d4 d5 2. Nf3 c6 3. c4 Nf6 4. Nc3 e6 5. Bf4 Bd6 6. Bg5 Be7 7. e3 O-O 8. Qc2
+Nbd7 9. Rd1 Re8 10. a3 Nf8 11. b4 Ng6 12. h4 h6 13. Bd3 hxg5 14. hxg5 Nd7 15.
+Bxg6 fxg6 16. Qxg6 Nf8 17. Qh5 dxc4 18. Qh8+ Kf7 19. Ne5# 1-0
+
+[Event "Rated Blitz tournament OxRShNHO"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "gustavo95"]
+[Black "luisangel1808"]
+[Result "0-1"]
+[ECO "C64"]
+[WhiteElo "2303"]
+[BlackElo "2370"]
+[PlyCount "134"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 e5 2. Nf3 Nc6 3. Bb5 Bc5 4. O-O Nd4 5. Nxd4 Bxd4 6. d3 c6 7. Ba4 Nf6 8.
+c3 Bb6 9. Qe2 O-O 10. Nd2 d5 11. Bc2 Re8 12. Rd1 Qe7 13. Nf1 Bg4 14. Qe1 Bxd1
+15. Bxd1 dxe4 16. dxe4 Rad8 17. Be3 Bxe3 18. Qxe3 b6 19. Bb3 Qc5 20. Qxc5 bxc5
+21. f3 Rd6 22. Kf2 Red8 23. Ke2 Kf8 24. Bc4 Ke7 25. Rc1 Ne8 26. Rc2 Nc7 27. Ne3
+g6 28. Ng4 f6 29. Ne3 Ne6 30. g3 Ng5 31. h4 Ne6 32. Ng4 h5 33. Ne3 Nc7 34. a4
+Na8 35. b3 Nb6 36. a5 Nd7 37. Ba6 Nf8 38. Nc4 R6d7 39. Ne3 Ne6 40. Bc4 Nc7 41.
+Nf1 Ne8 42. Rd2 Rxd2+ 43. Nxd2 Nd6 44. Bd3 Rb8 45. Kd1 c4 46. Bxc4 Nxc4 47.
+bxc4 Kd6 48. Kc2 Kc5 49. Kd3 Rd8+ 50. Kc2 Rxd2+ 51. Kxd2 Kxc4 52. Kc2 a6 53.
+Kd2 Kb3 54. f4 c5 55. f5 gxf5 56. exf5 Kc4 57. g4 hxg4 58. h5 g3 59. Ke2 g2 60.
+Kf2 Kd3 61. Kxg2 e4 62. h6 e3 63. Kf1 Kd2 64. h7 e2+ 65. Kg2 e1=Q 66. h8=Q Qe4+
+67. Kg3 Qxf5 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "GMshooter96"]
+[Black "petr_matyukov"]
+[Result "1-0"]
+[ECO "C00"]
+[WhiteElo "2377"]
+[BlackElo "2480"]
+[PlyCount "31"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 e6 2. d4 d5 3. Bd3 dxe4 4. Bxe4 Nf6 5. Bf3 c5 6. Ne2 Nc6 7. Be3 Nd5 8.
+Bxd5 Qxd5 9. Nbc3 Qxg2 10. Rg1 Qxh2 11. Bf4 Qh5 12. Nb5 e5 13. dxe5 Nxe5 14.
+Nc7+ Ke7 15. Bxe5 Qxe5 16. Nxa8 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Marohzevich"]
+[Black "corwinifred"]
+[Result "1-0"]
+[ECO "B40"]
+[WhiteElo "2475"]
+[BlackElo "2323"]
+[PlyCount "67"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 c5 2. Nf3 e6 3. b4 cxb4 4. Bb2 Nf6 5. e5 Nd5 6. a3 Nc6 7. Bc4 Nb6 8. Ba2
+Na4 9. Bc1 bxa3 10. Nxa3 Be7 11. O-O O-O 12. Re1 d6 13. exd6 Bxd6 14. Nc4 Be7
+15. Nce5 Bd7 16. Nxd7 Qxd7 17. Bxe6 fxe6 18. Rxa4 b5 19. Rae4 Rf6 20. Bb2 Rg6
+21. Qe2 b4 22. h4 Bf6 23. d4 Re8 24. Qc4 Kh8 25. Bc1 Bd8 26. h5 Rf6 27. h6 Rg8
+28. Rxe6 Rxe6 29. Qxe6 Qxe6 30. Rxe6 Ne7 31. Ne5 gxh6 32. Bxh6 Re8 33. Nf7+ Kg8
+34. Nxd8 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "sutcunuri"]
+[Black "ajedrez2021"]
+[Result "1/2-1/2"]
+[ECO "B06"]
+[WhiteElo "2517"]
+[BlackElo "2596"]
+[PlyCount "145"]
+[EventDate "2020.??.??"]
+
+1. e4 g6 2. e5 Bg7 3. f4 c5 4. Nf3 Nc6 5. Bb5 Qb6 6. Na3 Nh6 7. c3 O-O 8. d4
+cxd4 9. cxd4 d6 10. d5 Nb4 11. Qd2 a5 12. Qf2 Qxf2+ 13. Kxf2 dxe5 14. Nxe5 Nxd5
+15. Rd1 Rd8 16. h3 Be6 17. b3 Rac8 18. Bb2 Nxf4 19. Rxd8+ Rxd8 20. Re1 Bxe5 21.
+Bxe5 Nd3+ 22. Bxd3 Rxd3 23. Rc1 f6 24. Bf4 Nf5 25. Nc4 Bxc4 26. Rxc4 g5 27. Bc1
+Nd6 28. Ke2 Nxc4 29. Kxd3 Nd6 30. Kd4 Kf7 31. Kc5 Ke6 32. a4 Kd7 33. Bd2 Ne4+
+34. Kb6 Nxd2 35. Kxa5 Nxb3+ 36. Kb6 Nd4 37. Kxb7 Nb3 38. Kb6 e5 39. Kb5 Kd6 40.
+Kc4 Nd4 41. a5 Nc6 42. Kb5 Na7+ 43. Kb6 Nc6 44. a6 e4 45. Kb5 f5 46. Kc4 Ke5
+47. Kc5 Na7 48. Kb6 e3 49. Kxa7 e2 50. Kb7 e1=Q 51. a7 Qb4+ 52. Kc8 Qa4 53. Kb8
+Kf4 54. a8=Q Qxa8+ 55. Kxa8 Kg3 56. Kb7 Kh4 57. g4 Kg3 58. gxf5 g4 59. f6 gxh3
+60. f7 h2 61. f8=Q h1=Q+ 62. Kc7 Qe4 63. Kd7 Qd5+ 64. Qd6+ Qxd6+ 65. Kxd6 h5
+66. Ke5 h4 67. Kd4 h3 68. Ke3 h2 69. Ke2 h1=Q 70. Kd2 Qf3 71. Kc2 Qe4+ 72. Kd2
+Qd5+ 73. Kc2 1/2-1/2
+
+[Event "Rated Rapid game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Mivo11"]
+[Black "Fleetwood_Mac"]
+[Result "0-1"]
+[ECO "B01"]
+[WhiteElo "2435"]
+[BlackElo "2484"]
+[PlyCount "84"]
+[EventDate "2020.??.??"]
+[EventType "rapid"]
+
+1. e4 d5 2. exd5 Qxd5 3. Nc3 Qa5 4. d4 Nf6 5. Nf3 Bg4 6. h3 Bxf3 7. Qxf3 c6 8.
+Bd3 e6 9. O-O Bd6 10. Bd2 Qc7 11. Ne4 Nxe4 12. Bxe4 Nd7 13. c4 Nf6 14. Bd3 Rd8
+15. Bc3 O-O 16. Rad1 Be7 17. b3 a6 18. a4 b5 19. axb5 cxb5 20. Rc1 bxc4 21.
+bxc4 a5 22. Ra1 Bb4 23. Be2 Nd5 24. cxd5 Qxc3 25. dxe6 fxe6 26. Qe4 Qxd4 27.
+Qxe6+ Kh8 28. Rad1 Bd2 29. Qa2 Qc3 30. Bf3 Rd4 31. Qa1 Qc5 32. Rfe1 Bc3 33. Qc1
+Qb4 34. Rxd4 Qxd4 35. Rd1 Qb4 36. Qc2 Be5 37. Be4 a4 38. Bxh7 a3 39. Bg6 Bd4
+40. Rf1 Bxf2+ 41. Rxf2 Qe1+ 42. Kh2 Qxf2 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "psm-ajedrez"]
+[Black "H-Random"]
+[Result "0-1"]
+[ECO "C25"]
+[WhiteElo "2371"]
+[BlackElo "2362"]
+[PlyCount "54"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 e5 2. f4 Nc6 3. Nc3 Bc5 4. fxe5 d6 5. exd6 Qxd6 6. Nf3 Bg4 7. Bb5 O-O-O
+8. Bxc6 Qxc6 9. d3 f5 10. Qe2 Nf6 11. Bg5 Bd4 12. Bd2 fxe4 13. dxe4 Rhe8 14.
+O-O-O Bb6 15. Bg5 Rxd1+ 16. Rxd1 h6 17. Bxf6 Qxf6 18. h3 Qf4+ 19. Kb1 Bh5 20.
+Qd3 a6 21. g4 Bg6 22. Nh4 Bf7 23. Qd7+ Kb8 24. Qxf7 Qxf7 25. Nf5 Ba5 26. Nd5
+Rxe4 27. a3 Re1 0-1
+
+[Event "Rated Blitz tournament OxRShNHO"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Alfilparanoico"]
+[Black "elveneno"]
+[Result "1-0"]
+[ECO "B07"]
+[WhiteElo "2465"]
+[BlackElo "2464"]
+[PlyCount "147"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 Nf6 2. Nc3 g6 3. e4 d6 4. Bg5 Bg7 5. Qe2 O-O 6. O-O-O c6 7. e5 dxe5 8.
+dxe5 Nd5 9. Nxd5 cxd5 10. Qe1 Re8 11. Kb1 Nc6 12. f4 a6 13. Nf3 b5 14. Bd3 Qc7
+15. Qe2 Na5 16. Nd4 e6 17. Bf6 Bxf6 18. exf6 Qxf4 19. Qd2 Qxd4 20. Qxa5 Qxf6
+21. Rhf1 Qg7 22. Rf2 e5 23. Rdf1 Be6 24. a3 e4 25. Be2 f5 26. g4 fxg4 27. Rf6
+Bf5 28. Qb6 Rf8 29. Rd6 Qe5 30. Rd1 Qxh2 31. Bxg4 Bxg4 32. Rxg6+ hxg6 33. Qxg6+
+Kh8 34. Rxd5 Rg8 35. Qf6+ Rg7 36. Rg5 Qh7 37. Rxg4 Rag8 38. Rh4 Qxh4 39. Qxh4+
+Rh7 40. Qf6+ Rhg7 41. Qh4+ Rh7 42. Qxe4 Rg1+ 43. Ka2 Rg8 44. Qe5+ Rhg7 45. Qh5+
+Rh7 46. Qf5 Rh6 47. c3 Rg7 48. Qf4 Kh7 49. Qf5+ Rhg6 50. Qh5+ Kg8 51. Qf5 Rh6
+52. Qc8+ Kh7 53. Kb3 Rhg6 54. Qf5 Kg8 55. Qd5+ Kh7 56. Qa8 Kh6 57. Qh1+ Kg5 58.
+a4 Kf6 59. axb5 axb5 60. Qc6+ Kg5 61. Qxb5+ Kh6 62. Qe5 Kh7 63. Qe4 Kg8 64. Kc2
+Kh7 65. Kb1 Kg8 66. b4 Kh7 67. Kb2 Kg8 68. Kb3 Kh7 69. Qh4+ Kg8 70. Qd8+ Kf7
+71. b5 Ke6 72. Qd4 Kf5 73. Qd5+ Kg4 74. c4 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "alireza3700"]
+[Black "Frogkiller"]
+[Result "1-0"]
+[ECO "D00"]
+[WhiteElo "2341"]
+[BlackElo "2372"]
+[PlyCount "31"]
+[EventDate "2020.??.??"]
+
+1. d4 d5 2. Nc3 c6 3. Bg5 Qb6 4. e4 dxe4 5. f3 exf3 6. Nxf3 Bf5 7. Bd3 Bxd3 8.
+Qxd3 e6 9. O-O Nd7 10. Rae1 Ngf6 11. Ne5 Nxe5 12. Rxe5 Be7 13. Kh1 O-O 14. Bxf6
+Bxf6 15. Rh5 Qxd4 16. Qxh7# 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "MiroMiljkovic"]
+[Black "harry_p0tter"]
+[Result "1-0"]
+[ECO "A68"]
+[WhiteElo "2613"]
+[BlackElo "2623"]
+[PlyCount "111"]
+[EventDate "2020.??.??"]
+
+1. d4 Nf6 2. c4 c5 3. d5 e6 4. Nc3 exd5 5. cxd5 d6 6. e4 g6 7. f4 Bg7 8. Nf3
+O-O 9. Be2 Bg4 10. O-O Bxf3 11. Bxf3 Nbd7 12. Re1 Re8 13. a4 a6 14. Be3 Qb6 15.
+Qc2 Qa5 16. Kh1 Re7 17. Rad1 Rae8 18. e5 dxe5 19. d6 Re6 20. fxe5 Rxe5 21. Bf2
+Rxe1+ 22. Rxe1 Qb6 23. Rxe8+ Nxe8 24. Bg3 h5 25. Nd5 Qa5 26. Ne7+ Kh7 27. Qe2
+Ndf6 28. d7 Nxd7 29. Be4 Ndf6 30. Bd3 Qxa4 31. Be5 Qa1+ 32. Qf1 Qxf1+ 33. Bxf1
+Ng4 34. Bf4 Be5 35. Bd2 Bxb2 36. Nd5 Bd4 37. h3 Nf2+ 38. Kh2 Nd6 39. Bf4 Nfe4
+40. Be2 b5 41. Bf3 c4 42. Ne7 c3 43. Nd5 c2 44. Be2 Be5 45. Bxe5 c1=Q 46. Bf3
+Qe3 47. Nf6+ Nxf6 48. Bxd6 Qd4 49. Bg3 Qd6 50. h4 Qe7 51. Bf4 Ng4+ 52. Kg3
+Qxh4+ 53. Kxh4 f6 54. Bxg4 g5+ 55. Kxh5 f5 56. Bxf5+ 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Glig"]
+[Black "WhoozitWarriors"]
+[Result "0-1"]
+[ECO "B07"]
+[WhiteElo "2442"]
+[BlackElo "2597"]
+[PlyCount "134"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 d6 2. d4 Nd7 3. c3 Ngf6 4. Nd2 e5 5. Ngf3 Be7 6. Bc4 O-O 7. Bb3 c6 8. O-O
+a5 9. a3 Qc7 10. Re1 b5 11. h3 c5 12. a4 b4 13. Bc4 Bb7 14. d5 Nb6 15. Bb5 Bc8
+16. Nc4 Bd7 17. Nxb6 Qxb6 18. Bxd7 Nxd7 19. c4 g6 20. Bh6 Rfe8 21. Qd3 Bf8 22.
+Bd2 Bg7 23. Nh2 Rf8 24. Ng4 f5 25. exf5 gxf5 26. Nh6+ Bxh6 27. Bxh6 Rf6 28. Bg5
+Rf7 29. f4 Kh8 30. b3 Rg8 31. Qd2 Rg6 32. Re2 h6 33. Bh4 e4 34. Kh2 Qb8 35. Rg1
+Qg8 36. Bf2 Rfg7 37. Be3 Rg3 38. Qe1 Nf6 39. Qf1 Qf7 40. Bc1 Ng4+ 41. Kh1 Rg8
+42. Bb2+ Kh7 43. Qe1 e3 44. Rf1 Qh5 45. Qxg3 Nf2+ 46. Qxf2 exf2 47. Re7+ Kg6
+48. Rxf2 Qh4 49. Rfe2 Kh5 50. Bc1 Qg3 51. R7e6 Rg6 52. Re8 Qc3 53. Bb2 Qxb3 54.
+R8e3 Qxc4 55. Kh2 Qxd5 56. Re7 Qc4 57. Rf2 Qd3 58. Bf6 Qg3+ 59. Kg1 Rxf6 60.
+Re8 Rg6 61. Ree2 d5 62. Kf1 c4 63. Rf3 Qh2 64. Kf2 Qh1 65. Ke3 Qa1 66. Rd2 Qc3+
+67. Ke2 Qf6 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "dimochka_tsoi"]
+[Black "Olaffo"]
+[Result "1-0"]
+[ECO "A02"]
+[WhiteElo "2665"]
+[BlackElo "2519"]
+[PlyCount "83"]
+[EventDate "2020.??.??"]
+
+1. f4 e5 2. fxe5 d6 3. Nf3 Nc6 4. e4 dxe5 5. Nc3 Bc5 6. Bb5 Nf6 7. Nxe5 Qd4 8.
+Nd3 Nxe4 9. Qe2 f5 10. Nxe4 fxe4 11. Nxc5 Qxc5 12. Qxe4+ Qe7 13. Bxc6+ bxc6 14.
+Qxe7+ Kxe7 15. d4 Ba6 16. Bf4 Kd7 17. Kd2 Rae8 18. Rhe1 Rhf8 19. g3 h6 20. h4
+g5 21. hxg5 hxg5 22. Rxe8 Kxe8 23. Re1+ Kd7 24. Bxg5 Rf2+ 25. Kd1 Bb5 26. b3 a5
+27. a4 Ba6 28. Bd2 Rg2 29. Bxa5 Rxg3 30. Bd2 Bb7 31. Bf4 Rg4 32. Be5 c5 33.
+dxc5 Bf3+ 34. Kc1 Kc6 35. Kb2 Re4 36. Rf1 Be2 37. Rf6+ Kxc5 38. Bxc7 Bd1 39. c3
+Re2+ 40. Ka3 Bc2 41. c4 Bb1 42. Bb6# 1-0
+
+[Event "Rated Bullet tournament H3UwNQec"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "ScherlockKA"]
+[Black "digitalengineer"]
+[Result "1-0"]
+[ECO "A40"]
+[WhiteElo "2327"]
+[BlackElo "2336"]
+[PlyCount "1"]
+[EventDate "2020.??.??"]
+
+1. d4 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "vassiukov"]
+[Black "Caochonewell"]
+[Result "1-0"]
+[ECO "A46"]
+[WhiteElo "2343"]
+[BlackElo "2438"]
+[PlyCount "47"]
+[EventDate "2020.??.??"]
+
+1. d4 Nf6 2. Nf3 c5 3. Bf4 cxd4 4. c3 dxc3 5. Nxc3 d6 6. e4 g6 7. e5 dxe5 8.
+Qxd8+ Kxd8 9. Nxe5 Ke8 10. Bc4 e6 11. Nb5 Na6 12. Bg5 Nd7 13. Nxd7 Bxd7 14. Bf6
+Rg8 15. O-O Be7 16. Bd4 Rc8 17. Bd3 Bc5 18. Be5 Ke7 19. Rac1 Bxb5 20. Bxb5 Rgd8
+21. Rfe1 Bd4 22. Rxc8 Bxe5 23. Rxd8 Kxd8 24. Rxe5 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Aisen_Mestnikov"]
+[Black "RigelStar"]
+[Result "1-0"]
+[ECO "D43"]
+[WhiteElo "2394"]
+[BlackElo "2401"]
+[PlyCount "103"]
+[EventDate "2020.??.??"]
+
+1. d4 d5 2. c4 Nf6 3. Nf3 e6 4. Nc3 c6 5. g3 Bb4 6. Bg2 O-O 7. O-O Nbd7 8. a3
+Ba5 9. b4 Bc7 10. Nd2 Qe7 11. e4 dxc4 12. Nxc4 e5 13. d5 Nb6 14. d6 Qe6 15.
+dxc7 Nxc4 16. b5 Bd7 17. Bg5 cxb5 18. Bxf6 gxf6 19. Nd5 Bc6 20. Rc1 Qd6 21. Qh5
+Kh8 22. Rfd1 Rg8 23. Qh6 Rg6 24. Qh4 Bxd5 25. exd5 Qxc7 26. Be4 Rg7 27. d6 Qd7
+28. Qxf6 Rd8 29. a4 Qe6 30. Qxe6 fxe6 31. axb5 Nxd6 32. Bf3 Rgd7 33. Bg2 Nf7
+34. Rxd7 Rxd7 35. Rc8+ Kg7 36. Rb8 Kf6 37. Bf1 Rd1 38. Rxb7 Kg5 39. Rxa7 Nh6
+40. Rb7 Nf5 41. b6 e4 42. Kg2 e3 43. fxe3 Rd2+ 44. Kf3 Nxe3 45. Ke4 Rd5 46. Bd3
+Re5+ 47. Kd4 Ng4 48. Kc3 Nf6 49. Bc4 Rd5 50. Rg7+ Kf5 51. Bxd5 Ne4+ 52. Kd4 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "drop_stone"]
+[Black "C9C9C9C9C9"]
+[Result "0-1"]
+[ECO "B60"]
+[WhiteElo "2934"]
+[BlackElo "2976"]
+[PlyCount "76"]
+[EventDate "2020.??.??"]
+
+1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 Nc6 6. Bg5 Qb6 7. Bxf6 gxf6 8.
+Ndb5 a6 9. Nd5 Qa5+ 10. b4 Nxb4 11. Nbc7+ Kd8 12. Qd2 Rb8 13. Nxb4 Qxc7 14. Nd5
+Qc5 15. Be2 f5 16. exf5 Bxf5 17. O-O Be6 18. Bf3 Bg7 19. Rad1 b5 20. Rfe1 h6
+21. Nf4 Bd7 22. Qe2 e6 23. Nd3 Qb6 24. Nb4 a5 25. Nd3 Bc3 26. Rf1 b4 27. g3 Kc7
+28. Nf4 Bb5 29. Nd3 Rhg8 30. Qe4 Qd4 31. Qh7 Qf6 32. Qe4 d5 33. Qe3 Rb6 34.
+Qc5+ Kb7 35. a3 Rc8 36. Qe3 Bd4 37. Qe2 bxa3 38. Nf4 Bxe2 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Nurdin_Abubakar"]
+[Black "drdrunckenstein"]
+[Result "1-0"]
+[ECO "B08"]
+[WhiteElo "2372"]
+[BlackElo "2536"]
+[PlyCount "59"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 g6 2. d4 Bg7 3. Nc3 d6 4. Nf3 Nf6 5. Bc4 O-O 6. O-O Nc6 7. Be3 Ng4 8. Qd2
+Nxe3 9. fxe3 e5 10. Rad1 Kh8 11. h3 f5 12. exf5 Bxf5 13. Nd5 Be4 14. c3 exd4
+15. Nxd4 Nxd4 16. exd4 c6 17. Nf4 d5 18. Bd3 Bxd3 19. Qxd3 Qd7 20. Rde1 Rae8
+21. Rxe8 Rxe8 22. Qg3 Qe7 23. Kh1 Bh6 24. Nd3 Bg7 25. Rf3 Qe2 26. Qc7 Qe7 27.
+Rf7 Qxc7 28. Rxc7 Re3 29. Rc8+ Bf8 30. Rxf8+ 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "fullchola"]
+[Black "ahmedSulaimaniyah16"]
+[Result "1-0"]
+[ECO "A49"]
+[WhiteElo "2425"]
+[BlackElo "2411"]
+[PlyCount "131"]
+[EventDate "2020.??.??"]
+
+1. d4 Nf6 2. Nf3 g6 3. Nc3 Bg7 4. Bg5 O-O 5. Bxf6 Bxf6 6. h4 Bg7 7. e4 c5 8. d5
+Qa5 9. Qd2 h5 10. Bd3 d6 11. O-O Bg4 12. Ne1 Na6 13. f3 Bd7 14. a3 Nc7 15. Rb1
+Na6 16. f4 Qc7 17. f5 Bd4+ 18. Kh1 Bf6 19. g3 e6 20. Qh6 Bg7 21. Qg5 exf5 22.
+exf5 gxf5 23. Bxf5 Bxf5 24. Qxf5 Qe7 25. Qxh5 Qe3 26. Qg4 Rae8 27. Ng2 Qd4 28.
+Nf4 Kh8 29. Rbd1 Qe3 30. Qh5+ Kg8 31. Qg4 Nc7 32. Nh5 Qh6 33. Nf4 Kh8 34. Rde1
+Rxe1 35. Rxe1 Ne8 36. Ne4 Nf6 37. Nxf6 Bxf6 38. Kh2 Bxb2 39. Re7 Be5 40. Rxb7
+Rg8 41. Qf3 Bxf4 42. Qxf4 Qxf4 43. gxf4 Rg4 44. Kh3 Rxf4 45. Rxa7 Kg7 46. Kg3
+Kf6 47. Kxf4 c4 48. Ra6 c3 49. Rxd6+ Ke7 50. Rc6 f6 51. Rxc3 Kd7 52. Re3 Kd6
+53. Re6+ Kxd5 54. Rxf6 Kc5 55. Rf5+ Kc4 56. Re5 Kc3 57. Re3+ Kb2 58. a4 Ka2 59.
+a5 Kb2 60. c4 Kb1 61. c5 Kc1 62. c6 Kb2 63. c7 Ka1 64. c8=Q Ka2 65. Qc2+ Ka1
+66. Re1# 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Frogkiller"]
+[Black "alireza3700"]
+[Result "1-0"]
+[ECO "A00"]
+[WhiteElo "2366"]
+[BlackElo "2347"]
+[PlyCount "85"]
+[EventDate "2020.??.??"]
+
+1. g3 e5 2. Bg2 d5 3. c4 c6 4. cxd5 cxd5 5. Qb3 Nc6 6. Qxd5 Bd6 7. Nc3 Be6 8.
+Qb5 Nge7 9. Qxb7 Rc8 10. Nf3 O-O 11. O-O Rb8 12. Qa6 Nb4 13. Qa4 Bf5 14. d3
+Ned5 15. a3 Nxc3 16. bxc3 Nd5 17. Bd2 Qc7 18. Rab1 Rxb1 19. Rxb1 Nxc3 20. Bxc3
+Qxc3 21. Qb3 Qxb3 22. Rxb3 e4 23. Nh4 Be6 24. Rb7 exd3 25. exd3 Rc8 26. Be4
+Rc1+ 27. Kg2 g5 28. Nf3 g4 29. Nd4 Bc8 30. Rxa7 Bc5 31. Ra4 f5 32. Nxf5 Rc2 33.
+d4 Bxf5 34. Bxf5 Bd6 35. Bxg4 Ra2 36. Be6+ Kg7 37. Bxa2 Be7 38. h4 Kf6 39. Ra6+
+Kf5 40. Rh6 Kg4 41. Rxh7 Bf6 42. Rg7+ Bg5 43. Rxg5# 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "KeongDarat"]
+[Black "Phoenix-20"]
+[Result "0-1"]
+[ECO "B00"]
+[WhiteElo "2420"]
+[BlackElo "2481"]
+[PlyCount "42"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 a5 2. Nc3 a4 3. f4 h5 4. Nf3 h4 5. Bc4 d6 6. O-O h3 7. g3 e6 8. d4 b6 9.
+Be3 Bb7 10. Bb5+ c6 11. Bxa4 Nd7 12. Bb3 Ngf6 13. e5 Ng4 14. Bd2 dxe5 15. fxe5
+Be7 16. Ne4 c5 17. Neg5 Bxg5 18. Nxg5 Ndxe5 19. Ba4+ Rxa4 20. c3 Rxd4 21. Qb3
+Rxd2 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "dmitrij_IM"]
+[Black "Chess-Network"]
+[Result "1-0"]
+[ECO "A22"]
+[WhiteElo "2853"]
+[BlackElo "2713"]
+[PlyCount "119"]
+[EventDate "2020.??.??"]
+
+1. c4 Nf6 2. Nc3 e5 3. Nf3 d6 4. e3 Be7 5. d4 Nbd7 6. Be2 O-O 7. O-O Re8 8. Qc2
+Bf8 9. Rd1 Qe7 10. b3 c6 11. Ba3 e4 12. Nd2 h5 13. h3 h4 14. Bf1 g5 15. b4 Bh6
+16. b5 c5 17. dxc5 dxc5 18. Nb3 b6 19. Bb2 Bb7 20. Nd5 Nxd5 21. cxd5 Bg7 22.
+Bxg7 Kxg7 23. d6 Qe5 24. Bc4 f5 25. a4 Nf6 26. a5 f4 27. Ra2 g4 28. exf4 Qxf4
+29. Qd2 Qxd2 30. Rdxd2 e3 31. fxe3 Rxe3 32. axb6 axb6 33. Rxa8 Bxa8 34. d7 Nxd7
+35. Rxd7+ Kf6 36. hxg4 Rg3 37. Rd2 Rxg4 38. Bd5 Bxd5 39. Rxd5 Rb4 40. Nd2 Rxb5
+41. Nf3 Rb1+ 42. Kh2 c4 43. Rd6+ Ke7 44. Rc6 b5 45. Nxh4 Kd7 46. Rc5 Kd6 47.
+Rc8 Kd7 48. Rf8 c3 49. Rf2 b4 50. Nf3 b3 51. Nd4 b2 52. Rf7+ Kd6 53. Rb7 Kd5
+54. Ne2 Kc4 55. Nf4 c2 56. Rc7+ Kb3 57. Rb7+ Ka2 58. Nd3 Ra1 59. Nb4+ Kb1 60.
+Nxc2 1-0
+
+[Event "Rated Bullet tournament H3UwNQec"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Zuritadas"]
+[Black "Real-boy"]
+[Result "1/2-1/2"]
+[ECO "A10"]
+[WhiteElo "2393"]
+[BlackElo "2587"]
+[PlyCount "124"]
+[EventDate "2020.??.??"]
+
+1. c4 d5 2. cxd5 Qxd5 3. Nc3 Qd8 4. d4 Nf6 5. e4 g6 6. Nf3 Bg7 7. h3 O-O 8. Be3
+b6 9. Bd3 Bb7 10. O-O Nbd7 11. Qe2 c5 12. Rfd1 cxd4 13. Bxd4 Qe8 14. Rac1 e5
+15. Be3 Nh5 16. Nd5 Nf4 17. Bxf4 exf4 18. Nc7 Qe7 19. Nxa8 Rxa8 20. e5 Nc5 21.
+Bc2 Re8 22. b4 Bxf3 23. Qxf3 Nd7 24. e6 Qxe6 25. Bb3 Qe7 26. Rc7 Ne5 27. Rxe7
+Nxf3+ 28. gxf3 Rxe7 29. Rd8+ Bf8 30. Ra8 Kg7 31. Kg2 Rc7 32. b5 Bc5 33. Re8 Rd7
+34. Re2 Rd3 35. Rc2 h5 36. Re2 g5 37. Rc2 f5 38. Re2 Kf6 39. Re6+ Kg7 40. Re2
+g4 41. hxg4 hxg4 42. Re5 Rxf3 43. Rxf5 Rxf2+ 44. Kh1 f3 45. Rg5+ Kf6 46. Rxg4
+Rf1+ 47. Kh2 Bd6+ 48. Rf4+ Bxf4+ 49. Kh3 Rh1+ 50. Kg4 f2 51. Kf3 f1=Q+ 52. Ke4
+Qe2+ 53. Kd5 Rf1 54. Kc6 Qd2 55. Bd5 Rc1+ 56. Kb7 Qxd5+ 57. Kxa7 Qd7+ 58. Ka6
+Rb1 59. Kxb6 Rxb5+ 60. Ka6 Bd6 61. a4 Ra5+ 62. Kxa5 Qc6 1/2-1/2
+
+[Event "Rated Bullet tournament H3UwNQec"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "RhenzRheann_Auza98"]
+[Black "ScherlockKA"]
+[Result "1/2-1/2"]
+[ECO "A39"]
+[WhiteElo "2376"]
+[BlackElo "2333"]
+[PlyCount "72"]
+[EventDate "2020.??.??"]
+
+1. Nf3 c5 2. g3 g6 3. Bg2 Bg7 4. O-O Nf6 5. c4 O-O 6. Nc3 Nc6 7. d4 cxd4 8.
+Nxd4 Ne8 9. Nc2 Rb8 10. Bf4 d6 11. Be3 Bd7 12. Qd2 a6 13. Bh6 b5 14. cxb5 axb5
+15. Bxg7 Kxg7 16. Nd5 f6 17. Rfd1 Nc7 18. Ncb4 Nxb4 19. Qxb4 Nxd5 20. Bxd5 Qb6
+21. e3 Rfc8 22. Rac1 Rc5 23. Bg2 Rbc8 24. Rxc5 Rxc5 25. a4 Re5 26. a5 Qa7 27.
+Ra1 h5 28. a6 h4 29. Qa5 hxg3 30. hxg3 Bf5 31. b4 Rxe3 32. fxe3 Qxe3+ 33. Kh2
+Qh6+ 34. Kg1 Qe3+ 35. Kh1 Qh6+ 36. Kg1 Qe3+ 1/2-1/2
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "JiangoFett"]
+[Black "Atomrod"]
+[Result "0-1"]
+[ECO "E00"]
+[WhiteElo "2383"]
+[BlackElo "2496"]
+[PlyCount "109"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 e6 2. c4 Bb4+ 3. Nd2 c5 4. a3 Bxd2+ 5. Qxd2 cxd4 6. Nf3 Nc6 7. Nxd4 Nf6
+8. g3 d5 9. Bg2 O-O 10. O-O e5 11. Nxc6 bxc6 12. cxd5 cxd5 13. b4 Be6 14. Bb2
+Qd6 15. Qg5 Nd7 16. Rad1 Rac8 17. Qe3 d4 18. Qd2 Nb6 19. Ba1 Nc4 20. Qd3 Rfd8
+21. Rc1 g6 22. Rfd1 Bf5 23. Qb3 Qe6 24. b5 h5 25. a4 h4 26. Bc6 Na5 27. Qxe6
+Bxe6 28. Be4 Nb3 29. Rxc8 Rxc8 30. e3 Nxa1 31. Rxa1 dxe3 32. fxe3 hxg3 33. hxg3
+Rc3 34. Kf2 f5 35. Bc6 e4 36. a5 Rc2+ 37. Ke1 Rb2 38. b6 a6 39. b7 Kf7 40. Rd1
+Ke7 41. Rc1 Kd6 42. Kd1 g5 43. Ke1 Bd5 44. Bxd5 Kxd5 45. Rc7 g4 46. Rf7 Kc4 47.
+Rxf5 Kd3 48. Rd5+ Kxe3 49. Kd1 Rxb7 50. Rg5 Kf3 51. Rg6 e3 52. Rxa6 e2+ 53. Ke1
+Rb1+ 54. Kd2 e1=Q+ 55. Kc2 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "betman"]
+[Black "alphonsea"]
+[Result "0-1"]
+[ECO "A58"]
+[WhiteElo "2379"]
+[BlackElo "2321"]
+[PlyCount "66"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 Nf6 2. c4 c5 3. d5 b5 4. cxb5 a6 5. bxa6 g6 6. Nc3 Bg7 7. g3 O-O 8. Bg2
+d6 9. Nf3 Bxa6 10. O-O Nbd7 11. Qc2 Nb6 12. Rb1 Nbxd5 13. Nxd5 Nxd5 14. a3 Rc8
+15. Re1 Nf6 16. Bd2 Bb7 17. Bc3 Be4 18. Qc1 Bxb1 19. Qxb1 d5 20. e3 Ne4 21.
+Bxg7 Kxg7 22. Rd1 e6 23. Ne5 Qf6 24. f4 Rfd8 25. Bxe4 dxe4 26. Rxd8 Qxd8 27.
+Qxe4 Qd1+ 28. Kg2 Qe2+ 29. Kh3 Qh5+ 30. Kg2 Rd8 31. Qc2 Qd1 32. Qc3 Rd2+ 33.
+Kh3 Qh5# 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "BillyLaimbeer"]
+[Black "LordGrim2500"]
+[Result "0-1"]
+[ECO "B08"]
+[WhiteElo "2376"]
+[BlackElo "2434"]
+[PlyCount "116"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. Nf3 Nf6 2. d4 g6 3. Nc3 Bg7 4. e4 d6 5. Bc4 O-O 6. Qe2 c6 7. Bb3 Nbd7 8. e5
+Nd5 9. Bxd5 cxd5 10. Nxd5 dxe5 11. dxe5 Qa5+ 12. Nc3 Nxe5 13. Nxe5 Qxe5 14.
+Qxe5 Bxe5 15. Bd2 Bg4 16. f3 Bf5 17. O-O-O Rac8 18. g4 Be6 19. Rhe1 Bxh2 20.
+Bh6 Rfd8 21. Rxd8+ Rxd8 22. Ne4 b6 23. a3 Bd5 24. Bg5 Bxe4 25. Rxe4 f6 26. Bd2
+Kf7 27. a4 Bd6 28. c4 Rh8 29. Re1 h5 30. gxh5 gxh5 31. b4 h4 32. a5 bxa5 33. c5
+Bc7 34. b5 h3 35. Rh1 h2 36. Be3 Rb8 37. f4 Rxb5 38. Rxh2 a4 39. Ra2 Ra5 40.
+Kc2 a3 41. Kb3 a6 42. Kb4 Ke6 43. Rxa3 Rxa3 44. Kxa3 Ba5 45. Ka4 Be1 46. Kb3
+Kd5 47. Ka4 f5 48. Bg1 e6 49. Be3 Bc3 50. Bg1 Bd2 51. Bh2 Kxc5 52. Kb3 a5 53.
+Kc2 Be3 54. Kd3 Bd4 55. Bg3 a4 56. Kc2 Kc4 57. Be1 a3 58. Kb1 Kb3 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "MISSISSIPPIPLAYER"]
+[Black "Morphysher"]
+[Result "0-1"]
+[ECO "D35"]
+[WhiteElo "2408"]
+[BlackElo "2321"]
+[PlyCount "112"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 e6 2. c4 d5 3. Nc3 Nf6 4. e3 Bb4 5. cxd5 exd5 6. Bd3 O-O 7. Nge2 c5 8.
+Qc2 Nc6 9. Bd2 c4 10. Bf5 Bxf5 11. Qxf5 Ne7 12. Qh3 Ng6 13. O-O Re8 14. Ng3
+Bxc3 15. Bxc3 Ne4 16. Nxe4 Rxe4 17. a4 Qh4 18. Qxh4 Nxh4 19. a5 a6 20. Ra4 Rae8
+21. Rb4 R8e7 22. Rb6 f5 23. g3 Nf3+ 24. Kg2 Ng5 25. Ra1 R4e6 26. Rxe6 Rxe6 27.
+Ra4 Ne4 28. Rb4 Re7 29. Rb6 Kf7 30. h4 g6 31. h5 g5 32. Bb4 Rd7 33. f3 Nf6 34.
+Kh3 Nxh5 35. g4 Ng7 36. Rh6 Kg8 37. Rf6 fxg4+ 38. Kxg4 Rf7 39. Kxg5 h6+ 40. Kg6
+Rxf6+ 41. Kxf6 h5 42. Bd6 h4 43. Ke5 Ne8 44. Bb8 h3 45. Kxd5 Nf6+ 46. Kc5 Nd7+
+47. Kd6 Nxb8 48. Kc7 h2 49. Kxb8 h1=Q 50. Kxb7 Qxf3+ 51. Kb6 Qxe3 52. Kxa6 Qxd4
+53. Kb5 Qxb2+ 54. Kc5 c3 55. Kc4 c2 56. Kd3 c1=Q 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Tematico"]
+[Black "Odirovski"]
+[Result "0-1"]
+[ECO "B02"]
+[WhiteElo "2389"]
+[BlackElo "2460"]
+[PlyCount "122"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 Nf6 2. Nc3 d5 3. exd5 Nxd5 4. Ne4 Bf5 5. Ng3 Bg6 6. Nf3 Nc6 7. d4 Ndb4 8.
+Bd3 Nxd3+ 9. cxd3 Qd5 10. O-O e6 11. Be3 Bd6 12. Qc2 Nb4 13. Qa4+ b5 14. Qd1
+Bxd3 15. Re1 Bg6 16. Nh4 Qb7 17. Nxg6 hxg6 18. a3 Nd5 19. Ne4 Bxh2+ 20. Kf1 Bd6
+21. Qf3 b4 22. Nxd6+ cxd6 23. Kg1 O-O 24. axb4 Qxb4 25. g3 a5 26. Kg2 Qb7 27.
+Kh2 Rfb8 28. Re2 a4 29. Rh1 Nf6 30. Qf4 e5 31. Qh4 Qf3 32. Kg1 Qh5 33. Qxh5
+Nxh5 34. dxe5 dxe5 35. Kg2 Nf6 36. Ra1 Nd5 37. Bc5 f6 38. Ba3 Rb3 39. Rd2 Ra5
+40. Rad1 Rbb5 41. Rc2 Kf7 42. Rdc1 g5 43. Rc8 Ra7 44. g4 Rab7 45. Rf8+ Kg6 46.
+Rh1 Nf4+ 47. Kg3 Rb3+ 48. f3 e4 49. Re1 Rxf3+ 50. Kh2 Rh3+ 51. Kg1 Rg3+ 52. Kh1
+Rxg4 53. Rh8 Rb3 54. Rh2 e3 55. Rg1 Rxg1+ 56. Kxg1 e2 57. Kf2 Rd3 58. Ke1 Rd1+
+59. Kf2 Rf1+ 60. Kg3 e1=Q+ 61. Kg4 Qh4+ 0-1
+
+[Event "Rated Blitz tournament te4AhseI"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Cloud_ec"]
+[Black "mux77"]
+[Result "0-1"]
+[ECO "A48"]
+[WhiteElo "2443"]
+[BlackElo "2449"]
+[PlyCount "108"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 Nf6 2. Nf3 g6 3. Bf4 Bg7 4. e3 O-O 5. h3 d6 6. Be2 Nbd7 7. O-O b6 8. c3
+Bb7 9. Bh2 Qe8 10. a4 a6 11. Nbd2 e5 12. Nc4 e4 13. Nfd2 d5 14. Na3 Rc8 15. c4
+Qe7 16. a5 dxc4 17. axb6 cxb6 18. Naxc4 Rc6 19. Ne5 Nxe5 20. Bxe5 Rfc8 21. Bxa6
+Rc2 22. b3 Bxa6 23. Rxa6 Qb4 24. Nc4 Qxb3 25. Nd6 Rd8 26. Bxf6 Bxf6 27. Nxe4
+Bg7 28. Ra3 Qb2 29. Qa1 Qb4 30. Rb1 Qf8 31. Rxb6 Rdc8 32. Nc5 R2xc5 33. Rba6
+Rc1+ 34. Kh2 Rxa1 35. Rxa1 h5 36. g3 h4 37. g4 Qd8 38. Kg2 Qd5+ 39. Kg1 Rc2 40.
+Ra8+ Kh7 41. R8a4 Qf3 42. Rf1 Qxh3 43. Ra5 Qxg4+ 44. Kh1 Qf3+ 45. Kh2 Rxf2+ 46.
+Rxf2 Qxf2+ 47. Kh1 Qf3+ 48. Kh2 Qg3+ 49. Kh1 h3 50. Ra2 Bh6 51. Re2 Bxe3 52.
+Rxe3 Qxe3 53. Kh2 Qf3 54. Kg1 Qg2# 0-1
+
+[Event "Rated Blitz tournament te4AhseI"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "MiracleEcu"]
+[Black "Alberto_Santos"]
+[Result "0-1"]
+[ECO "B27"]
+[WhiteElo "2358"]
+[BlackElo "2316"]
+[PlyCount "78"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 c5 2. Nf3 g6 3. Nc3 Bg7 4. d4 cxd4 5. Nxd4 Nc6 6. Nb3 Bxc3+ 7. bxc3 Nf6
+8. f3 d5 9. exd5 Qxd5 10. Bb2 Qxd1+ 11. Rxd1 O-O 12. Nd4 Bd7 13. Nb5 a6 14. Na3
+b5 15. c4 b4 16. Nb1 Be6 17. Bd3 Na5 18. Nd2 Rfc8 19. O-O Nxc4 20. Nxc4 Bxc4
+21. Rfe1 Kf8 22. Be4 Rab8 23. a3 a5 24. axb4 axb4 25. Ra1 Be6 26. Ra7 Nxe4 27.
+Rxe4 Rxc2 28. Be5 Rb5 29. Ra8+ Rc8 30. Rxc8+ Bxc8 31. Rc4 Be6 32. Rc7 f6 33.
+Rc6 Rxe5 34. Rc8+ Bxc8 35. h4 b3 36. h5 b2 37. hxg6 b1=Q+ 38. Kh2 Qe1 39. f4
+Rh5# 0-1
+
+[Event "Rated Blitz tournament te4AhseI"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "LeninGuerra"]
+[Black "joseag1303"]
+[Result "0-1"]
+[ECO "B56"]
+[WhiteElo "2447"]
+[BlackElo "2325"]
+[PlyCount "108"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 e5 6. Nf3 h6 7. Be2 Be7 8. O-O
+O-O 9. b3 Nc6 10. Bb2 Be6 11. Re1 Re8 12. Bf1 Rc8 13. h3 a6 14. a4 Nb4 15. Qd2
+Nh5 16. g3 Qb6 17. Kh2 Rc6 18. a5 Qc7 19. Ba3 Rxc3 20. Bxb4 Rxf3 21. Bg2 Rf6
+22. c4 g6 23. Qxh6 Bf8 24. Qd2 Kh7 25. Rad1 Bh6 26. Qxd6 Qxd6 27. Bxd6 Rxf2 28.
+Bxe5 Bxh3 29. Kxh3 Rxe5 30. Rd7 Nf6 31. Rxf7+ Kg8 32. Rxf6 Rxf6 33. g4 Bg5 34.
+Rd1 Kf7 35. Rd7+ Re7 36. Rd5 Bf4 37. g5 Rfe6 38. Kg4 Be5 39. b4 Rd6 40. c5 Rxd5
+41. exd5 Re8 42. d6 Bc3 43. Bxb7 Bxb4 44. d7 Rd8 45. c6 Bxa5 46. Bxa6 Bc7 47.
+Bd3 Ke7 48. Bxg6 Kd6 49. Be4 Ke5 50. Bg2 Bd6 51. Kh5 Rg8 52. g6 Ke6 53. Kh6 Kf6
+54. Be4 Rh8# 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Kidefence"]
+[Black "BlueGreensun"]
+[Result "1-0"]
+[ECO "C21"]
+[WhiteElo "2707"]
+[BlackElo "2760"]
+[PlyCount "49"]
+[EventDate "2020.??.??"]
+
+1. e4 e5 2. d4 exd4 3. Nf3 c5 4. c3 dxc3 5. Nxc3 d6 6. Bc4 Nf6 7. Qb3 Be6 8.
+Bxe6 fxe6 9. Qxe6+ Be7 10. Ng5 Rf8 11. O-O Qd7 12. Qb3 Nc6 13. Ne6 Rg8 14. Nb5
+Rc8 15. Rd1 Na5 16. Qa4 a6 17. Nbc7+ Kf7 18. Qxa5 Nxe4 19. Bf4 Bf6 20. Qe1 Qc6
+21. f3 g5 22. Qxe4 gxf4 23. Qxf4 Ke7 24. Nd5+ Kxe6 25. Qxf6+ 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Betovsky"]
+[Black "hungzhao"]
+[Result "1-0"]
+[ECO "C00"]
+[WhiteElo "2609"]
+[BlackElo "2642"]
+[PlyCount "107"]
+[EventDate "2020.??.??"]
+
+1. d4 e6 2. e4 d6 3. Bd3 e5 4. Nf3 Nd7 5. dxe5 Nxe5 6. O-O Nf6 7. h3 Be7 8. Bf4
+Nxf3+ 9. Qxf3 O-O 10. Nc3 Be6 11. Rad1 Nd7 12. Nd5 Bxd5 13. exd5 Bf6 14. c3 g6
+15. Rfe1 Ne5 16. Qg3 Nxd3 17. Qxd3 Bg5 18. Bg3 Qd7 19. Re4 Rfe8 20. Rde1 Rxe4
+21. Qxe4 Kf8 22. h4 Bf6 23. h5 Re8 24. Qb1 Rxe1+ 25. Qxe1 Qe8 26. Qd2 Qe4 27.
+hxg6 hxg6 28. a3 b5 29. Qd1 a5 30. Qd2 a4 31. Qd1 Ke7 32. Qd2 Kd7 33. f3 Qb1+
+34. Kh2 Qf5 35. Kg1 g5 36. Qe2 Qxd5 37. Bf2 c6 38. Qc2 Ke6 39. Qh7 Qf5 40. Qg8
+Qb1+ 41. Kh2 Be5+ 42. g3 Qxb2 43. Kg2 Qxc3 44. Qc8+ Kd5 45. Qf5 Kc4 46. Qxf7+
+Kd3 47. Qf5+ Kd2 48. Qe4 Qd3 49. Qe1+ Kc2 50. Qg1 Qd2 51. Kh3 Qd3 52. Qe1 Qg6
+53. Qe2+ Kb3 54. Qe4 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "champblair"]
+[Black "estocastico"]
+[Result "0-1"]
+[ECO "B50"]
+[WhiteElo "2371"]
+[BlackElo "2547"]
+[PlyCount "70"]
+[EventDate "2020.??.??"]
+
+1. e4 c5 2. Nf3 d6 3. d4 Nf6 4. e5 dxe5 5. dxe5 Qxd1+ 6. Kxd1 Ng4 7. Ke1 Nc6 8.
+Bb5 Bd7 9. Bxc6 Bxc6 10. Bf4 g5 11. Bg3 h5 12. h4 gxh4 13. Rxh4 Bg7 14. Nc3
+O-O-O 15. Rd1 Bxf3 16. gxf3 Rxd1+ 17. Kxd1 Nxe5 18. Bxe5 Bxe5 19. Nd5 e6 20.
+Ne3 Bxb2 21. Ng2 f5 22. Nf4 Bf6 23. Rxh5 Rxh5 24. Nxh5 Be5 25. f4 Bd6 26. Ke2
+Kd7 27. Ke3 Ke7 28. Ng3 c4 29. Ne2 Bc5+ 30. Kf3 Kd6 31. Nc3 a6 32. Na4 Bd4 33.
+c3 Bf6 34. Ke3 b5 35. Nb2 Bxc3 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Son_Goku7"]
+[Black "Trommelwirbel"]
+[Result "0-1"]
+[ECO "B77"]
+[WhiteElo "2391"]
+[BlackElo "2357"]
+[PlyCount "148"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 g6 6. Be3 Bg7 7. f3 O-O 8. Qd2
+Nc6 9. Nb3 Na5 10. Nd4 Be6 11. O-O-O Rc8 12. Kb1 Bc4 13. b3 Bxf1 14. Rhxf1 a6
+15. Nd5 Nxd5 16. exd5 Qc7 17. c4 Nxc4 18. bxc4 Qxc4 19. Nb3 b5 20. Bh6 Bxh6 21.
+Qxh6 a5 22. Qd2 a4 23. Na5 Qh4 24. g3 Qf6 25. Nc6 e6 26. Nb4 Rc4 27. a3 Rfc8
+28. dxe6 fxe6 29. Qb2 Rc3 30. g4 Rb3 31. Qxb3 axb3 32. Rxd6 Qf4 33. Rfd1 Qxf3
+34. R6d3 Qxg4 35. R1d2 Qg1+ 36. Rd1 Qc5 37. Rxb3 Qf5+ 38. Kb2 Qe5+ 39. Ka2
+Qxh2+ 40. Rb2 Qe5 41. Rdd2 h5 42. Re2 Qf6 43. Rf2 Qg7 44. Rbe2 Rf8 45. Rg2 Rf6
+46. Nd3 Qc7 47. Rc2 Qd6 48. Nb4 Qe5 49. Rge2 Qd4 50. Red2 Qg4 51. Rg2 Qf5 52.
+Rc8+ Kg7 53. Rc7+ Kh6 54. Rcc2 Qf1 55. Rgd2 Rf3 56. Nc6 Qh3 57. Kb2 Rb3+ 58.
+Kc1 Qf1+ 59. Rd1 Qf4+ 60. Rdd2 Rxa3 61. Nd4 Ra1+ 62. Kb2 Ra4 63. Nb3 Re4 64.
+Rf2 Qe5+ 65. Ka2 Ra4+ 66. Kb1 h4 67. Rfe2 Re4 68. Rh2 g5 69. Nc5 Re1+ 70. Ka2
+Qa1+ 71. Kb3 Rb1+ 72. Rb2 Rxb2+ 73. Rxb2 Qd1+ 74. Ka3 Qd6 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "terminator-t800"]
+[Black "Zobbie"]
+[Result "1-0"]
+[ECO "B10"]
+[WhiteElo "2346"]
+[BlackElo "2382"]
+[PlyCount "75"]
+[EventDate "2020.??.??"]
+
+1. e4 c6 2. Nc3 d5 3. Nf3 a6 4. d4 Bg4 5. e5 e6 6. h3 Bh5 7. g4 Bg6 8. Bd3 c5
+9. Ne2 Nc6 10. c3 Qb6 11. O-O Nge7 12. a3 Bxd3 13. Qxd3 h5 14. g5 Nf5 15. b4
+cxd4 16. cxd4 g6 17. Be3 Be7 18. h4 O-O 19. Ng3 Rac8 20. Nxf5 exf5 21. Rac1 a5
+22. b5 Na7 23. a4 Rxc1 24. Rxc1 Rc8 25. Rxc8+ Nxc8 26. Qc2 Qd8 27. Bd2 Kf8 28.
+Bxa5 Qxa5 29. Qxc8+ Kg7 30. e6 fxe6 31. Qxe6 Qc7 32. Ne5 Bd6 33. Qxg6+ Kf8 34.
+Qxf5+ Ke7 35. Qf6+ Ke8 36. g6 Bxe5 37. dxe5 Qc1+ 38. Kg2 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Evgen_88"]
+[Black "NEKI_NOVI_KLINAC"]
+[Result "1/2-1/2"]
+[ECO "D35"]
+[WhiteElo "2537"]
+[BlackElo "2443"]
+[PlyCount "160"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 e6 2. c4 d5 3. Nc3 Nf6 4. cxd5 exd5 5. Bg5 b6 6. e3 Bb7 7. Be2 Nbd7 8.
+Nf3 Be7 9. Qb3 h6 10. Bh4 O-O 11. O-O c5 12. dxc5 Nxc5 13. Qc2 Nce4 14. Rac1
+Rc8 15. Qb3 Nxc3 16. Rxc3 Rxc3 17. bxc3 Ne4 18. Bxe7 Qxe7 19. c4 dxc4 20. Qxc4
+Rc8 21. Qb3 Nc5 22. Qa3 Bxf3 23. Bxf3 a5 24. Bd5 Qe5 25. Bc4 Rc6 26. g3 Rd6 27.
+Qc1 Ne4 28. Rd1 Qf5 29. f4 Qg4 30. Rxd6 Nxd6 31. Bd3 Qe6 32. Qd2 Nc4 33. Bxc4
+Qxc4 34. Qd8+ Kh7 35. Qxb6 Qxa2 36. Qb5 Qe6 37. Qxa5 Qxe3+ 38. Kg2 Qe4+ 39. Kg1
+f5 40. Qd2 Qb1+ 41. Kg2 Qb7+ 42. Kg1 Qf3 43. Qf2 Qd1+ 44. Kg2 h5 45. Qf1 Qd5+
+46. Qf3 Qe6 47. Qxh5+ Kg8 48. Qf3 g6 49. Qc3 Qe2+ 50. Kg1 Qd1+ 51. Kg2 Qe2+ 52.
+Kg1 Qh5 53. Qe3 Kf7 54. Qe5 Qd1+ 55. Kg2 Qd7 56. Qe3 Qb7+ 57. Qf3 Qe7 58. Qf2
+Kf6 59. Qf3 Qe4 60. Qxe4 fxe4 61. Kf2 Ke6 62. Ke3 Kd5 63. g4 Ke6 64. Kxe4 Kf6
+65. f5 g5 66. Kd5 Kg7 67. Ke6 Kh6 68. f6 Kg6 69. Ke5 Kh7 70. Kf5 Kh6 71. f7 Kg7
+72. Kxg5 Kf8 73. Kf5 Kxf7 74. g5 Kf8 75. g6 Kg8 76. Kf6 Kf8 77. g7+ Kg8 78. h3
+Kh7 79. Kf7 Kh6 80. g8=Q Kh5 1/2-1/2
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Olaffo"]
+[Black "dimochka_tsoi"]
+[Result "0-1"]
+[ECO "A04"]
+[WhiteElo "2515"]
+[BlackElo "2669"]
+[PlyCount "66"]
+[EventDate "2020.??.??"]
+
+1. Nf3 f5 2. d3 Nf6 3. e4 fxe4 4. dxe4 d6 5. Bd3 e5 6. O-O Be7 7. Bg5 O-O 8.
+Nc3 Kh8 9. h3 Nc6 10. Re1 Be6 11. Qd2 Nd7 12. Bxe7 Qxe7 13. Nd5 Bxd5 14. exd5
+Nd8 15. c4 Nf6 16. Bf5 Qf7 17. Ng5 Qh5 18. g4 Qh6 19. Kg2 g6 20. Be6 Kg7 21. f4
+Nxg4 22. Bxg4 Rxf4 23. Nf3 Nf7 24. c5 Rf8 25. cxd6 cxd6 26. Rac1 e4 27. Nd4
+Rxg4+ 28. hxg4 Qxd2+ 29. Ne2 Ne5 30. Kh3 Qe3+ 31. Kg2 Rf2+ 32. Kg1 Nf3+ 33. Kh1
+Rh2# 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "lord_barre"]
+[Black "MrMania"]
+[Result "0-1"]
+[ECO "D38"]
+[WhiteElo "2406"]
+[BlackElo "2388"]
+[PlyCount "51"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 Nf6 2. c4 e6 3. Nf3 d5 4. Nc3 Bb4 5. Bg5 h6 6. Bxf6 Qxf6 7. Qa4+ Nc6 8.
+e3 O-O 9. Qc2 dxc4 10. Bxc4 e5 11. d5 e4 12. Nd2 Ne5 13. Ncxe4 Qg6 14. Bf1
+Bxd2+ 15. Kxd2 Bf5 16. f3 Rad8 17. Qa4 Rxd5+ 18. Ke1 b5 19. Qb4 a5 20. Qxa5
+Bxe4 21. fxe4 Qxe4 22. Qc3 Nd3+ 23. Bxd3 Rxd3 24. Qc1 Rxe3+ 25. Kf1 Re8 26. Rg1
+0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Rama75"]
+[Black "fusionpro"]
+[Result "1-0"]
+[ECO "B22"]
+[WhiteElo "2467"]
+[BlackElo "2454"]
+[PlyCount "49"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 c5 2. d4 cxd4 3. c3 Nf6 4. e5 Nd5 5. Nf3 d6 6. cxd4 Nc6 7. Bc4 Nb6 8. Bb3
+dxe5 9. d5 Nd4 10. Nxd4 exd4 11. Qxd4 e6 12. Nc3 exd5 13. O-O Be6 14. Re1 Be7
+15. Qxg7 Bf6 16. Qh6 Rg8 17. Bf4 Rg6 18. Qxh7 Qd7 19. Nb5 Kf8 20. Nc7 Re8 21.
+Nxe8 Qxe8 22. Bd6+ Be7 23. Rxe6 fxe6 24. Bxe7+ Qxe7 25. Qxg6 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "jdjdejdejy"]
+[Black "vassiukov"]
+[Result "0-1"]
+[ECO "B01"]
+[WhiteElo "2310"]
+[BlackElo "2351"]
+[PlyCount "120"]
+[EventDate "2020.??.??"]
+
+1. e4 d5 2. d3 dxe4 3. dxe4 Qxd1+ 4. Kxd1 Nf6 5. f3 e5 6. Bc4 c6 7. a4 Na6 8.
+Bxa6 bxa6 9. Be3 Be6 10. b3 Rd8+ 11. Nd2 Bb4 12. Ne2 O-O 13. Kc1 Rd7 14. c3 Be7
+15. Kc2 Rfd8 16. Rad1 Nh5 17. g3 g5 18. g4 Nf4 19. Bxf4 gxf4 20. Nc1 c5 21. Nc4
+Bxc4 22. bxc4 Bd6 23. Rd5 Bc7 24. Rhd1 Rxd5 25. Rxd5 Rxd5 26. cxd5 h5 27. h3 c4
+28. Kb2 a5 29. Ne2 hxg4 30. hxg4 Kg7 31. Ng1 Kg6 32. Nh3 Bb6 33. Kc2 Bc5 34.
+Kd1 Kf6 35. Ke2 Be7 36. Nf2 Kg7 37. Nd1 Kf8 38. Nb2 Ke8 39. Nxc4 Kd7 40. Nxa5
+Kc7 41. Nc4 f6 42. Kd3 Kb7 43. Nd2 Ka6 44. Nb3 Bd6 45. c4 Bc7 46. c5 Bd8 47.
+Kc4 Kb7 48. d6 Kc6 49. a5 a6 50. Na1 Bxa5 51. Nc2 Bd8 52. Nb4+ Kd7 53. Nd5 Bc7
+54. Nb4 Bxd6 55. Kd5 Bxc5 56. Kxc5 a5 57. Na6 Ke6 58. Kc4 f5 59. Kb3 fxg4 60.
+Ka3 g3 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Yoseqpuedo"]
+[Black "Caochonewell"]
+[Result "1/2-1/2"]
+[ECO "A00"]
+[WhiteElo "2393"]
+[BlackElo "2431"]
+[PlyCount "157"]
+[EventDate "2020.??.??"]
+
+1. e3 Nf6 2. f4 g6 3. Nf3 Bg7 4. f5 O-O 5. fxg6 hxg6 6. Be2 d5 7. O-O c5 8. Qe1
+d4 9. Qh4 dxe3 10. Ng5 exd2 11. Nxd2 Nc6 12. Rxf6 Qd4+ 13. Qxd4 Nxd4 14. Rf2
+Nxc2 15. Rb1 Bd4 16. Ngf3 Bxf2+ 17. Kxf2 Bf5 18. h3 Rfd8 19. g4 Na3 20. gxf5
+Nxb1 21. fxg6 Nxd2 22. gxf7+ Kxf7 23. Bxd2 e6 24. Bg5 Rh8 25. h4 a6 26. Ke3 Kg6
+27. Bd3+ Kg7 28. Ne5 b5 29. Be4 Rad8 30. Bxd8 Rxd8 31. Kf4 Rd2 32. h5 Rxb2 33.
+Kg5 Rxa2 34. h6+ Kh8 35. Ng6+ Kg8 36. Ne7+ Kh8 37. Ng6+ Kg8 38. Ne7+ Kh8 39. h7
+Rh2 40. Ng6+ Kxh7 41. Nf4+ Kg7 42. Nxe6+ Kf7 43. Nxc5 Ke7 44. Kf5 Kd6 45. Nd3
+Rd2 46. Kf4 Rxd3 47. Bxd3 Kc5 48. Ke3 a5 49. Kd2 a4 50. Kc2 b4 51. Kb2 b3 52.
+Be4 Kb4 53. Bd3 a3+ 54. Kb1 Kc3 55. Be4 b2 56. Ka2 Kd2 57. Bb1 Kc1 58. Be4
+b1=Q+ 59. Bxb1 Kd2 60. Be4 Kc3 61. Bf5 Kd4 62. Bg6 Ke5 63. Bf7 Kd6 64. Bg8 Ke5
+65. Bf7 Kd6 66. Bb3 Ke5 67. Bc2 Kd6 68. Kb3 Ke5 69. Bb1 Kd6 70. Ba2 Ke5 71. Kc3
+Kd6 72. Kd3 Ke5 73. Ke3 Kd6 74. Ke4 Kc5 75. Ke5 Kb4 76. Ke4 Kc3 77. Bd5 Kb2 78.
+Bc4 a2 79. Bxa2 1/2-1/2
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "ajedrez2021"]
+[Black "sutcunuri"]
+[Result "0-1"]
+[ECO "A04"]
+[WhiteElo "2595"]
+[BlackElo "2518"]
+[PlyCount "36"]
+[EventDate "2020.??.??"]
+
+1. Nf3 b6 2. g3 Bb7 3. Bg2 g5 4. Nxg5 Bxg2 5. Rg1 Bb7 6. c3 e6 7. Nf3 Bg7 8. d4
+Ne7 9. Bh6 Bxh6 10. Qa4 Bg7 11. Na3 O-O 12. O-O-O a6 13. Qc2 b5 14. Ng5 Ng6 15.
+h4 h6 16. Nf3 f5 17. h5 Be4 18. Kb1 Bxc2+ 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "LeePalma"]
+[Black "emiliofelixramirez"]
+[Result "1-0"]
+[ECO "D20"]
+[WhiteElo "2407"]
+[BlackElo "2399"]
+[PlyCount "73"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 d5 2. c4 dxc4 3. e3 e5 4. Bxc4 Nc6 5. Nf3 exd4 6. exd4 Bb4+ 7. Nc3 Nf6 8.
+O-O O-O 9. h3 h6 10. Be3 Bf5 11. Rc1 a6 12. a3 Bd6 13. Re1 b5 14. Bd3 Bxd3 15.
+Qxd3 Qd7 16. Rcd1 Rfe8 17. d5 Na5 18. Bd4 Rxe1+ 19. Rxe1 Ne8 20. Ne5 Qe7 21.
+Re2 Qg5 22. Ne4 Qc1+ 23. Kh2 Nc4 24. Nxd6 Nexd6 25. Nc6 Qg5 26. g3 Kf8 27. Qh7
+f6 28. f4 Qxd5 29. Re7 Nf7 30. Rxf7+ Qxf7 31. Bc5+ Nd6 32. Qd3 Qe6 33. f5 Qd7
+34. Nd4 Kg8 35. Ne6 Re8 36. Qd5 Kh8 37. g4 1-0
+
+[Event "Rated Blitz tournament te4AhseI"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Stormart"]
+[Black "Fantasma94"]
+[Result "0-1"]
+[ECO "A11"]
+[WhiteElo "2357"]
+[BlackElo "2397"]
+[PlyCount "110"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. c4 c6 2. Nf3 d5 3. g3 Nf6 4. Bg2 Be6 5. cxd5 cxd5 6. O-O Nc6 7. d4 Bg4 8.
+Ne5 e6 9. Nxg4 Nxg4 10. Nc3 Be7 11. e4 Nf6 12. exd5 Nxd5 13. Nxd5 exd5 14. Qb3
+Nxd4 15. Qa4+ Nc6 16. Rd1 O-O 17. Bxd5 Qb6 18. Be3 Bc5 19. Bxc5 Qxc5 20. Rac1
+Qb6 21. Rd2 Ne5 22. Re1 Ng6 23. Qb3 Qxb3 24. Bxb3 Rfd8 25. Red1 Rxd2 26. Rxd2
+Ne5 27. Re2 Re8 28. Kg2 Kf8 29. Rc2 Nc6 30. Ba4 Re6 31. Bxc6 bxc6 32. Kf3 Ke7
+33. Re2 Kd6 34. Rxe6+ fxe6 35. Ke4 a5 36. f4 c5 37. b3 g6 38. g4 h6 39. h4 h5
+40. g5 Kd7 41. Ke5 Ke7 42. a3 a4 43. bxa4 Kd7 44. a5 Kc6 45. Kxe6 c4 46. f5 c3
+47. fxg6 c2 48. g7 c1=Q 49. g8=Q Qc4+ 50. Kf6 Qxg8 51. a6 Kd6 52. g6 Qf8+ 53.
+Kg5 Ke6 54. a7 Qf6+ 55. Kh6 Kf5 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "harry_p0tter"]
+[Black "MiroMiljkovic"]
+[Result "0-1"]
+[ECO "D00"]
+[WhiteElo "2617"]
+[BlackElo "2619"]
+[PlyCount "102"]
+[EventDate "2020.??.??"]
+
+1. d4 d5 2. Nc3 c6 3. f3 Nf6 4. e4 dxe4 5. fxe4 e5 6. Nf3 Bb4 7. Bg5 exd4 8.
+Qxd4 Qxd4 9. Nxd4 Nxe4 10. Bd2 Nxd2 11. Kxd2 O-O 12. Bd3 Rd8 13. Nf3 Bf5 14. a3
+Ba5 15. Rae1 Na6 16. b4 Bc7 17. Rhf1 Bf4+ 18. Ke2 Bxd3+ 19. cxd3 Nc7 20. Ne4
+Nd5 21. Kf2 h6 22. g3 Bc7 23. d4 Bb6 24. Rd1 a5 25. b5 cxb5 26. Ne5 b4 27. a4
+Nc3 28. Nxc3 bxc3 29. Nf3 c2 30. Rd2 Rac8 31. Rc1 Rc4 32. Rcxc2 Rxc2 33. Rxc2
+Bxd4+ 34. Ke2 b6 35. Rd2 Bf6 36. Rxd8+ Bxd8 37. Ne5 g5 38. Nc6 Bc7 39. Nd4 Kg7
+40. Nb5 Be5 41. g4 Kf6 42. h3 Ke6 43. Kd3 f5 44. gxf5+ Kxf5 45. Ke3 h5 46. Kf3
+g4+ 47. hxg4+ hxg4+ 48. Kg2 Ke4 49. Na7 Kd5 50. Nb5 Kc5 51. Nc7 Bxc7 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "petr_matyukov"]
+[Black "Brocha"]
+[Result "0-1"]
+[ECO "A50"]
+[WhiteElo "2472"]
+[BlackElo "2461"]
+[PlyCount "76"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 Nf6 2. c4 e6 3. Nc3 b6 4. e4 Bb7 5. Bd3 Bb4 6. Qc2 c5 7. d5 exd5 8. exd5
+d6 9. Nf3 b5 10. b3 Qe7+ 11. Be2 Ne4 12. Bb2 O-O 13. Kf1 Nxc3 14. Bxc3 Bxc3 15.
+Qxc3 b4 16. Qc2 Bc8 17. Bd3 g6 18. Re1 Qf6 19. h4 Bg4 20. Ng5 h6 21. Ne4 Qd8
+22. f3 Bf5 23. h5 Bxe4 24. Rxe4 g5 25. f4 Nd7 26. g3 Nf6 27. Re2 Re8 28. Qd2
+Ng4 29. fxg5 Qxg5 30. Qxg5+ hxg5 31. h6 Ne5 32. h7+ Kg7 33. Bf5 Rh8 34. g4 Rae8
+35. Kg2 Re7 36. Rhe1 Rhe8 37. Kh3 Kh8 38. Re4 a5 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Valema"]
+[Black "mixo23"]
+[Result "0-1"]
+[ECO "B10"]
+[WhiteElo "2307"]
+[BlackElo "2433"]
+[PlyCount "118"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 c6 2. Nf3 d5 3. Nc3 g6 4. g3 Bg7 5. Bg2 dxe4 6. Nxe4 Nd7 7. O-O Ngf6 8.
+d3 O-O 9. Re1 Nxe4 10. dxe4 Ne5 11. Nxe5 Bxe5 12. c3 Be6 13. Be3 Qa5 14. f4 Bg7
+15. Qc2 Rfd8 16. h3 Bc4 17. b3 Bd3 18. Qf2 Qxc3 19. Rac1 Qb4 20. Bc5 Qxc5 21.
+Rxc5 Bd4 22. Qxd4 Rxd4 23. e5 Rad8 24. a4 h5 25. Kh2 Bf5 26. Re2 Rd2 27. Re3
+Rb2 28. g4 Rdd2 29. gxf5 Rxg2+ 30. Kh1 gxf5 31. a5 Rgc2 32. Rg3+ Kf8 33. Rxc2
+Rxc2 34. h4 e6 35. Kg1 a6 36. Rd3 Ke7 37. Rg3 Rc5 38. Rg5 Rxa5 39. Rxh5 Rb5 40.
+Kg2 Rxb3 41. Rg5 a5 42. h5 a4 43. h6 a3 44. h7 Rb2+ 45. Kg3 Rb3+ 46. Kg2 Rb2+
+47. Kg3 Rb3+ 48. Kh4 Rb1 49. Rh5 Rh1+ 50. Kg5 Rxh5+ 51. Kxh5 a2 52. h8=Q a1=Q
+53. Qf6+ Ke8 54. Qh8+ Kd7 55. Kg5 Qg1+ 56. Kh4 Qh2+ 57. Kg5 Qg3+ 58. Kh5 Qg4+
+59. Kh6 Qg6# 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "RigelStar"]
+[Black "Aisen_Mestnikov"]
+[Result "1-0"]
+[ECO "A01"]
+[WhiteElo "2396"]
+[BlackElo "2399"]
+[PlyCount "123"]
+[EventDate "2020.??.??"]
+
+1. b3 b6 2. Bb2 Bb7 3. d4 d5 4. Nf3 e6 5. Nbd2 Ne7 6. e3 Ng6 7. c4 Bb4 8. cxd5
+Bxd5 9. a3 Be7 10. b4 a5 11. e4 Bb7 12. b5 c6 13. a4 cxb5 14. axb5 Nd7 15. Bd3
+O-O 16. O-O Nf4 17. Bc4 Rc8 18. Re1 Nf6 19. g3 Ng6 20. Bd3 Bb4 21. Ba3 Qe7 22.
+Qb3 Bxa3 23. Qxa3 Qxa3 24. Rxa3 Rfd8 25. Re3 Nd7 26. Nc4 e5 27. Nd6 exd4 28.
+Nxd4 Rc7 29. Nxb7 Rxb7 30. Nc6 Re8 31. Bc4 Nc5 32. Bd5 Rd7 33. f4 h6 34. h4 Ne7
+35. Bc4 Nc8 36. e5 Na7 37. Nxa7 Rxa7 38. Bd5 Rc7 39. Bc6 Rec8 40. Rac3 Rb8 41.
+Re1 a4 42. Rd1 Ra7 43. Ra3 Nb3 44. Rda1 Nc5 45. Rc1 Rc8 46. Rcc3 Ra5 47. Kf2
+Rd8 48. Ke3 Rd4 49. Kxd4 Nb3+ 50. Kc4 Nc5 51. Kb4 Ne6 52. Rc4 Nd4 53. Rxa4 Ne6
+54. Rxa5 bxa5+ 55. Kxa5 g6 56. b6 Kg7 57. b7 Nf8 58. b8=Q Ne6 59. Qd6 g5 60.
+Bd5 Kg6 61. Bxe6 Kh5 62. Bxf7+ 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "ahmedSulaimaniyah16"]
+[Black "Paanoos"]
+[Result "1-0"]
+[ECO "B03"]
+[WhiteElo "2406"]
+[BlackElo "2413"]
+[PlyCount "55"]
+[EventDate "2020.??.??"]
+
+1. e4 Nf6 2. e5 Nd5 3. c4 Nb6 4. d4 d6 5. exd6 cxd6 6. Nc3 g6 7. Be3 Bg7 8. Rc1
+O-O 9. b3 e5 10. d5 f5 11. f4 Na6 12. Nf3 Nc5 13. Bxc5 dxc5 14. Nxe5 Bxe5 15.
+fxe5 Re8 16. e6 Qf6 17. Be2 Qh4+ 18. g3 Qh3 19. Qd3 Bxe6 20. dxe6 Rxe6 21. Rf1
+Rae8 22. Rf2 f4 23. Qf3 Re3 24. Qxf4 Qe6 25. Kd2 Nd7 26. Bf3 Ne5 27. Bd5 Rd3+
+28. Kc2 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "alireza3700"]
+[Black "Frogkiller"]
+[Result "1-0"]
+[ECO "A00"]
+[WhiteElo "2342"]
+[BlackElo "2372"]
+[PlyCount "99"]
+[EventDate "2020.??.??"]
+
+1. d4 c5 2. Nc3 cxd4 3. Qxd4 Nc6 4. Qh4 Qa5 5. Qg5 Qxg5 6. Bxg5 a6 7. O-O-O e6
+8. e4 Bb4 9. Nge2 h6 10. Bh4 Nf6 11. Bxf6 gxf6 12. f4 Be7 13. g3 d6 14. Bg2 Bd7
+15. Nd4 Nxd4 16. Rxd4 Bc6 17. Rhd1 h5 18. Ne2 h4 19. Kb1 O-O-O 20. a3 Rdg8 21.
+Rc4 Kb8 22. b4 Bb5 23. Rdd4 Bxc4 24. Rxc4 hxg3 25. hxg3 Rh2 26. Bf3 Rf2 27. Rc3
+Bd8 28. Rd3 Bc7 29. Nd4 Rxg3 30. Bh5 Rxf4 31. Rxg3 Rxe4 32. Rg8+ Ka7 33. Nb3 d5
+34. Bxf7 Be5 35. Bxe6 Re1+ 36. Ka2 d4 37. Re8 a5 38. Bd7 a4 39. Nc5 d3 40. Rxe5
+fxe5 41. Nxd3 Re2 42. Bf5 e4 43. Kb1 exd3 44. Bxd3 Re3 45. Kb2 Re5 46. Bc4 Rg5
+47. Bd3 b5 48. c4 Kb6 49. c5+ Kc6 50. Be4+ 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "BlueGreensun"]
+[Black "Kidefence"]
+[Result "0-1"]
+[ECO "B03"]
+[WhiteElo "2754"]
+[BlackElo "2714"]
+[PlyCount "46"]
+[EventDate "2020.??.??"]
+
+1. e4 Nf6 2. e5 Nd5 3. d4 d6 4. c4 Nb6 5. f4 g6 6. Nf3 Bg7 7. Nc3 O-O 8. Be2
+Bg4 9. b3 Nc6 10. O-O dxe5 11. d5 exf4 12. Bb2 Bxf3 13. Bxf3 Nd4 14. Be4 e5 15.
+dxe6 Nxe6 16. Bxb7 Rb8 17. Be4 Qe7 18. Nd5 Nxd5 19. Bxg7 Ne3 20. Bxf8 Qxf8 21.
+Qd2 Nxf1 22. Rxf1 Rd8 23. Kh1 Rxd2 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "sutcunuri"]
+[Black "fullchola"]
+[Result "1-0"]
+[ECO "A00"]
+[WhiteElo "2525"]
+[BlackElo "2431"]
+[PlyCount "129"]
+[EventDate "2020.??.??"]
+
+1. d3 d6 2. Nd2 Nf6 3. Ngf3 Nbd7 4. g3 e5 5. Bg2 e4 6. dxe4 d5 7. e5 Ng4 8. c4
+Ndxe5 9. cxd5 Qxd5 10. O-O Qd8 11. Nc4 Nxf3+ 12. exf3 Qxd1 13. Rxd1 Nf6 14. Bf4
+c6 15. Re1+ Be6 16. Na5 b6 17. Nxc6 Bc5 18. Be5 O-O 19. f4 Rac8 20. a3 a5 21.
+b4 axb4 22. axb4 Rxc6 23. Bxc6 Bxb4 24. Red1 Bg4 25. Rdb1 Bc5 26. Rc1 Nd7 27.
+Bxd7 Bxd7 28. Rd1 Be6 29. Bd6 Rc8 30. Bxc5 bxc5 31. Rac1 c4 32. Rc3 g6 33. Kf1
+Rb8 34. Ke2 Kf8 35. Kd2 Ke7 36. Rc2 Rb3 37. Rc3 Rb7 38. Rdc1 Rd7+ 39. Kc2 Ra7
+40. Rb1 Ra2+ 41. Rb2 Ra7 42. Re3 Rd7 43. Kc3 Kf6 44. Rb4 Ra7 45. Rb6 Ra3+ 46.
+Kd4 Ra4 47. Rc6 Ra5 48. g4 Kg7 49. h3 Ra1 50. f3 Rd1+ 51. Kc3 Rc1+ 52. Kb4 Rh1
+53. Kc5 c3 54. Rcxe6 Rxh3 55. Rxc3 fxe6 56. Kd4 h5 57. Rc7+ Kf6 58. gxh5 gxh5
+59. Ke4 Rh4 60. Rh7 Rh2 61. Rh6+ Kg7 62. Rh8 Kxh8 63. f5 h4 64. fxe6 Rf2 65. f4
+1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "ajedrez2021"]
+[Black "tuntematon"]
+[Result "1-0"]
+[ECO "A04"]
+[WhiteElo "2588"]
+[BlackElo "2768"]
+[PlyCount "119"]
+[EventDate "2020.??.??"]
+
+1. Nf3 g6 2. g3 c5 3. Bg2 Nc6 4. O-O Bg7 5. c4 d6 6. Nc3 e5 7. d4 h6 8. d5 Nce7
+9. e4 f5 10. a3 Nf6 11. b4 b6 12. Rb1 O-O 13. bxc5 bxc5 14. Bd2 g5 15. Qa4 Nxe4
+16. Nxe4 fxe4 17. Ne1 Bg4 18. Nc2 Bf3 19. Ne3 Nf5 20. Nxf5 Rxf5 21. Rb7 Bf8 22.
+Rfb1 Bxg2 23. Kxg2 Qf6 24. Be3 Rf3 25. Qd7 Bg7 26. Qe6+ Qxe6 27. dxe6 Re8 28.
+e7 Rf7 29. Rxa7 Rfxe7 30. Rxe7 Rxe7 31. a4 Ra7 32. Ra1 Kf7 33. a5 Ra6 34. Bd2
+Ke6 35. Rb1 Bf6 36. Rb8 Kd7 37. Rf8 Bd8 38. Rh8 Bxa5 39. Rh7+ Kc6 40. Bxa5 Rxa5
+41. Rxh6 Ra4 42. Rg6 Rxc4 43. Rxg5 Rb4 44. h4 Rb8 45. h5 Rh8 46. h6 Kd5 47. Rh5
+c4 48. g4 c3 49. g5 c2 50. Rh1 Ke6 51. Rc1 Rg8 52. Rxc2 Rxg5+ 53. Kf1 Rh5 54.
+Rc8 Rxh6 55. Rh8 Kf5 56. Rxh6 d5 57. Rh8 d4 58. Rf8+ Ke6 59. Rd8 Kf5 60. Rf8+
+1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Chess-Network"]
+[Black "dmitrij_IM"]
+[Result "0-1"]
+[ECO "A46"]
+[WhiteElo "2709"]
+[BlackElo "2857"]
+[PlyCount "104"]
+[EventDate "2020.??.??"]
+
+1. d4 Nf6 2. Nf3 e6 3. Bf4 d5 4. e3 Bd6 5. Bg3 c5 6. c3 Qc7 7. Nbd2 Nbd7 8. Bd3
+e5 9. dxe5 Nxe5 10. Bxe5 Bxe5 11. Nxe5 Qxe5 12. Qf3 Bg4 13. Qg3 Qxg3 14. hxg3
+O-O-O 15. f3 Be6 16. Kf2 g6 17. g4 h5 18. g5 Nd7 19. b4 Ne5 20. Be2 d4 21. cxd4
+cxd4 22. Rac1+ Kb8 23. Ne4 dxe3+ 24. Kxe3 Bf5 25. Rhd1 Bxe4 26. Kxe4 Rde8 27.
+Kf4 Re7 28. Bb5 a6 29. Ba4 Rc8 30. Rxc8+ Kxc8 31. Bb3 Kc7 32. Rd5 Nc6 33. a3
+Re2 34. Rc5 Re7 35. Bd5 Kd6 36. Bxc6 bxc6 37. g4 h4 38. Rc2 Re1 39. Rd2+ Ke6
+40. Rh2 Ra1 41. Rxh4 Rxa3 42. Rh8 Ra4 43. Ra8 c5 44. Kg3 cxb4 45. Rb8 a5 46.
+Rb6+ Kd5 47. f4 Ra3+ 48. Kf2 b3 49. f5 a4 50. fxg6 fxg6 51. Rxg6 b2 52. Rb6 Rb3
+0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Cebuanochessking"]
+[Black "FedaMaster"]
+[Result "0-1"]
+[ECO "B01"]
+[WhiteElo "2428"]
+[BlackElo "2544"]
+[PlyCount "78"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 d5 2. exd5 Qxd5 3. Nc3 Qd6 4. d4 Nf6 5. Bc4 a6 6. a4 Bg4 7. f3 Bh5 8.
+Nge2 Nc6 9. Bf4 Qb4 10. Bb3 O-O-O 11. d5 e6 12. Bd2 exd5 13. Nxd5 Nxd5 14. Bxb4
+Bxb4+ 15. c3 Nxc3 16. bxc3 Rxd1+ 17. Rxd1 Bc5 18. Nd4 Re8+ 19. Kf2 Rd8 20. g4
+Bg6 21. Kg2 Nxd4 22. cxd4 Rxd4 23. h4 Rb4 24. Bd5 c6 25. h5 Rb2+ 26. Kh3 Bc2
+27. Rd2 Bb4 28. Rg2 cxd5 29. Rhh2 Kd7 30. Rxc2 Rxc2 31. Rxc2 d4 32. Rc4 Bc3 33.
+Kg3 b5 34. axb5 axb5 35. Rc5 b4 36. Kf2 b3 37. Rb5 b2 38. Ke2 Kc6 39. Kd3 Kxb5
+0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "dimochka_tsoi"]
+[Black "Olaffo"]
+[Result "1-0"]
+[ECO "A02"]
+[WhiteElo "2672"]
+[BlackElo "2512"]
+[PlyCount "91"]
+[EventDate "2020.??.??"]
+
+1. f4 e5 2. fxe5 d6 3. Nf3 Nc6 4. e4 dxe5 5. Bb5 Bc5 6. c3 Bg4 7. h3 Bh5 8. g4
+Bg6 9. d4 exd4 10. cxd4 Bb4+ 11. Bd2 Bxd2+ 12. Nbxd2 Nf6 13. e5 Ne4 14. Nxe4
+Bxe4 15. Qe2 Bd5 16. O-O O-O 17. Bxc6 Bxc6 18. Kh2 Qd5 19. Rad1 Rae8 20. Qe3 f6
+21. Rde1 Qxa2 22. e6 Qxb2+ 23. Rf2 Qb5 24. Nh4 Bd5 25. e7 Rf7 26. Nf5 Qd7 27.
+g5 Be6 28. Qxe6 Qxe6 29. Rxe6 fxg5 30. Kg3 h6 31. d5 a5 32. Kg4 a4 33. Rfe2 g6
+34. Nxh6+ Kg7 35. Nxf7 Kxf7 36. d6 cxd6 37. Kxg5 a3 38. Rf6+ Kg7 39. Rxg6+ Kf7
+40. Rf6+ Kg7 41. Ree6 a2 42. Rf1 b5 43. Rg6+ Kh7 44. Rf7+ Kh8 45. Kh6 Rxe7 46.
+Rf8# 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "leopslr"]
+[Black "Club-Jaque-al-Rey"]
+[Result "1-0"]
+[ECO "D06"]
+[WhiteElo "2418"]
+[BlackElo "2520"]
+[PlyCount "111"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 d5 2. c4 c5 3. cxd5 Qxd5 4. Nf3 cxd4 5. Qxd4 Nf6 6. Nc3 Qxd4 7. Nxd4 a6
+8. e4 e5 9. Nc2 Nc6 10. Bg5 Be7 11. Bxf6 Bxf6 12. Nd5 Bd8 13. O-O-O Ne7 14.
+Nce3 Be6 15. Kb1 Nxd5 16. exd5 Bd7 17. Bd3 g6 18. Nc4 f6 19. Nd6+ Ke7 20. Nxb7
+Bb6 21. d6+ Kf7 22. Be4 Ra7 23. Rc1 Rb8 24. Nc5 Bxc5 25. Rxc5 Ke6 26. Rd1 Rc8
+27. Ra5 f5 28. Bd5+ Kf6 29. Bb3 Be6 30. Ba4 Rd8 31. a3 e4 32. Rc5 Bc8 33. b4
+Rb7 34. Bc6 Rb6 35. d7 Bb7 36. Ba4 Ke7 37. Kb2 Rd6 38. Re5+ Re6 39. Rxe6+ Kxe6
+40. Kc3 Ke5 41. Kc4 f4 42. Kc5 e3 43. fxe3 fxe3 44. Kb6 Bxg2 45. Kc7 Rf8 46.
+d8=Q Rxd8 47. Rxd8 Bf3 48. Re8+ Kf4 49. Kd6 e2 50. Bb3 Be4 51. Rf8+ Ke3 52. Re8
+e1=Q 53. Bd5 Qd2 54. Rxe4+ Kf2 55. Re6 Qa2 56. Bxa2 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "uspanops70"]
+[Black "imdejong"]
+[Result "1-0"]
+[ECO "C15"]
+[WhiteElo "2319"]
+[BlackElo "2349"]
+[PlyCount "49"]
+[EventDate "2020.??.??"]
+
+1. e4 e6 2. d4 d5 3. Nc3 Bb4 4. Nge2 dxe4 5. a3 Bxc3+ 6. Nxc3 Nc6 7. Be3 Nf6 8.
+Qd2 b6 9. O-O-O Bb7 10. Be2 Qe7 11. f3 O-O-O 12. fxe4 Nxd4 13. Bxd4 e5 14. Qe3
+exd4 15. Rxd4 Rxd4 16. Qxd4 Rd8 17. Qa4 Nxe4 18. Qxa7 Nxc3 19. Bg4+ Rd7 20.
+Bxd7+ Qxd7 21. bxc3 Bxg2 22. Rd1 Qf5 23. Qa6+ Bb7 24. Qd3 Qc5 25. Qd8# 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "hungzhao"]
+[Black "Betovsky"]
+[Result "1/2-1/2"]
+[ECO "B01"]
+[WhiteElo "2636"]
+[BlackElo "2615"]
+[PlyCount "128"]
+[EventDate "2020.??.??"]
+
+1. e4 d5 2. exd5 Nf6 3. Bb5+ Bd7 4. Be2 Nxd5 5. d4 Nf6 6. a3 Bf5 7. Nf3 c5 8.
+O-O e6 9. Be3 cxd4 10. Nxd4 Bg6 11. Bf3 Be4 12. Nc3 Bxf3 13. Qxf3 Qc8 14. Ndb5
+Nc6 15. Rad1 Be7 16. Nd6+ Bxd6 17. Rxd6 O-O 18. Rfd1 Ne5 19. Qg3 Nc4 20. R6d4
+Nxe3 21. Qxe3 a6 22. Qf3 Qc7 23. g3 b5 24. Kg2 Rad8 25. Rxd8 Rxd8 26. Rxd8+
+Qxd8 27. Ne4 Ne8 28. Qd3 Qc7 29. b4 h6 30. Nc5 Nf6 31. Qf3 Qa7 32. Qc6 Nd5 33.
+Qxa6 Qe7 34. Qxb5 Qf6 35. Qd3 Qb2 36. c4 Nc3 37. Ne4 Nxe4 38. Qxe4 Qxa3 39. c5
+Qa6 40. c6 Qc8 41. Qc4 f5 42. b5 Qc7 43. Qc5 Kf7 44. b6 Qe7 45. Qxe7+ Kxe7 46.
+b7 Kf6 47. b8=Q f4 48. Qc7 f3+ 49. Kxf3 g5 50. Qd8+ Kg6 51. Qe8+ Kf5 52. Qxe6+
+Kxe6 53. c7 g4+ 54. Kxg4 h5+ 55. Kxh5 Kf6 56. c8=Q Ke7 57. Qc7+ Ke6 58. Qc5 Kf6
+59. Qg5+ Ke6 60. Kg4 Kd6 61. h4 Kd7 62. h5 Ke8 63. Qg6+ Kf8 64. Kf5 Ke7 1/2-1/2
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "ditzoo"]
+[Black "aidenzhouu"]
+[Result "0-1"]
+[ECO "C11"]
+[WhiteElo "2422"]
+[BlackElo "2431"]
+[PlyCount "104"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 e6 2. d4 d5 3. Nc3 Nf6 4. e5 Nfd7 5. f4 c5 6. Nf3 Nc6 7. Be3 cxd4 8. Nxd4
+Bc5 9. Qd2 a6 10. Qf2 Qe7 11. O-O-O O-O 12. Bd3 Bxd4 13. Bxd4 b5 14. Ne2 b4 15.
+g4 a5 16. f5 Ndxe5 17. Bc5 Nxd3+ 18. Rxd3 Qg5+ 19. Be3 Qf6 20. Nd4 Nxd4 21.
+Bxd4 e5 22. g5 Qxg5+ 23. Be3 Qxf5 24. Qg3 d4 25. Rg1 Qg6 26. Qxe5 f6 27. Qd5+
+Qf7 28. Qxa8 dxe3 29. Rxe3 Qxa2 30. Qg2 g6 31. Re7 Rd8 32. c3 b3 33. Qe4 a4 34.
+Qc4+ Kh8 35. Qe4 a3 36. Re8+ Rxe8 37. Qxe8+ Kg7 38. Qe7+ Kg8 39. Qd8+ Kg7 40.
+Qe7+ Kh6 41. Qe3+ Kg7 42. Kd2 Qxb2+ 43. Ke1 Qb1+ 44. Kf2 Qc2+ 45. Qe2 Qxe2+ 46.
+Kxe2 b2 47. Rd1 a2 48. Rd6 b1=Q 49. Rc6 a1=Q 50. Rc5 Qe4+ 51. Kf2 Qb2+ 52. Kg3
+Qbg2# 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "WildBreath"]
+[Black "estocastico"]
+[Result "1-0"]
+[ECO "B23"]
+[WhiteElo "2389"]
+[BlackElo "2550"]
+[PlyCount "109"]
+[EventDate "2020.??.??"]
+
+1. e4 c5 2. Nc3 d6 3. Bb5+ Nc6 4. Bxc6+ bxc6 5. d3 g6 6. f4 Bg7 7. Nf3 Rb8 8.
+O-O Nf6 9. Qe1 O-O 10. Qh4 e6 11. f5 exf5 12. Bh6 Ng4 13. Qxd8 Rxd8 14. Bxg7
+Kxg7 15. h3 Ne3 16. Rf2 f4 17. Re1 h6 18. Rfe2 Rxb2 19. g3 Rxc2 20. gxf4 Rxe2
+21. Rxe2 Bxh3 22. Rxe3 Rb8 23. Re2 Bg4 24. Kg2 Kf6 25. Kf2 Ke7 26. Ke3 h5 27.
+Rh2 f6 28. Nh4 Kf7 29. Nf3 Rb7 30. Rc2 Ke6 31. Nd2 d5 32. Nb3 d4+ 33. Nxd4+
+cxd4+ 34. Kxd4 Rb4+ 35. Ke3 Kd6 36. a3 Rb3 37. Na4 Rxa3 38. Nc5 g5 39. fxg5
+fxg5 40. Kd4 Bf3 41. Rf2 g4 42. Rh2 g3 43. Rh4 g2 44. e5+ Ke7 45. Rf4 g1=Q+ 46.
+Kc4 Rc3+ 47. Kxc3 Qxc5+ 48. Rc4 Qxe5+ 49. d4 Qe3+ 50. Kb4 Bd5 51. Rc5 Qb3+ 52.
+Ka5 Qb6+ 53. Ka4 Bb3+ 54. Ka3 Bd5 55. Rc3 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "John-Nash"]
+[Black "tankredi"]
+[Result "0-1"]
+[ECO "B49"]
+[WhiteElo "2301"]
+[BlackElo "2398"]
+[PlyCount "62"]
+[EventDate "2020.??.??"]
+
+1. e4 c5 2. Nf3 e6 3. d4 cxd4 4. Nxd4 Nc6 5. Nc3 Qc7 6. Be3 a6 7. Be2 Nf6 8.
+O-O b5 9. f4 Bb7 10. Bf3 Nxd4 11. Bxd4 Bc5 12. a3 h5 13. Kh1 O-O-O 14. e5 Ng4
+15. Bxb7+ Kxb7 16. Qf3+ Kb8 17. Bxc5 Qxc5 18. Ne4 Qc6 19. Nd6 Rhf8 20. Qxc6
+dxc6 21. h3 Ne3 22. Rf2 f6 23. Re2 Nd5 24. g3 fxe5 25. fxe5 Rf3 26. Kg2 Rdf8
+27. Rd1 Ne3+ 28. Rxe3 Rxe3 29. h4 Re2+ 30. Kh3 Rff2 31. Ne8 Rh2# 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Kidefence"]
+[Black "BlueGreensun"]
+[Result "0-1"]
+[ECO "B21"]
+[WhiteElo "2720"]
+[BlackElo "2748"]
+[PlyCount "24"]
+[EventDate "2020.??.??"]
+
+1. e4 c5 2. d4 cxd4 3. Nf3 e5 4. c3 dxc3 5. Nxc3 d6 6. Bc4 Nf6 7. Ng5 Be6 8.
+Nxe6 fxe6 9. Bxe6 Nc6 10. O-O Nd4 11. Bc4 Rc8 12. Qxd4 exd4 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Kelevra90"]
+[Black "Alexis_Emil_Maribao"]
+[Result "0-1"]
+[ECO "B25"]
+[WhiteElo "2442"]
+[BlackElo "2424"]
+[PlyCount "75"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 c5 2. Nc3 Nc6 3. Bb5 g6 4. Nf3 Bg7 5. O-O e5 6. a3 Nge7 7. b4 cxb4 8.
+axb4 O-O 9. Rb1 d5 10. exd5 Nxd5 11. Nxd5 Qxd5 12. c4 Qd8 13. Re1 Bg4 14. Bxc6
+bxc6 15. h3 Bf5 16. Rb3 e4 17. Nh2 Qd4 18. Qe2 Rfe8 19. Bb2 Qd7 20. Bxg7 Kxg7
+21. b5 c5 22. Nf1 Rad8 23. g4 Be6 24. Re3 f5 25. gxf5 gxf5 26. Rg3+ Kh8 27. Qh5
+Rg8 28. Kh1 Bxc4 29. Rxg8+ Rxg8 30. Ng3 Qxd2 31. Rg1 Qxf2 32. Qxf5 Qxf5 33.
+Nxf5 Rxg1+ 34. Kxg1 Bxb5 35. Kf2 a5 36. Ke3 Bd3 37. Nd6 a4 38. Nb5 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "KeongDarat"]
+[Black "GMshooter96"]
+[Result "1-0"]
+[ECO "C29"]
+[WhiteElo "2415"]
+[BlackElo "2385"]
+[PlyCount "103"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 e5 2. Nc3 Nf6 3. f4 d5 4. fxe5 Nxe4 5. Nf3 Be7 6. d4 O-O 7. Bd3 Nxc3 8.
+bxc3 c5 9. O-O Nc6 10. Be3 Bg4 11. Qd2 cxd4 12. cxd4 f6 13. exf6 Bxf6 14. c3
+Re8 15. Bg5 Bxf3 16. Bxf6 Qxf6 17. Rxf3 Qe7 18. Rh3 g6 19. Rf1 Rf8 20. Re1 Qf6
+21. Rf3 Qg7 22. Qg5 Rxf3 23. gxf3 Rf8 24. Qxd5+ Kh8 25. Be4 Qh6 26. Qd6 Re8 27.
+Qf6+ Qg7 28. Qxg7+ Kxg7 29. Rb1 Re7 30. Bxc6 bxc6 31. Kf2 Kf6 32. Rb8 h5 33. c4
+Ke6 34. Rd8 Rf7 35. Ke3 Rb7 36. Rg8 Kf5 37. Rf8+ Kg5 38. f4+ Kg4 39. Rf6 Rb2
+40. Rxg6+ Kh3 41. Rxc6 Rxa2 42. Rh6 h4 43. c5 Rxh2 44. c6 Rc2 45. d5 Rc5 46.
+Kd4 Rc1 47. f5 Kg3 48. f6 h3 49. f7 Rd1+ 50. Kc5 Rf1 51. c7 Rf6 52. Rxf6 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Chesscoach46"]
+[Black "ahmedSulaimaniyah16"]
+[Result "1-0"]
+[ECO "B21"]
+[WhiteElo "2312"]
+[BlackElo "2411"]
+[PlyCount "94"]
+[EventDate "2020.??.??"]
+
+1. e4 c5 2. d4 cxd4 3. Nf3 Nf6 4. Nxd4 Nxe4 5. Bd3 Nf6 6. Nc3 Nc6 7. Nxc6 bxc6
+8. Bg5 e6 9. O-O d5 10. f4 Be7 11. f5 h6 12. Bxf6 Bxf6 13. fxe6 Bxe6 14. Qe2
+O-O 15. Rae1 Qb6+ 16. Kh1 Qxb2 17. Nd1 Qxa2 18. Qh5 Qa1 19. Ne3 Qd4 20. Nf5
+Bxf5 21. Qxf5 g6 22. Qxf6 Qxf6 23. Rxf6 Kg7 24. Rxc6 a5 25. g3 a4 26. Ra1 a3
+27. Rc3 Rfb8 28. Rcxa3 Rxa3 29. Rxa3 Rd8 30. Kg2 g5 31. Ra6 Re8 32. h4 Re6 33.
+Rxe6 fxe6 34. hxg5 hxg5 35. Kf3 Kf6 36. Ke3 Ke5 37. Kf3 Kd4 38. Kg4 e5 39. Kxg5
+e4 40. Be2 Ke3 41. Bd1 Kd2 42. Bg4 Kxc2 43. Kf4 d4 44. Kxe4 d3 45. Ke3 d2 46.
+Be2 d1=Q 47. Bxd1+ Kxd1 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "BlueGreensun"]
+[Black "Kidefence"]
+[Result "1/2-1/2"]
+[ECO "B02"]
+[WhiteElo "2753"]
+[BlackElo "2715"]
+[PlyCount "105"]
+[EventDate "2020.??.??"]
+
+1. e4 Nf6 2. Nc3 d5 3. exd5 Nxd5 4. d4 c6 5. Nf3 g6 6. h4 h5 7. Ne5 Bg7 8. Qf3
+O-O 9. Bd3 Nd7 10. Nxd5 Nxe5 11. dxe5 Qxd5 12. Qxd5 cxd5 13. f4 Bf5 14. Bxf5
+gxf5 15. Be3 Rfc8 16. c3 e6 17. Ke2 Bh6 18. g3 b5 19. Rhc1 Bf8 20. a4 a6 21.
+axb5 axb5 22. Kd3 Be7 23. Bd4 Kf8 24. Kc2 Ke8 25. Kb3 Kd7 26. Bb6 Kc6 27. Bf2
+Rg8 28. Rd1 Bc5 29. Be1 Bb6 30. Kc2 Rad8 31. Rd3 Rg6 32. Rad1 Rgg8 33. Rf3 Ra8
+34. Rf1 Ra2 35. Rb1 Ra4 36. Rf3 Re4 37. Kd3 Rg4 38. Bd2 Rg8 39. Rbf1 Bc5 40.
+Rh1 d4 41. Ra1 dxc3 42. bxc3 Rd8+ 43. Kc2 Re2 44. Rd3 Rxd3 45. Kxd3 Rg2 46. Be1
+Rg1 47. Ke2 Kd5 48. Rd1+ Kc4 49. Rd7 Rg2+ 50. Kf3 Rg1 51. Ke2 Rg2+ 52. Kf3 Rg1
+53. Ke2 1/2-1/2
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "kostya24"]
+[Black "Trxps"]
+[Result "1/2-1/2"]
+[ECO "A01"]
+[WhiteElo "2346"]
+[BlackElo "2336"]
+[PlyCount "114"]
+[EventDate "2020.??.??"]
+
+1. b3 c6 2. Nf3 d5 3. e3 Nf6 4. d4 Bf5 5. c4 Bg6 6. cxd5 cxd5 7. Nc3 e6 8. Bb5+
+Nc6 9. Bd3 Bxd3 10. Qxd3 Bb4 11. Qe2 Ne4 12. Bd2 Nxd2 13. Qxd2 Qa5 14. Rc1 Qa3
+15. O-O Qa5 16. Rfd1 Kf8 17. Qd3 Ba3 18. Rc2 Nb4 19. Qe2 Nxc2 20. Qxc2 Rc8 21.
+Qd3 Qxc3 22. Qb5 Bc1 23. Ne5 Bxe3 24. fxe3 Qxe3+ 25. Kh1 f6 26. Qd7 fxe5 27.
+Rf1+ Qf4 28. Rxf4+ exf4 29. Qxc8+ Kf7 30. Qxh8 Kf6 31. Qxh7 Kg5 32. Qd3 Kf6 33.
+g3 g5 34. gxf4 gxf4 35. Qf3 Kf5 36. Kg2 b5 37. Qd3+ Kf6 38. Qxb5 e5 39. Qa6+
+Kf5 40. Qxa7 Ke4 41. Qc5 Kd3 42. dxe5 Ke4 43. Qxd5+ Kxd5 44. Kf3 Ke6 45. h4
+Kxe5 46. h5 Kf5 47. h6 Kg6 48. h7 Kh6 49. Kxf4 Kxh7 50. Ke4 Kg7 51. Kd5 Kf6 52.
+Kc6 Ke6 53. Kc7 Ke7 54. b4 Kf7 55. b5 Ke7 56. b6 Ke6 57. b7 Kf5 1/2-1/2
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "pro100still"]
+[Black "alphonsea"]
+[Result "1-0"]
+[ECO "B90"]
+[WhiteElo "2351"]
+[BlackElo "2328"]
+[PlyCount "75"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bd3 e5 7. Nde2 Be7 8. h3
+b5 9. g4 Bb7 10. Ng3 b4 11. Nce2 g6 12. Bh6 Nbd7 13. a3 bxa3 14. Rxa3 Nc5 15.
+c3 d5 16. exd5 Bxd5 17. O-O Nxd3 18. Qxd3 Bxa3 19. bxa3 Bb7 20. Qxd8+ Rxd8 21.
+Bg7 Ke7 22. Rb1 Bf3 23. Rb6 Ne4 24. Bxh8 Nxg3 25. Bf6+ Kd7 26. fxg3 Re8 27. Kf2
+Bc6 28. Rxa6 Re6 29. Ra7+ Ke8 30. Bg5 f6 31. Be3 f5 32. gxf5 gxf5 33. Rxh7 Be4
+34. Ra7 Rc6 35. h4 Rc8 36. h5 Rb8 37. h6 Kf8 38. h7 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "MiroMiljkovic"]
+[Black "harry_p0tter"]
+[Result "1-0"]
+[ECO "A68"]
+[WhiteElo "2625"]
+[BlackElo "2611"]
+[PlyCount "53"]
+[EventDate "2020.??.??"]
+
+1. d4 Nf6 2. c4 c5 3. d5 e6 4. Nc3 exd5 5. cxd5 d6 6. e4 g6 7. f4 Bg7 8. Nf3
+O-O 9. Be2 Bg4 10. O-O a6 11. a4 Nbd7 12. h3 Bxf3 13. Bxf3 Re8 14. Re1 c4 15.
+Be3 Qc7 16. Bd4 Nc5 17. Bxc5 Qxc5+ 18. Kh2 b5 19. axb5 axb5 20. Rxa8 Rxa8 21.
+e5 Nd7 22. Ne4 Qb4 23. e6 Nf6 24. Ng5 Qxb2 25. exf7+ Kh8 26. Re2 Rf8 27. Rxb2
+1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "dmitrij_IM"]
+[Black "Chess-Network"]
+[Result "1-0"]
+[ECO "B11"]
+[WhiteElo "2860"]
+[BlackElo "2706"]
+[PlyCount "59"]
+[EventDate "2020.??.??"]
+
+1. e4 c6 2. Nc3 d5 3. Nf3 Bg4 4. h3 Bh5 5. g4 Bg6 6. exd5 cxd5 7. Bb5+ Nc6 8.
+Ne5 Rc8 9. Qe2 Qd6 10. d4 f6 11. Nxg6 hxg6 12. Be3 e6 13. O-O-O Kf7 14. h4 Nge7
+15. Kb1 a6 16. Bd3 Nb4 17. h5 gxh5 18. gxh5 Nxd3 19. Qxd3 Nf5 20. Ne2 Qd7 21.
+Ng3 Nxg3 22. Qg6+ Ke7 23. Qxg3 Qe8 24. Qf3 Kd7 25. Rdg1 Qf7 26. Rg6 Rh7 27.
+Rhg1 Bd6 28. h6 Rg8 29. c4 Rf8 30. Rxg7 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "kinez24"]
+[Black "rampageJackson"]
+[Result "0-1"]
+[ECO "B02"]
+[WhiteElo "2325"]
+[BlackElo "2390"]
+[PlyCount "90"]
+[EventDate "2020.??.??"]
+
+1. e4 Nf6 2. Nc3 d6 3. Nf3 Nbd7 4. Be2 e5 5. d4 Be7 6. dxe5 dxe5 7. Bg5 O-O 8.
+Qd2 c6 9. Qe3 Qc7 10. a3 Re8 11. b4 Nf8 12. h3 Ng6 13. g3 b6 14. h4 a5 15. bxa5
+Rxa5 16. h5 Nf8 17. h6 g6 18. O-O Ne6 19. Bc4 Ng4 20. Qd2 Nxg5 21. Nxg5 Rf8 22.
+Bb3 c5 23. Nd5 Qd8 24. Nxe7+ Qxe7 25. f4 Nxh6 26. f5 Kg7 27. f6+ Qxf6 28. Rxf6
+Kxf6 29. Rf1+ Kg7 30. Qd6 Ra7 31. Qxb6 Re7 32. Qxc5 Rfe8 33. Nxf7 Nxf7 34.
+Rxf7+ Rxf7 35. Bxf7 Kxf7 36. Qd5+ Be6 37. Qb7+ Re7 38. Qb4 Kf6 39. c4 Rc7 40.
+c5 Bd7 41. Qb6+ Rc6 42. Qb7 Ke7 43. a4 Rxc5 44. a5 Rb5 45. Qc7 Rc5 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "AJ_CARALDE"]
+[Black "AGG2020"]
+[Result "0-1"]
+[ECO "A40"]
+[WhiteElo "2331"]
+[BlackElo "2483"]
+[PlyCount "47"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 e6 2. Nf3 d5 3. Bg5 Be7 4. Bxe7 Qxe7 5. Nbd2 Nf6 6. e3 Nbd7 7. Bd3 O-O 8.
+O-O e5 9. dxe5 Nxe5 10. Nxe5 Qxe5 11. Nf3 Qxb2 12. Rb1 Qxa2 13. Nd4 c6 14. Qf3
+Qa5 15. h3 Qc7 16. g4 Re8 17. g5 Ne4 18. h4 a6 19. Ne2 Bd7 20. Nf4 Rad8 21. Kg2
+Bc8 22. Rh1 Qe5 23. Qg3 Nxg3 24. fxg3 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Mia_Khaliffa"]
+[Black "JacobAagaard"]
+[Result "0-1"]
+[ECO "B22"]
+[WhiteElo "2448"]
+[BlackElo "2484"]
+[PlyCount "70"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 c5 2. d4 cxd4 3. c3 Nf6 4. e5 Nd5 5. cxd4 d6 6. exd6 e6 7. Nc3 Nxc3 8.
+bxc3 Bxd6 9. Nf3 Qc7 10. Bd2 O-O 11. Bd3 Nd7 12. h4 Nf6 13. h5 h6 14. Qc1 Nd5
+15. c4 Nf4 16. Bxf4 Bxf4 17. Qc2 b6 18. Rh4 Bb7 19. Kf1 Bxf3 20. gxf3 Rad8 21.
+Rd1 Bg5 22. Rg4 Qh2 23. Ke2 f5 24. Rg3 Bh4 25. Rdg1 Bxg3 26. Rxg3 Rxd4 27. c5
+Rfd8 28. f4 Qxh5+ 29. Kf1 Rxd3 30. Rxd3 Qh1+ 31. Ke2 Qe4+ 32. Kd2 Rxd3+ 33.
+Qxd3 Qxd3+ 34. Kxd3 bxc5 35. Kc4 h5 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Olaffo"]
+[Black "dimochka_tsoi"]
+[Result "0-1"]
+[ECO "A04"]
+[WhiteElo "2509"]
+[BlackElo "2675"]
+[PlyCount "144"]
+[EventDate "2020.??.??"]
+
+1. Nf3 f5 2. e4 fxe4 3. Ng5 Nf6 4. d3 d5 5. dxe4 Nxe4 6. Nxe4 dxe4 7. Qh5+ g6
+8. Qe5 Rg8 9. Bc4 Bg7 10. Qxe4 Rf8 11. Nc3 Nc6 12. Be3 Bf5 13. Qh4 Nb4 14. Bb3
+Nxc2+ 15. Bxc2 Bxc2 16. O-O e6 17. Qb4 Qe7 18. Qb5+ c6 19. Qc4 Rd8 20. Rac1 Bf5
+21. Bc5 Qd7 22. Bxf8 Kxf8 23. Rce1 Bf6 24. Qf4 Qd6 25. Qxd6+ Rxd6 26. Ne4 Bxe4
+27. Rxe4 Bxb2 28. Rb1 b5 29. h4 Bd4 30. a4 a6 31. axb5 axb5 32. h5 gxh5 33. Rh4
+Rd5 34. g3 Kg7 35. Kg2 Kg6 36. f4 e5 37. f5+ Kxf5 38. Rxh5+ Kg6 39. Rbh1 Be3
+40. Rxh7 b4 41. Rb7 Bd2 42. Rhh7 e4 43. Rhg7+ Kf6 44. Rgf7+ Ke5 45. Rfe7+ Kd4
+46. Rbd7 e3 47. Rxd5+ cxd5 48. Kf3 b3 49. Rb7 Kc3 50. Rb5 b2 51. Rc5+ Kb3 52.
+Rxd5 Bb4 53. Rd1 Kc2 54. Rf1 Bd2 55. Kg4 b1=Q 56. Rxb1 Kxb1 57. Kf3 Kc1 58. Ke2
+Kc2 59. g4 Kc3 60. g5 Kd4 61. g6 Ke4 62. g7 Bc3 63. g8=Q Be5 64. Qg4+ Bf4 65.
+Qf3+ Ke5 66. Qg2 Kf5 67. Qf3 Ke5 68. Qg2 Kf5 69. Qf3 Kf6 70. Qd5 Kg7 71. Qe4
+Kg8 72. Kf3 Kh8 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Hendra-Supriyadi"]
+[Black "H-Random"]
+[Result "1-0"]
+[ECO "C45"]
+[WhiteElo "2331"]
+[BlackElo "2368"]
+[PlyCount "69"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 e5 2. Nf3 Nc6 3. d4 exd4 4. Bc4 Bc5 5. c3 dxc3 6. Bxf7+ Kxf7 7. Qd5+ Kf8
+8. Qxc5+ d6 9. Qxc3 Nf6 10. Nbd2 Qe8 11. O-O Nxe4 12. Nxe4 Qxe4 13. Re1 Qb4 14.
+Qe3 Bg4 15. Bd2 Qc5 16. Qe4 Qf5 17. Qe3 Bxf3 18. gxf3 h6 19. Bc3 Kg8 20. Kh1
+Kh7 21. Rg1 Rhg8 22. Rg3 Ne5 23. Rag1 Raf8 24. Qxa7 Rf7 25. Qxb7 c6 26. Qb4
+Nxf3 27. Rd1 Nxh2 28. Kxh2 Qh5+ 29. Kg2 Qxd1 30. Qe4+ Kh8 31. Qg6 Qd5+ 32. f3
+Re8 33. Bxg7+ Kg8 34. Bf6+ Kf8 35. Qg8# 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Paanoos"]
+[Black "mbodek"]
+[Result "0-1"]
+[ECO "B02"]
+[WhiteElo "2411"]
+[BlackElo "2587"]
+[PlyCount "38"]
+[EventDate "2020.??.??"]
+
+1. e4 Nf6 2. Nc3 d5 3. e5 Ne4 4. Nce2 f6 5. d3 Nc5 6. d4 Ne6 7. Nf3 Nc6 8. c3
+fxe5 9. Nxe5 Nxe5 10. dxe5 g6 11. Nd4 Nxd4 12. cxd4 Bg7 13. Bg5 O-O 14. Qd2 c6
+15. Bh6 Bxh6 16. Qxh6 Qa5+ 17. Kd1 Rxf2 18. h4 Bg4+ 19. Kc1 Qe1# 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Aisen_Mestnikov"]
+[Black "RigelStar"]
+[Result "0-1"]
+[ECO "A43"]
+[WhiteElo "2394"]
+[BlackElo "2401"]
+[PlyCount "60"]
+[EventDate "2020.??.??"]
+
+1. d4 c5 2. d5 e6 3. c4 exd5 4. cxd5 d6 5. Nc3 g6 6. e4 Bg7 7. Nf3 Ne7 8. Be2
+O-O 9. O-O f5 10. Qd2 fxe4 11. Nxe4 Nf5 12. Nfg5 h6 13. Ne6 Bxe6 14. dxe6 Nc6
+15. Bc4 Qe7 16. g4 Nfd4 17. Qe3 Rf3 18. Qe1 Rh3 19. Kg2 Qh4 20. Rh1 Qxg4+ 21.
+Ng3 Ne5 22. Be2 Nxe2 23. Qxe2 Rxg3+ 24. Kf1 Rf3 25. Rg1 Qxe6 26. Be3 Qf7 27.
+Re1 h5 28. Bg5 Ng4 29. h3 Nxf2 30. Qxf2 Rxf2# 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Nenidon_Andriy"]
+[Black "sutcunuri"]
+[Result "0-1"]
+[ECO "A00"]
+[WhiteElo "2395"]
+[BlackElo "2530"]
+[PlyCount "12"]
+[EventDate "2020.??.??"]
+
+1. e3 d6 2. d4 Bg4 3. f4 Bxd1 4. Kxd1 Nf6 5. Nf3 g6 6. Bd3 Bg7 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Frogkiller"]
+[Black "alireza3700"]
+[Result "1-0"]
+[ECO "C00"]
+[WhiteElo "2366"]
+[BlackElo "2348"]
+[PlyCount "73"]
+[EventDate "2020.??.??"]
+
+1. e4 e6 2. d4 b6 3. Bd3 Bb7 4. Nf3 d5 5. e5 c5 6. c3 cxd4 7. cxd4 Bb4+ 8. Nc3
+Ne7 9. O-O Nbc6 10. a3 Bxc3 11. bxc3 Ng6 12. a4 O-O 13. Qe2 Na5 14. Ba3 Re8 15.
+Bb5 Bc6 16. Bd3 Rc8 17. Bb4 Qd7 18. Ba6 Bb7 19. Bb5 Bc6 20. Ba6 Bb7 21. Bd3 Nc4
+22. a5 bxa5 23. Bxa5 Nxa5 24. Rxa5 Rxc3 25. Rxa7 Ra8 26. Rfa1 Rxa7 27. Rxa7
+Rc1+ 28. Ne1 Nf4 29. Qd2 Nxd3 30. h3 Rxe1+ 31. Kh2 Rb1 32. Qxd3 Qb5 33. Qa3 h6
+34. Qe7 Rf1 35. Rxb7 Qd3 36. Qxf7+ Kh8 37. Qxg7# 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Caochonewell"]
+[Black "Yoseqpuedo"]
+[Result "0-1"]
+[ECO "A40"]
+[WhiteElo "2431"]
+[BlackElo "2394"]
+[PlyCount "76"]
+[EventDate "2020.??.??"]
+
+1. d4 e6 2. Nf3 f5 3. c4 Nf6 4. Nc3 Be7 5. Bg5 O-O 6. Bxf6 Bxf6 7. g3 d6 8. Bg2
+Qe8 9. O-O Kh8 10. e4 fxe4 11. Nxe4 Bd8 12. Re1 Qg6 13. Nc3 Nc6 14. d5 Ne5 15.
+Nxe5 dxe5 16. Rxe5 Bf6 17. Re3 e5 18. Ne4 Be7 19. Qe2 Bf5 20. Re1 Rae8 21. Rf1
+a6 22. b3 Bg4 23. f3 Bf5 24. Qd2 Qh6 25. Re2 Qg6 26. Rfe1 Ba3 27. Nc3 Bc5+ 28.
+Kh1 Bd4 29. Ne4 Rf7 30. Nf2 h6 31. Nh3 Bxh3 32. Bxh3 Ref8 33. f4 exf4 34. Qxd4
+fxg3 35. hxg3 Qxg3 36. Bg2 Rf4 37. Qe3 Rh4+ 38. Kg1 Qh2# 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "tuntematon"]
+[Black "ajedrez2021"]
+[Result "1-0"]
+[ECO "A40"]
+[WhiteElo "2759"]
+[BlackElo "2597"]
+[PlyCount "75"]
+[EventDate "2020.??.??"]
+
+1. d4 g6 2. c4 Bg7 3. e4 c5 4. d5 d6 5. Nc3 Nf6 6. h3 O-O 7. Bd3 e6 8. Nf3 Re8
+9. O-O exd5 10. cxd5 c4 11. Bc2 Nbd7 12. Bf4 Nc5 13. Re1 a6 14. a3 b5 15. Nd4
+Bb7 16. Qd2 Qb6 17. Be3 Ncxe4 18. Nxe4 Nxe4 19. Bxe4 Rxe4 20. Nc6 Qc7 21. Bh6
+Rxe1+ 22. Rxe1 Bxc6 23. Bxg7 Kxg7 24. Qd4+ Kg8 25. dxc6 Qxc6 26. Re7 Rf8 27. h4
+Qc5 28. Qf6 c3 29. bxc3 Qxa3 30. f4 h5 31. Kh2 Qc1 32. Ra7 Qe3 33. Rxa6 Rc8 34.
+Rxd6 Rf8 35. Rd7 Qe6 36. Qxe6 fxe6 37. g3 Rxf4 38. gxf4 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Nenidon_Andriy"]
+[Black "terminator-t800"]
+[Result "1-0"]
+[ECO "D00"]
+[WhiteElo "2391"]
+[BlackElo "2369"]
+[PlyCount "105"]
+[EventDate "2020.??.??"]
+
+1. e3 d5 2. d4 Nf6 3. f4 Bg4 4. Nf3 e6 5. Bd3 c5 6. O-O Nc6 7. c3 Bd6 8. Bd2
+O-O 9. Be1 Qb6 10. Qb3 c4 11. Qxb6 axb6 12. Bc2 Bxf3 13. gxf3 b5 14. a3 b4 15.
+cxb4 Nxb4 16. Bxb4 Bxb4 17. Kf2 Bd6 18. Nc3 Nd7 19. Nb5 Bb8 20. Rg1 g6 21. Ke2
+Rc8 22. f5 Kf8 23. fxe6 fxe6 24. h4 Nf6 25. Nc3 Nh5 26. f4 Kf7 27. Kf2 Rf8 28.
+Bd1 Nf6 29. Bf3 Bd6 30. h5 gxh5 31. Rh1 Rg8 32. Bxh5+ Nxh5 33. Rxh5 Rg7 34.
+Rah1 Rag8 35. Rxh7 Be7 36. Rxg7+ Rxg7 37. Rh2 Bd6 38. Ne2 b5 39. Ng1 b4 40.
+axb4 Bxb4 41. Nf3 c3 42. Ng5+ Ke7 43. bxc3 Bxc3 44. Kf3 Bb4 45. Rh7 Bd6 46.
+Rxg7+ Kd8 47. Rf7 Be7 48. Rxe7 Kxe7 49. Nxe6 Kd6 50. e4 Kxe6 51. exd5+ Kd6 52.
+f5 Kxd5 53. Kf4 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Phutressniak"]
+[Black "Marohzevich"]
+[Result "0-1"]
+[ECO "A40"]
+[WhiteElo "2422"]
+[BlackElo "2479"]
+[PlyCount "102"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 e6 2. Nf3 d5 3. c4 a6 4. Nc3 Nf6 5. c5 b6 6. cxb6 cxb6 7. Bf4 Bb7 8. e3
+Bb4 9. Rc1 Nc6 10. Bd3 O-O 11. O-O Rc8 12. Qe2 b5 13. h3 Re8 14. Bg5 h6 15. Bh4
+Be7 16. a3 Na5 17. Ne5 Nc4 18. f4 Nd6 19. Qf3 Nfe4 20. Bxe7 Qxe7 21. Bxe4 dxe4
+22. Qg3 f6 23. Ng6 Qf7 24. Nh4 Rc4 25. Ne2 Rec8 26. b3 Rxc1 27. Rxc1 Rxc1+ 28.
+Nxc1 Qc7 29. Ne2 Qc2 30. Kf2 f5 31. Qg6 Bd5 32. g4 Bxb3 33. gxf5 Bc4 34. f6
+Qxe2+ 35. Kg3 Qxe3+ 36. Kg2 Qe2+ 37. Kh1 Qf1+ 38. Kh2 Qxf4+ 39. Kh1 Qxf6 40.
+Qg4 Qf1+ 41. Kh2 Qf6 42. Ng2 Nf5 43. Qg3 Nxg3 44. Kxg3 Qg5+ 45. Kh2 e3 46. h4
+Qg4 47. Nxe3 Qf4+ 48. Kh3 Qxe3+ 49. Kg4 Qxd4+ 50. Kh5 Be2+ 51. Kg6 Qf6# 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Elhlwagy11"]
+[Black "i_love_lubimka"]
+[Result "1-0"]
+[ECO "C11"]
+[WhiteElo "2307"]
+[BlackElo "2360"]
+[PlyCount "48"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 Nf6 2. Nc3 e6 3. e4 d5 4. Bg5 dxe4 5. Nxe4 Be7 6. Bxf6 Bxf6 7. Nf3 b6 8.
+c3 Bb7 9. Bd3 Nd7 10. Qc2 Qe7 11. O-O-O O-O-O 12. Qa4 Kb8 13. Rhe1 Rhe8 14. Ba6
+g6 15. Bxb7 Kxb7 16. d5 exd5 17. Rxd5 Ne5 18. Nxf6 Qxf6 19. Rdxe5 Rxe5 20. Nxe5
+Qxf2 21. Qe4+ Ka6 22. Qe2+ Qxe2 23. Rxe2 Re8 24. Kd2 f6 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "imdejong"]
+[Black "bonsitorus"]
+[Result "1-0"]
+[ECO "B01"]
+[WhiteElo "2343"]
+[BlackElo "2301"]
+[PlyCount "47"]
+[EventDate "2020.??.??"]
+
+1. e4 d5 2. exd5 e6 3. Nc3 exd5 4. Nf3 c6 5. d4 Nf6 6. Bd3 Be7 7. O-O O-O 8. h3
+Nbd7 9. Bf4 Re8 10. Re1 Nf8 11. Ne5 Ng6 12. Bxg6 hxg6 13. Qf3 Bd6 14. g4 Bf8
+15. g5 Nh5 16. Nxf7 Rxe1+ 17. Rxe1 Nxf4 18. Nxd8 Nxh3+ 19. Kh2 Bf5 20. Ne6 Nxg5
+21. Nxg5 Bd6+ 22. Kg2 Rf8 23. Qe3 Bxc2 24. Qe6+ 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "elveneno"]
+[Black "yaguigor"]
+[Result "0-1"]
+[ECO "B20"]
+[WhiteElo "2458"]
+[BlackElo "2453"]
+[PlyCount "128"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 c5 2. d3 Nc6 3. g3 g6 4. h3 Bg7 5. Bg2 d6 6. Nf3 e5 7. O-O Nge7 8. c3 O-O
+9. Na3 h6 10. Nc2 f5 11. Re1 Rb8 12. exf5 gxf5 13. d4 cxd4 14. cxd4 e4 15. Nh4
+d5 16. Bf4 Kh7 17. Bxb8 Nxb8 18. Bf1 Nbc6 19. Ng2 Be6 20. Nf4 Bf7 21. Qd2 Qb6
+22. Red1 Rc8 23. b4 Ng6 24. Nxg6 Bxg6 25. b5 Na5 26. Ne3 Nc4 27. Bxc4 dxc4 28.
+a4 c3 29. Qe2 Bxd4 30. Nd5 Qc5 31. Nf4 Bf7 32. Rac1 Rc7 33. Kg2 Be5 34. Qe3
+Qxe3 35. fxe3 c2 36. Rd2 Bb3 37. Kf2 Bb2 38. Ne2 Bxa4 39. h4 Bxc1 40. Nxc1 Bxb5
+41. Rd5 Bd7 42. Ke2 Kg6 43. Kd2 Kf6 44. Ra5 b6 45. Rd5 Ke7 46. Ne2 Be6 47. Rd4
+Bc4 48. Nf4 Bd3 49. Kc1 Rc5 50. Nxd3 exd3 51. Rxd3 Ke6 52. Rb3 b5 53. Ra3 Rc7
+54. Ra6+ Ke5 55. Rxh6 b4 56. Ra6 Ke4 57. Ra4 a5 58. Rxa5 Kd3 59. Rxf5 b3 60.
+Rb5 Kc3 61. e4 Rc4 62. e5 Rd4 63. Rc5+ Kb4 64. Rxc2 bxc2 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Betovsky"]
+[Black "hungzhao"]
+[Result "1-0"]
+[ECO "C01"]
+[WhiteElo "2616"]
+[BlackElo "2635"]
+[PlyCount "59"]
+[EventDate "2020.??.??"]
+
+1. d4 e6 2. e4 d5 3. exd5 e5 4. Bd3 exd4 5. Nf3 Qxd5 6. O-O c5 7. c4 Qd8 8.
+Re1+ Be7 9. b4 b6 10. Be4 Nf6 11. Bxa8 O-O 12. bxc5 Bxc5 13. Bg5 Nbd7 14. Nbd2
+Ba6 15. Bd5 h6 16. Bxf6 Nxf6 17. Nb3 Nxd5 18. cxd5 d3 19. Nxc5 bxc5 20. Qa4 Qd6
+21. Rad1 c4 22. Ne5 Rc8 23. Nc6 Rxc6 24. dxc6 d2 25. Qxa6 c3 26. Qc8+ Kh7 27.
+Qf5+ Qg6 28. Qxg6+ Kxg6 29. Rxd2 cxd2 30. Rd1 1-0
+
+[Event "Rated Bullet tournament Ob1BCTUI"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "GMChavez"]
+[Black "antetokwombo"]
+[Result "1-0"]
+[ECO "A04"]
+[WhiteElo "2551"]
+[BlackElo "2327"]
+[PlyCount "147"]
+[EventDate "2020.??.??"]
+
+1. Nf3 g6 2. g3 Bg7 3. Bg2 c6 4. O-O d6 5. d3 Nf6 6. Nbd2 O-O 7. e4 Qa5 8. Re1
+Qh5 9. Qe2 Bg4 10. Qf1 Nbd7 11. h3 Bxf3 12. Nxf3 Qa5 13. Qe2 Ne5 14. Nxe5 Qxe5
+15. Rb1 Qc5 16. Bd2 Qxc2 17. Rec1 Qa4 18. a3 Qa6 19. Bc3 Nd7 20. Bxg7 Kxg7 21.
+Qd2 Ne5 22. d4 Nd7 23. Qc3 Kg8 24. b4 Qb6 25. Bf1 Rac8 26. h4 Qd8 27. h5 c5 28.
+bxc5 dxc5 29. d5 Nf6 30. h6 b6 31. a4 Qd6 32. e5 Nxd5 33. exd6 Nxc3 34. dxe7
+Rfe8 35. Rxc3 Rxe7 36. a5 Re6 37. axb6 Rxb6 38. Ra1 Rc7 39. Re3 Kf8 40. Rae1 f5
+41. Re8+ Kf7 42. Rh8 Kf6 43. Bc4 Kg5 44. Kg2 Kxh6 45. Rg8 Rb4 46. Bd5 Rd4 47.
+Bf3 Kg5 48. Rh1 h5 49. Ra8 Rd6 50. Ra1 f4 51. R1xa7 fxg3 52. Kxg3 Rxa7 53. Rxa7
+c4 54. Ra5+ Kh6 55. Rc5 g5 56. Rxc4 h4+ 57. Kg2 Rg6 58. Bg4 Rf6 59. Rd4 Rf4 60.
+Rd3 Rxg4+ 61. Kh2 Rf4 62. f3 Rf6 63. Kh3 Rg6 64. Kg4 Rf6 65. Rd5 Kg6 66. Kh3
+Rf4 67. Kg2 Rf5 68. Rd6+ Rf6 69. Rd4 Rf5 70. Rg4 Rf6 71. Kh3 Kh6 72. f4 Rf5 73.
+fxg5+ Rxg5 74. Rxh4+ 1-0
+
+[Event "Rated Bullet tournament Ob1BCTUI"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Chuunhu"]
+[Black "pasino"]
+[Result "1/2-1/2"]
+[ECO "A40"]
+[WhiteElo "2670"]
+[BlackElo "2668"]
+[PlyCount "27"]
+[EventDate "2020.??.??"]
+
+1. d4 f6 2. Nf3 g6 3. e4 Bg7 4. h4 h5 5. Bc4 Nh6 6. e5 d5 7. exd6 exd6 8. Bd3
+Bf5 9. O-O Bxd3 10. Qxd3 Nf5 11. c3 O-O 12. Re1 Kh7 13. Bf4 Qd7 14. Nbd2
+1/2-1/2
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "harry_p0tter"]
+[Black "MiroMiljkovic"]
+[Result "1-0"]
+[ECO "A43"]
+[WhiteElo "2606"]
+[BlackElo "2630"]
+[PlyCount "61"]
+[EventDate "2020.??.??"]
+
+1. d4 c5 2. d5 Nf6 3. Nc3 g6 4. e4 d6 5. f4 Bg7 6. Bb5+ Bd7 7. e5 Nh5 8. Bxd7+
+Nxd7 9. g4 Nxf4 10. Bxf4 Nxe5 11. Bxe5 Bxe5 12. Nf3 Bg7 13. Qd2 O-O 14. O-O-O
+b5 15. Kb1 a5 16. Ne4 a4 17. h4 b4 18. h5 b3 19. cxb3 axb3 20. a3 Ra4 21. Rde1
+Qa8 22. hxg6 fxg6 23. Nfg5 Rxa3 24. bxa3 Qxa3 25. Nc3 Qa5 26. Qe2 Rf6 27. Nce4
+Rf2 28. Nf6+ Rxf6 29. Qxe7 Rf2 30. Qe6+ Kh8 31. Rxh7# 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "tatamaco"]
+[Black "zakorov"]
+[Result "0-1"]
+[ECO "B02"]
+[WhiteElo "2320"]
+[BlackElo "2312"]
+[PlyCount "90"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 Nf6 2. e5 Nd5 3. Nc3 Nxc3 4. dxc3 d5 5. f4 c5 6. Nf3 Nc6 7. Bd3 Bg4 8. h3
+Bh5 9. g4 c4 10. Be2 Bg6 11. f5 e6 12. fxg6 hxg6 13. Be3 Qc7 14. Bd4 Be7 15.
+Qd2 Bh4+ 16. Nxh4 Rxh4 17. Qe3 O-O-O 18. O-O-O Rdh8 19. Rdf1 b5 20. Rf2 a5 21.
+Qf3 Nxe5 22. Qg3 Nd3+ 23. Qxd3 cxd3 24. Bxd3 Rxh3 25. Rhf1 Rh1 26. Bxg7 R8h2
+27. Rxh1 Rxh1+ 28. Kd2 Rh2 29. Ke2 Rxf2+ 30. Kxf2 Qf4+ 31. Ke1 Qxg4 32. Bxb5
+Qe4+ 33. Kd2 g5 34. Bd3 Qf4+ 35. Ke2 g4 36. Bd4 e5 37. Be3 Qf3+ 38. Kd2 g3 39.
+Be2 Qf5 40. a4 g2 41. b4 Qf4 42. Bxf4 exf4 43. Bf3 g1=Q 44. Bxd5 Qe3+ 45. Kd1
+Qxc3 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "ahmedSulaimaniyah16"]
+[Black "Paanoos"]
+[Result "0-1"]
+[ECO "B03"]
+[WhiteElo "2404"]
+[BlackElo "2408"]
+[PlyCount "58"]
+[EventDate "2020.??.??"]
+
+1. e4 Nf6 2. e5 Nd5 3. c4 Nb6 4. d4 d6 5. exd6 cxd6 6. Nc3 g6 7. Be3 Bg7 8. Rc1
+O-O 9. b3 a5 10. Bd3 Na6 11. Nge2 Nb4 12. Bb1 e5 13. d5 f5 14. f4 e4 15. O-O
+Qe7 16. Bd4 Nd7 17. a3 Na6 18. Bxg7 Qxg7 19. Nd4 Nac5 20. b4 axb4 21. axb4 Nd3
+22. Bxd3 Qxd4+ 23. Kh1 Qxd3 24. Qxd3 exd3 25. Nb5 Nb6 26. Nxd6 Rd8 27. c5 Nxd5
+28. b5 d2 29. Rcd1 Ne3 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "mbodek"]
+[Black "sutcunuri"]
+[Result "0-1"]
+[ECO "C11"]
+[WhiteElo "2590"]
+[BlackElo "2533"]
+[PlyCount "90"]
+[EventDate "2020.??.??"]
+
+1. Nc3 Nf6 2. e4 e6 3. d4 d5 4. e5 Ne4 5. f4 Nxc3 6. bxc3 c5 7. Nf3 Nc6 8. Bd3
+Qa5 9. Bd2 Qa4 10. O-O cxd4 11. cxd4 Nxd4 12. Nxd4 Qxd4+ 13. Kh1 Bd7 14. Rb1 b6
+15. f5 exf5 16. Bxf5 Bxf5 17. Rxf5 g6 18. Rf1 Bg7 19. e6 O-O 20. e7 Rfe8 21.
+Bb4 Qxd1 22. Rbxd1 a5 23. Bd6 d4 24. g4 Rac8 25. Rd2 Rc6 26. Ba3 b5 27. Rdf2 f6
+28. Rf4 b4 29. Bb2 Rxe7 30. Bxd4 Ree6 31. R1f2 Rc4 32. Ba7 Rxf4 33. Rxf4 Re1+
+34. Kg2 Re2+ 35. Rf2 Rxf2+ 36. Kxf2 f5 37. gxf5 gxf5 38. Ke3 Kf7 39. Kd3 Ke6
+40. Kc4 f4 41. Kb5 Kd5 42. Kxa5 f3 43. Kxb4 Bd4 44. c4+ Ke4 45. Bxd4 Kxd4 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "WildBreath"]
+[Black "Zobbie"]
+[Result "1-0"]
+[ECO "B11"]
+[WhiteElo "2397"]
+[BlackElo "2381"]
+[PlyCount "141"]
+[EventDate "2020.??.??"]
+
+1. e4 c6 2. Nc3 d5 3. d3 a6 4. g3 g6 5. Bg2 Bg7 6. Nge2 d4 7. Nb1 e5 8. Nd2 Nf6
+9. O-O O-O 10. h3 c5 11. f4 Nc6 12. f5 gxf5 13. exf5 Re8 14. Ne4 Nxe4 15. Bxe4
+f6 16. g4 Bd7 17. Ng3 Ne7 18. Nh5 Bc6 19. Nxg7 Kxg7 20. Qd2 Bxe4 21. Qh6+ Kg8
+22. dxe4 Nc6 23. g5 Rf8 24. g6 Qe7 25. Kh1 Qg7 26. Rg1 Qxh6 27. Bxh6 hxg6 28.
+Rxg6+ Kh7 29. Bxf8 Rxf8 30. Rag1 Rf7 31. Rg8 Nb4 32. R8g4 Kh8 33. Rh4+ Rh7 34.
+Rxh7+ Kxh7 35. c3 Nxa2 36. Rg6 dxc3 37. bxc3 Nxc3 38. Rxf6 Nxe4 39. Rb6 c4 40.
+Rxb7+ Kh6 41. Rb6+ Kg5 42. Rxa6 Kxf5 43. Rc6 c3 44. Kg2 Kf4 45. h4 Ke3 46. h5
+Kd4 47. h6 Ng5 48. Kg3 Kd3 49. Kg4 Nh7 50. Kh5 Nf8 51. Kg5 c2 52. Kf6 c1=Q 53.
+Rxc1 Nd7+ 54. Kg7 e4 55. h7 Ne5 56. h8=Q Kd2 57. Rh1 Nd3 58. Qh2+ Kc3 59. Rd1
+Kd4 60. Rxd3+ Kxd3 61. Qg1 e3 62. Qe1 e2 63. Kf6 Ke3 64. Kf5 Kf3 65. Kg5 Ke3
+66. Kg4 Kd3 67. Kg3 Kc2 68. Kf2 Kd3 69. Qxe2+ Kd4 70. Qe1 Kd5 71. Qe2 1-0
+
+[Event "Rated Bullet tournament sfWF37UV"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Bob_Fletcher"]
+[Black "Real-boy"]
+[Result "1-0"]
+[ECO "D35"]
+[WhiteElo "2583"]
+[BlackElo "2581"]
+[PlyCount "53"]
+[EventDate "2020.??.??"]
+
+1. c4 Nf6 2. Nc3 e6 3. d4 d5 4. f3 dxc4 5. e4 Bb4 6. Bxc4 Nc6 7. Nge2 O-O 8.
+O-O e5 9. d5 Bc5+ 10. Kh1 Nd4 11. Be3 Nxe2 12. Qxe2 Bxe3 13. Qxe3 c6 14. Rad1
+cxd5 15. Nxd5 Nxd5 16. Bxd5 Qe7 17. Qc3 Kh8 18. Rc1 f6 19. Qc5 Qe8 20. Qd6 Bd7
+21. Rfd1 Rd8 22. Rc7 Ba4 23. Qb4 Bxd1 24. Qxb7 Rb8 25. Qxa7 Qg6 26. Rf7 Rxf7
+27. Qxb8+ 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "SuperDonald"]
+[Black "Erisapo"]
+[Result "1-0"]
+[ECO "D11"]
+[WhiteElo "2330"]
+[BlackElo "2306"]
+[PlyCount "89"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 d5 2. c4 c6 3. Nf3 Nf6 4. Qc2 dxc4 5. Qxc4 Bf5 6. g3 e6 7. Bg2 Be7 8. O-O
+O-O 9. Rd1 Nbd7 10. e3 Rc8 11. Qe2 a6 12. Ne5 Qc7 13. Nxd7 Nxd7 14. Nc3 e5 15.
+d5 Bg6 16. e4 b5 17. a3 Nb6 18. Be3 Nc4 19. Rac1 c5 20. Bh3 Rcd8 21. d6 Bxd6
+22. Nd5 Qb8 23. f3 Nxe3 24. Qxe3 c4 25. Kg2 h6 26. Rc2 Kh7 27. Rcd2 Bc7 28. Bf5
+Bxf5 29. exf5 f6 30. Qe4 Rd6 31. Ne7 Rxd2+ 32. Rxd2 Bd6 33. Ng6 Rd8 34. Qg4 Bc7
+35. Re2 Rd4 36. Qh5 Qe8 37. h4 b4 38. g4 Bd8 39. f4 e4 40. g5 e3 41. gxh6 gxh6
+42. Qg4 Qe4+ 43. Kh2 Be7 44. Rg2 Rd2 45. Nf8+ 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Chess-Network"]
+[Black "dmitrij_IM"]
+[Result "0-1"]
+[ECO "E92"]
+[WhiteElo "2702"]
+[BlackElo "2863"]
+[PlyCount "108"]
+[EventDate "2020.??.??"]
+
+1. d4 Nf6 2. Nf3 g6 3. c4 Bg7 4. Nc3 O-O 5. e4 d6 6. Be2 e5 7. d5 a5 8. Bg5 h6
+9. Bh4 Qe8 10. Nd2 Na6 11. g4 Nh7 12. a3 Bd7 13. Qc2 a4 14. f3 Bf6 15. Bf2 Bg5
+16. Nf1 Nc5 17. Bxc5 dxc5 18. h4 Bf4 19. Nd2 Qe7 20. O-O-O Kh8 21. Kb1 Rfb8 22.
+Ka2 Nf8 23. Bd3 Nh7 24. Ne2 Be3 25. Nf1 Bd4 26. Nxd4 cxd4 27. c5 Nf6 28. Nd2 c6
+29. d6 Be6+ 30. Bc4 Qe8 31. Bxe6 Qxe6+ 32. Qc4 Qxc4+ 33. Nxc4 Nd7 34. Rc1 f6
+35. g5 Kg7 36. gxf6+ Kxf6 37. Rhd1 Ke6 38. f4 exf4 39. Rxd4 Nxc5 40. e5 Nb3 41.
+Rcd1 Nxd4 42. Rxd4 Rf8 43. d7 Rad8 44. Rd6+ Ke7 45. e6 f3 46. Rd1 f2 47. Rf1
+Kxe6 48. Nd2 Rxd7 49. Ne4 Rd4 50. Nc5+ Kd5 51. Nxb7 Re4 52. Na5 Re1 53. Rxf2
+Rxf2 54. Nxc6 Kxc6 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Kidefence"]
+[Black "BlueGreensun"]
+[Result "0-1"]
+[ECO "C03"]
+[WhiteElo "2715"]
+[BlackElo "2752"]
+[PlyCount "144"]
+[EventDate "2020.??.??"]
+
+1. e4 e6 2. d4 d5 3. Nd2 dxe4 4. Nxe4 Nf6 5. Nxf6+ gxf6 6. Nf3 Nc6 7. g3 Qd5 8.
+Bg2 Qe4+ 9. Qe2 Qxe2+ 10. Kxe2 b6 11. Re1 Ba6+ 12. Kd1 O-O-O 13. c3 e5 14. Nd2
+Bb7 15. Bxc6 Bxc6 16. dxe5 fxe5 17. Rxe5 Bc5 18. f4 Rd3 19. Kc2 Rhd8 20. Nb3
+Bf3 21. Bd2 a5 22. a4 Bf8 23. Rae1 R3d7 24. Re8 Kb7 25. Rxd8 Rxd8 26. Nd4 Bg4
+27. Be3 c5 28. Ne2 Bf5+ 29. Kc1 Rd3 30. Bd2 Bg7 31. Ng1 Bd7 32. Re3 Rxe3 33.
+Bxe3 Bxa4 34. Nf3 Bc6 35. Ng5 Bd5 36. Nxh7 b5 37. Bxc5 Kc6 38. Bf8 Bh8 39. Ng5
+f6 40. Nh3 Bg2 41. Nf2 Kd5 42. Kd2 f5 43. Be7 Bg7 44. Bd8 a4 45. Be7 Kc4 46.
+Nd3 Be4 47. Ne5+ Kb3 48. Ba3 Bf6 49. h4 Bg7 50. Ke3 Bd5 51. g4 fxg4 52. Nxg4
+Bxc3 53. bxc3 Kxa3 54. h5 Kb2 55. h6 Bg8 56. Nf6 a3 57. Nxg8 a2 58. h7 a1=Q 59.
+h8=Q Qe1+ 60. Kf3 Qf1+ 61. Kg4 Qg2+ 62. Kf5 Qc2+ 63. Kg4 Qe2+ 64. Kf5 Qd3+ 65.
+Ke6 Qc4+ 66. Ke7 Qc5+ 67. Kf7 Qc6 68. Qf6 Qc7+ 69. Kg6 Qc4 70. Qf5 Qe4 71. Kg5
+Qe3 72. Qe4 Qxe4 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "MrMania"]
+[Black "lord_barre"]
+[Result "1-0"]
+[ECO "A00"]
+[WhiteElo "2395"]
+[BlackElo "2400"]
+[PlyCount "99"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. g3 d5 2. Bg2 e5 3. d4 exd4 4. Nf3 g6 5. Qxd4 Nf6 6. Bg5 Bg7 7. Qe5+ Qe7 8.
+Bxf6 Bxf6 9. Qxd5 Be6 10. Qxb7 O-O 11. Nc3 Nd7 12. O-O Rab8 13. Qxc7 Rxb2 14.
+Ne4 Bg7 15. Rad1 Bf5 16. Nh4 Bxe4 17. Rxd7 Qe8 18. Re7 Bxg2 19. Rxe8 Rxe8 20.
+Nxg2 Rxe2 21. Qc8+ Bf8 22. Rc1 Rxa2 23. Nf4 Re5 24. c4 Rc5 25. Qd8 Ra4 26. Nd5
+Raxc4 27. Rxc4 Rxc4 28. Nf6+ Kg7 29. Ne8+ Kg8 30. h4 h5 31. Qd7 Bc5 32. Nd6
+Bxd6 33. Qxd6 a5 34. Qd5 Ra4 35. Qb5 Ra3 36. Qb8+ Kh7 37. Qf8 Rf3 38. Kg2 Rf5
+39. f3 Rf6 40. Qe7 Kg7 41. Qe5 a4 42. g4 hxg4 43. fxg4 g5 44. hxg5 Kf8 45. Qxf6
+Ke8 46. g6 Kd7 47. gxf7 Kc7 48. f8=Q Kb7 49. Q8e7+ Kb8 50. Qff8# 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "TCL"]
+[Black "Privorotsky_Oleg"]
+[Result "0-1"]
+[ECO "D02"]
+[WhiteElo "2405"]
+[BlackElo "2320"]
+[PlyCount "64"]
+[EventDate "2020.??.??"]
+
+1. d4 d5 2. Nf3 Nf6 3. c3 c5 4. Bf4 Nbd7 5. e3 Qb6 6. Be2 c4 7. Qc1 g6 8. Nbd2
+Bg7 9. h3 O-O 10. O-O a5 11. b3 cxb3 12. axb3 Qc6 13. c4 dxc4 14. bxc4 b6 15.
+Ne5 Nxe5 16. dxe5 Ne4 17. Bf3 Bf5 18. g4 Rad8 19. gxf5 gxf5 20. Nxe4 fxe4 21.
+Bg2 Qg6 22. Qc2 f5 23. exf6 Bxf6 24. Qxe4 Bxa1 25. Rxa1 Qxe4 26. Bxe4 Rd2 27.
+Rb1 e5 28. Bxe5 Rfxf2 29. Rxb6 Rfe2 30. Bd5+ Kf8 31. Bd6+ Ke8 32. Rb7 Re1# 0-1
+
+[Event "Rated Blitz tournament 32Y8CIiO"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Darop"]
+[Black "bagoysuragoy"]
+[Result "1-0"]
+[ECO "C67"]
+[WhiteElo "2324"]
+[BlackElo "2305"]
+[PlyCount "59"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 Nc6 2. Nf3 e5 3. Bb5 Nf6 4. O-O Nxe4 5. Re1 Nd6 6. Nxe5 Be7 7. Nxc6 dxc6
+8. Bf1 O-O 9. d4 Re8 10. c3 Nf5 11. Bf4 Be6 12. Nd2 Bd6 13. Bxd6 Nxd6 14. Nf3
+f6 15. h3 a5 16. Bd3 a4 17. Qc2 g6 18. Bxg6 hxg6 19. Qxg6+ Kh8 20. Qh6+ Kg8 21.
+Nh4 Qd7 22. Re3 Re7 23. Qxf6 Rae8 24. Ng6 Rg7 25. Rae1 Bf7 26. Ne7+ Kf8 27. Qh6
+Bg8 28. Rf3+ Nf7 29. Rg3 Nd6 30. Qxg7# 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "RigelStar"]
+[Black "Aisen_Mestnikov"]
+[Result "1/2-1/2"]
+[ECO "D43"]
+[WhiteElo "2407"]
+[BlackElo "2388"]
+[PlyCount "129"]
+[EventDate "2020.??.??"]
+
+1. d4 d5 2. Nf3 c6 3. c4 Nf6 4. Nc3 e6 5. Bg5 Be7 6. e3 O-O 7. Bd3 dxc4 8. Bxc4
+b5 9. Bd3 a5 10. Qc2 b4 11. Ne4 h6 12. Bxf6 Bxf6 13. O-O Ba6 14. Bxa6 Rxa6 15.
+Nc5 Ra7 16. a3 bxa3 17. Rxa3 Nd7 18. Nd3 Qb6 19. Rc3 Rb8 20. Rxc6 Qb5 21. Rc1
+a4 22. h3 Raa8 23. Rc7 Nb6 24. Rc5 Qd7 25. Nb4 a3 26. bxa3 Rxa3 27. Nc6 Re8 28.
+Qb2 Ra6 29. Qb5 Qb7 30. Rb1 Rea8 31. Qb3 Qd7 32. Nb4 R6a7 33. Qc2 Qe8 34. Rc1
+Nd5 35. Nc6 Rc7 36. Qd1 Rac8 37. Nce5 Rxc5 38. dxc5 Bxe5 39. Nxe5 Qe7 40. c6
+Qd6 41. Nd7 Rxc6 42. e4 Rxc1 43. Qxc1 Qxd7 44. exd5 exd5 45. Qb1 g6 46. Qd1 d4
+47. Qd3 Qd5 48. Kf1 f5 49. Ke2 Qxg2 50. Qxd4 Qe4+ 51. Qxe4 fxe4 52. Ke3 Kf7 53.
+Kxe4 Kf6 54. Kf3 Kf5 55. Ke3 h5 56. Kf3 g5 57. Kg3 g4 58. h4 Ke4 59. Kg2 Kf4
+60. Kh2 Kf3 61. Kg1 g3 62. fxg3 Kxg3 63. Kh1 Kxh4 64. Kg1 Kg3 65. Kh1 1/2-1/2
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "zpxocivubyntmraeswdq"]
+[Black "drdrunckenstein"]
+[Result "1-0"]
+[ECO "B06"]
+[WhiteElo "2690"]
+[BlackElo "2528"]
+[PlyCount "67"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 g6 2. d4 Bg7 3. Nc3 d6 4. Be3 Nf6 5. Qd2 O-O 6. Bh6 Nc6 7. Nge2 e5 8.
+Bxg7 Kxg7 9. f3 Nd7 10. h4 h6 11. O-O-O f6 12. g4 exd4 13. Nxd4 Nxd4 14. Qxd4
+Ne5 15. Be2 g5 16. Rh2 Ng6 17. hxg5 hxg5 18. Rdh1 Nh4 19. f4 c5 20. Qd2 Be6 21.
+b3 Qe7 22. Kb2 Rad8 23. a4 Rh8 24. Rd1 a6 25. a5 Bf7 26. Rf2 Ng6 27. fxg5 fxg5
+28. Rf5 Nf4 29. Bc4 Bg6 30. Nd5 Nxd5 31. Rxd5 Qf6+ 32. e5 Qf4 33. exd6 Qxd2 34.
+R1xd2 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "JiangoFett"]
+[Black "betman"]
+[Result "0-1"]
+[ECO "E01"]
+[WhiteElo "2379"]
+[BlackElo "2375"]
+[PlyCount "93"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 Nf6 2. c4 e6 3. g3 d5 4. Bg2 Bb4+ 5. Nd2 O-O 6. Ngf3 dxc4 7. Qc2 a6 8.
+Qxc4 Be7 9. O-O b5 10. Qc2 Bb7 11. e4 Nbd7 12. Rd1 Qc8 13. e5 Nd5 14. Ne4 c5
+15. Neg5 g6 16. dxc5 Qxc5 17. Qxc5 Nxc5 18. Bd2 Rac8 19. Rac1 h6 20. Nh3 Kg7
+21. Nd4 Rfd8 22. Ba5 Rd7 23. f4 Bd8 24. Bxd8 Rdxd8 25. Kf2 Nd3+ 26. Rxd3 Rxc1
+27. Rd2 Rdc8 28. Ng1 R8c7 29. Nge2 R1c4 30. b3 R4c5 31. a3 Nb6 32. b4 Rc4 33.
+Nb3 Bxg2 34. Kxg2 Rc2 35. Rxc2 Rxc2 36. Kf3 Nc4 37. Nc5 Nxa3 38. Nxa6 Rc4 39.
+Ke3 Nc2+ 40. Kd3 Nxb4+ 41. Nxb4 Rxb4 42. Nd4 Rb2 43. h4 Rg2 44. Nxb5 Rxg3+ 45.
+Ke4 Rg4 46. Nd6 Rxh4 47. Kf3 0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "IrwinDAton"]
+[Black "edrocks"]
+[Result "1-0"]
+[ECO "B12"]
+[WhiteElo "2331"]
+[BlackElo "2306"]
+[PlyCount "83"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 c6 2. d4 d5 3. e5 c5 4. f4 Nc6 5. Nf3 Bg4 6. dxc5 e6 7. h3 Bxf3 8. Qxf3
+Bxc5 9. Be3 Qb6 10. Bxc5 Qxc5 11. Bd3 h5 12. Nd2 h4 13. Nb3 Qb6 14. Qf2 Qxf2+
+15. Kxf2 Nge7 16. Ke3 b6 17. Rhf1 g6 18. c3 Kd7 19. Ba6 f5 20. exf6 Nf5+ 21.
+Kd3 Rhf8 22. Nd2 Rxf6 23. Nf3 Kc7 24. Rae1 Rd8 25. Ng5 Rd6 26. Rf2 Ng3 27. Rf3
+Nh5 28. Ref1 Ne7 29. Kd2 Ng3 30. Re1 Nh5 31. Bd3 Nxf4 32. Bf1 Rf5 33. Rxf4 Rxf4
+34. Rxe6 Rf2+ 35. Ke1 Rxe6+ 36. Nxe6+ Kd6 37. Kxf2 Kxe6 38. Kf3 Ke5 39. Kg4 Nf5
+40. Bd3 Ne3+ 41. Kxh4 Nd1 42. Bxg6 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Maybach77"]
+[Black "Glig"]
+[Result "0-1"]
+[ECO "B01"]
+[WhiteElo "2384"]
+[BlackElo "2439"]
+[PlyCount "78"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 d5 2. exd5 Qxd5 3. Nc3 Qd8 4. Bc4 c6 5. Qf3 Nf6 6. Nge2 Bg4 7. Qg3 Qd6 8.
+d3 Qxg3 9. hxg3 e6 10. f3 Bf5 11. Bf4 Nbd7 12. O-O-O Nb6 13. Bb3 Nbd5 14. Be5
+Be7 15. Ne4 O-O-O 16. Nd4 Bg6 17. g4 h6 18. Rhe1 Rhg8 19. c4 Nb4 20. a3 Na6 21.
+Bc2 Nxe4 22. dxe4 h5 23. gxh5 Bxh5 24. b4 Bg6 25. Kb2 Rd7 26. b5 cxb5 27. Nxb5
+Bc5 28. Rxd7 Kxd7 29. Ba4 Kc8 30. Nd6+ Bxd6 31. Bxd6 Rd8 32. Be5 f6 33. Bc3 Nc5
+34. Bc2 e5 35. Re2 Bf7 36. Bb3 b5 37. Bb4 Nxb3 38. cxb5 Nd4 39. Re3 Nxb5 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "estocastico"]
+[Black "Donald666Trump"]
+[Result "0-1"]
+[ECO "B34"]
+[WhiteElo "2542"]
+[BlackElo "2377"]
+[PlyCount "100"]
+[EventDate "2020.??.??"]
+
+1. e4 c5 2. d4 cxd4 3. Nf3 Nc6 4. Nxd4 g6 5. Nxc6 dxc6 6. Qxd8+ Kxd8 7. Nc3 e5
+8. Bf4 exf4 9. O-O-O+ Kc7 10. Bc4 Be6 11. Bd3 Ne7 12. Kb1 Bg7 13. h4 h5 14. Ne2
+Be5 15. g3 fxg3 16. f4 Bd6 17. e5 Bc5 18. Nxg3 Rad8 19. Ne4 Be3 20. Rhf1 Nf5
+21. Ng5 Nxh4 22. Rde1 Bd2 23. Re2 Bb4 24. a3 Be7 25. Nxe6+ fxe6 26. Rg1 Rhg8
+27. Bc4 Rgf8 28. Rf1 Rd4 29. Bxe6 Rdxf4 30. Rd1 Rd8 31. Red2 Rxd2 32. Rxd2 Kb6
+33. Rd7 Bg5 34. Rg7 Re4 35. Bc8 Rxe5 36. Rxb7+ Kc5 37. b4+ Kd6 38. Rd7+ Ke6 39.
+Rc7+ Kf6 40. Rxc6+ Kg7 41. Rc7+ Kh6 42. Rxa7 Bf6 43. Rf7 Kg5 44. a4 Re2 45. a5
+Nf5 46. Bxf5 Kxf5 47. a6 Re1+ 48. Ka2 Ra1+ 49. Kb3 Rxa6 50. c4 Re6 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Trxps"]
+[Black "MinutesTactics"]
+[Result "1-0"]
+[ECO "C41"]
+[WhiteElo "2336"]
+[BlackElo "2510"]
+[PlyCount "99"]
+[EventDate "2020.??.??"]
+
+1. Nf3 d6 2. Nc3 Nd7 3. e4 Ngf6 4. d4 e5 5. Bd3 exd4 6. Nxd4 Be7 7. O-O O-O 8.
+Nf5 Re8 9. Bg5 h6 10. Nxe7+ Qxe7 11. Bh4 Qf8 12. Bg3 c6 13. f4 Ne5 14. fxe5
+dxe5 15. Ne2 Be6 16. Kh1 Rad8 17. Nc3 Rd7 18. Qe2 Red8 19. Qe1 c5 20. Bxe5 b6
+21. Bxf6 gxf6 22. Rxf6 Qg7 23. Qf2 c4 24. Be2 b5 25. e5 b4 26. Ne4 Kh7 27. Rf3
+Rg8 28. Nf6+ Kh8 29. Nxg8 Qxg8 30. Rf6 Qg7 31. Qe3 Rd8 32. Rxh6+ Kg8 33. Rf6
+Kf8 34. Qh6 Ke7 35. Qxg7 Rg8 36. Qxg8 Kd7 37. Rxf7+ Kc6 38. Qg6 Kc5 39. Qxe6
+Kd4 40. Qd6+ Ke3 41. Rf3+ Kxe2 42. Re1+ Kxe1 43. Qd4 Ke2 44. Qe3+ Kd1 45. Rf2
+c3 46. bxc3 bxc3 47. Qd3+ Kc1 48. Rf1+ Kb2 49. Qc4 Ka3 50. Qb3# 1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "FedaMaster"]
+[Black "Cebuanochessking"]
+[Result "1/2-1/2"]
+[ECO "B21"]
+[WhiteElo "2548"]
+[BlackElo "2424"]
+[PlyCount "107"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 c5 2. d4 cxd4 3. c3 d3 4. Bxd3 Nc6 5. c4 d6 6. h3 Nf6 7. Nf3 g6 8. O-O
+Bg7 9. Nc3 O-O 10. Be3 Nd7 11. Rc1 Nde5 12. Nxe5 dxe5 13. f3 Nd4 14. Ne2 e6 15.
+Nxd4 exd4 16. Bd2 e5 17. b4 Qh4 18. Qe1 Qh5 19. c5 Kh8 20. b5 f5 21. exf5 gxf5
+22. c6 bxc6 23. bxc6 Rb8 24. Rf2 Bf6 25. g4 Qxh3 26. Qe2 fxg4 27. Rh2 gxf3 28.
+Rxh3 fxe2 29. Rxh7+ Kg8 30. Rxa7 Rb2 31. Be1 Bg5 32. Bg3 Bxc1 33. Bc4+ Rf7 34.
+Rxf7 Be3+ 35. Kh1 e1=Q+ 36. Rf1+ Kh7 37. Bxe1 Bf5 38. Rxf5 Rb1 39. Rf7+ Kg6 40.
+Rf1 e4 41. Bd5 Rb2 42. Bxe4+ Kg5 43. Bg3 Kg4 44. Bh2 Rxa2 45. Bf5+ Kg5 46. c7
+Rc2 47. c8=Q Rxc8 48. Bxc8 d3 49. Rf5+ Kg4 50. Rd5+ Kh4 51. Rxd3 Bf2 52. Rd5
+Bg3 53. Kg2 Bxh2 54. Kxh2 1/2-1/2
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "rampageJackson"]
+[Black "Paanoos"]
+[Result "0-1"]
+[ECO "D11"]
+[WhiteElo "2395"]
+[BlackElo "2413"]
+[PlyCount "134"]
+[EventDate "2020.??.??"]
+
+1. d4 d5 2. Nf3 c6 3. c4 Bg4 4. cxd5 Bxf3 5. gxf3 Qxd5 6. Nc3 Qa5 7. e4 Nf6 8.
+Bd2 e5 9. dxe5 Qxe5 10. Qb3 Qc7 11. Bc4 Bd6 12. Rg1 O-O 13. Bh6 Nh5 14. h3 Kh8
+15. Be3 Bf4 16. O-O-O Bxe3+ 17. fxe3 b5 18. Be2 Ng3 19. a3 a5 20. Rde1 b4 21.
+axb4 axb4 22. Qxb4 Ra1+ 23. Kc2 Nxe2 24. Rxa1 Nxg1 25. Rxg1 Qh2+ 26. Ne2 Qxe2+
+27. Kb1 Kg8 28. Qd4 g6 29. f4 Qf2 30. Rd1 Qf3 31. e5 c5 32. Qd6 Qxe3 33. f5
+Qe4+ 34. Qd3 Qxd3+ 35. Rxd3 gxf5 36. Rf3 Kh8 37. Rxf5 Nd7 38. Kc2 Kg7 39. Kc3
+Kg6 40. Rf3 Nxe5 41. Rg3+ Kf6 42. Re3 Ke6 43. Re1 f6 44. Kc2 Rc8 45. Kc3 c4 46.
+Rg1 Rb8 47. Rg7 Rb3+ 48. Kc2 Rxh3 49. Ra7 Rh2+ 50. Kc3 Rh3+ 51. Kc2 Rb3 52. Kb1
+Rb6 53. Ra6 Rxa6 54. Kc2 Rb6 55. Kc3 Rxb2 56. Kxb2 Kd5 57. Kc3 Kc5 58. Kd2 Kd4
+59. Ke2 c3 60. Kd1 Kd3 61. Kc1 c2 62. Kb2 Kd2 63. Kb3 c1=Q 64. Kb4 Qc4+ 65. Ka3
+Qb5 66. Ka2 Kc2 67. Ka3 Qb3# 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "coryr305"]
+[Black "ahmedSulaimaniyah16"]
+[Result "1-0"]
+[ECO "B22"]
+[WhiteElo "2337"]
+[BlackElo "2399"]
+[PlyCount "49"]
+[EventDate "2020.??.??"]
+
+1. e4 c5 2. c3 Nf6 3. f3 d6 4. d4 cxd4 5. cxd4 Nc6 6. Be3 e5 7. d5 Ne7 8. Nc3
+g6 9. Nge2 a6 10. g4 Bg7 11. Ng3 O-O 12. Qd2 b5 13. h4 b4 14. Nce2 Ne8 15. Bh6
+f5 16. gxf5 gxf5 17. Nh5 f4 18. Bxg7 Nxg7 19. Nxg7 Kxg7 20. Qxb4 Rb8 21. Qxb8
+Qa5+ 22. b4 Qa3 23. Qxd6 Qb2 24. Qxe7+ Rf7 25. Rg1+ 1-0
+
+[Event "Rated Blitz tournament te4AhseI"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Chang90"]
+[Black "alekhinnemanaba"]
+[Result "0-1"]
+[ECO "B23"]
+[WhiteElo "2323"]
+[BlackElo "2350"]
+[PlyCount "74"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 c5 2. Nc3 g6 3. g3 Bg7 4. Bg2 d6 5. d3 e5 6. h4 f5 7. Bg5 Bf6 8. Nh3 Nc6
+9. Nd5 Be6 10. exf5 gxf5 11. Qh5+ Kd7 12. c3 h6 13. Be3 Qe8 14. Qe2 Qf7 15.
+Nxf6+ Nxf6 16. O-O-O Bxa2 17. Bxc6+ bxc6 18. f4 Bb3 19. fxe5 Bxd1 20. Rxd1 dxe5
+21. Bxc5 Qd5 22. d4 e4 23. Nf4 Qa2 24. d5 Rhd8 25. dxc6+ Kxc6 26. Bd4 Nd5 27.
+Qh5 Rab8 28. Qxh6+ Rd6 29. Qxd6+ Kxd6 30. c4 Qxc4+ 31. Kb1 Nxf4 32. Bxa7+ Nd3
+33. Bxb8+ Ke6 34. Bf4 Qb4 35. Bc1 Nxc1 36. Kxc1 e3 37. h5 e2 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "hungzhao"]
+[Black "Betovsky"]
+[Result "1-0"]
+[ECO "A04"]
+[WhiteElo "2629"]
+[BlackElo "2622"]
+[PlyCount "41"]
+[EventDate "2020.??.??"]
+
+1. Nf3 b6 2. g3 Bb7 3. Bg2 Nf6 4. O-O d5 5. c4 e6 6. cxd5 Nxd5 7. Qa4+ Nd7 8.
+Nc3 Be7 9. Ne5 Nxc3 10. bxc3 Bxg2 11. Kxg2 Bd6 12. Nc6 Qc8 13. d4 O-O 14. e4 e5
+15. f3 a6 16. Be3 b5 17. Qc2 Nb6 18. dxe5 Qb7 19. Na5 Qc8 20. exd6 cxd6 21.
+Bxb6 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "alireza3700"]
+[Black "Frogkiller"]
+[Result "0-1"]
+[ECO "A40"]
+[WhiteElo "2343"]
+[BlackElo "2371"]
+[PlyCount "72"]
+[EventDate "2020.??.??"]
+
+1. d4 e5 2. Nc3 exd4 3. Qxd4 Nc6 4. Qd1 Nf6 5. e3 d5 6. Nf3 Bb4 7. Bb5 O-O 8.
+O-O Bg4 9. h3 Bh5 10. Bxc6 bxc6 11. Bd2 Re8 12. g4 Bg6 13. Nd4 Qd7 14. Nce2 Bf8
+15. Nf4 Ne4 16. Nxg6 hxg6 17. f3 Ng5 18. h4 Ne6 19. Nxe6 Rxe6 20. f4 Re4 21.
+Qf3 Rae8 22. Rae1 Bc5 23. Kg2 Bb6 24. h5 gxh5 25. gxh5 Qf5 26. Rg1 c5 27. Kh2
+d4 28. Rg3 dxe3 29. Bxe3 c4 30. Reg1 Rxe3 31. Rxg7+ Kf8 32. Rg8+ Ke7 33. Rxe8+
+Kxe8 34. Qc6+ Ke7 35. Qg2 Qxh5+ 36. Qh3 Qxh3# 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "dimochka_tsoi"]
+[Black "Olaffo"]
+[Result "0-1"]
+[ECO "A02"]
+[WhiteElo "2678"]
+[BlackElo "2506"]
+[PlyCount "168"]
+[EventDate "2020.??.??"]
+
+1. f4 g5 2. Nf3 h6 3. fxg5 hxg5 4. Nxg5 e5 5. d3 Be7 6. Nf3 Nc6 7. e4 d5 8. Be3
+d4 9. Bf2 Bg4 10. Nbd2 Nf6 11. Be2 Qd7 12. Ng5 Rh5 13. Bxg4 Nxg4 14. Ngf3 O-O-O
+15. Qe2 Rdh8 16. O-O-O Nxh2 17. Nxh2 Rxh2 18. Rxh2 Rxh2 19. Bg3 Rh8 20. Nc4 f6
+21. Kb1 Qe6 22. Qf3 b5 23. Nd2 Nb4 24. Nb3 a5 25. a3 a4 26. Nc1 Na6 27. Rf1 Nc5
+28. Ne2 Rg8 29. Qf5 Qxf5 30. Rxf5 Ne6 31. Rf2 Ng5 32. Bh4 Nh7 33. g3 Rg4 34.
+Ng1 Kd7 35. Kc1 Ke6 36. Kd1 Ng5 37. Ke2 Nf7 38. Nf3 Nd6 39. Nd2 c5 40. Kf3 Rg8
+41. g4 c4 42. Kg3 Rc8 43. Nf3 cxd3 44. cxd3 Rc1 45. g5 fxg5 46. Bxg5 Nf7 47.
+Bxe7 Kxe7 48. Nh4 Nd6 49. Ng6+ Ke6 50. Rf8 Rc2 51. Rb8 Rxb2 52. Rb6 Rd2 53. Nh4
+Rxd3+ 54. Kg4 Re3 55. Nf5 Rxe4+ 56. Kg5 Kd5 57. Rxd6+ Kc4 58. Rd7 Kb3 59. Nd6
+Re3 60. Nxb5 Kc4 61. Rb7 Kb3 62. Nd6+ Kxa3 63. Nf5 Re1 64. Kf6 d3 65. Nd6 d2
+66. Nc4+ Ka2 67. Nxd2 Ka1 68. Nc4 Rd1 69. Nxe5 Rf1+ 70. Ke6 a3 71. Kd5 a2 72.
+Nd3 Re1 73. Kd4 Rc1 74. Ra7 Rd1 75. Ra4 Rd2 76. Kc4 Rxd3 77. Kxd3 Kb2 78. Rb4+
+Kc1 79. Rc4+ Kb1 80. Rg4 a1=Q 81. Rg1+ Kb2 82. Rg2+ Kb3 83. Ke3 Qb2 84. Kf4 Qc3
+0-1
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "Atomrod"]
+[Black "Rama75"]
+[Result "1/2-1/2"]
+[ECO "D24"]
+[WhiteElo "2500"]
+[BlackElo "2472"]
+[PlyCount "122"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. d4 d5 2. Nf3 Nf6 3. c4 dxc4 4. Nc3 a6 5. a4 Nc6 6. d5 Na5 7. Bg5 h6 8. Bxf6
+exf6 9. e4 Bd6 10. Nd2 O-O 11. Nxc4 Nxc4 12. Bxc4 f5 13. O-O fxe4 14. Nxe4
+Bxh2+ 15. Kxh2 Qh4+ 16. Kg1 Qxe4 17. Rc1 Bg4 18. f3 Qe3+ 19. Rf2 Bf5 20. Qd2
+Qe7 21. Bb3 Rad8 22. Re2 Qd6 23. Qc3 Rd7 24. Qc5 Qf6 25. Qc3 Qg5 26. Qe3 Qg6
+27. Ree1 h5 28. Qf4 Bh3 29. Rc2 Bf5 30. Rc3 Qf6 31. Kh2 h4 32. Rec1 Re8 33.
+Rxc7 Rxc7 34. Rxc7 g5 35. Qc4 Qd6+ 36. f4 gxf4 37. Qc5 Qg6 38. Bc4 Qg3+ 39. Kg1
+h3 40. Bf1 Re1 41. Rc8+ Bxc8 42. Qxc8+ Kg7 43. Qxh3 Qxh3 44. gxh3 Rd1 45. Kf2
+Rxd5 46. Kf3 Rd4 47. b3 Rb4 48. Bc4 b5 49. axb5 axb5 50. Bd5 Kf6 51. h4 Ke5 52.
+Bxf7 Rd4 53. h5 Rd3+ 54. Kg4 Rg3+ 55. Kh4 Kf6 56. Bd5 Rg7 57. h6 Rg6 58. Kh5
+Rg5+ 59. Kh4 Rg6 60. Kh5 Rg5+ 61. Kh4 Rg6 1/2-1/2
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "LordGrim2500"]
+[Black "fusionpro"]
+[Result "1-0"]
+[ECO "B33"]
+[WhiteElo "2439"]
+[BlackElo "2449"]
+[PlyCount "115"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 c5 2. Nf3 Nc6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 e5 6. Ndb5 d6 7. Bg5 a6 8.
+Na3 b5 9. Nd5 Be7 10. Bxf6 Bxf6 11. c3 O-O 12. Nc2 Rb8 13. Be2 Bg5 14. h4 Bxh4
+15. g3 Be7 16. Bg4 Be6 17. Nce3 Bg5 18. f4 exf4 19. gxf4 Bh4+ 20. Kd2 Ne7 21.
+Rxh4 Bxd5 22. exd5 Nxd5 23. Qh1 Nf6 24. Qh2 Re8 25. Nc2 b4 26. Nxb4 a5 27. Nd3
+Qb6 28. Qg1 Ne4+ 29. Kc2 Qb5 30. Re1 Qa4+ 31. Kb1 Nxc3+ 32. Kc1 Nxa2+ 33. Kb1
+Nc3+ 34. Kc1 Qa1+ 35. Kc2 Qa4+ 36. Kxc3 Rbc8+ 37. Nc5 Qb4+ 38. Kd3 Rxe1 39. Qd4
+dxc5 40. Qxb4 cxb4 41. Bxc8 Re8 42. Ba6 Rd8+ 43. Kc4 Ra8 44. Kb5 a4 45. Bb7 Rb8
+46. Kxb4 a3 47. Kxa3 Rxb7 48. b4 f6 49. Ka4 Kf7 50. b5 h6 51. Ka5 g5 52. Rxh6
+gxf4 53. Rh4 Ke6 54. Rxf4 Rd7 55. b6 Ke5 56. Rf1 f5 57. Rb1 Kf6 58. b7 1-0
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "kemelgallo"]
+[Black "RARS03"]
+[Result "0-1"]
+[ECO "A30"]
+[WhiteElo "2492"]
+[BlackElo "2417"]
+[PlyCount "128"]
+[EventDate "2020.??.??"]
+
+1. c4 c5 2. Nf3 Nc6 3. Nc3 g6 4. e3 Nf6 5. d4 cxd4 6. exd4 d5 7. cxd5 Nxd5 8.
+Qb3 Nxc3 9. Bc4 Nd5 10. Bxd5 e6 11. Bxc6+ bxc6 12. Qa4 Qd5 13. O-O Bg7 14. Be3
+O-O 15. Rfd1 Bd7 16. Qc2 Rfc8 17. Rac1 Rab8 18. b3 Qa5 19. Nd2 Qh5 20. Ne4 e5
+21. dxe5 Bf5 22. f3 Rb4 23. Rd4 Rxd4 24. Bxd4 c5 25. Ng3 Bxc2 26. Nxh5 cxd4 27.
+Nf4 d3 28. Nxd3 Rc3 29. Ne1 Re3 30. Nxc2 Rc3 31. Kf2 Bxe5 32. Ke2 Bf4 33. Rd1
+Rxc2+ 34. Kd3 Rxa2 35. g3 Bh6 36. f4 Bf8 37. Kc4 Ra3 38. Rd8 Ra2 39. Ra8 a5 40.
+Kb5 Rb2 41. Ka4 Ra2+ 42. Kb5 Rb2 43. Kc4 Kg7 44. Kb5 Rxb3+ 45. Ka4 Rb2 46. Kxa5
+Rxh2 47. Kb6 Rg2 48. Kb7 Rxg3 49. Kc7 Bd6+ 50. Kd7 Rd3 51. Kd8 Bxf4+ 52. Ke8
+Rd7 53. Kxd7 Bg5 54. Kc6 Bf6 55. Kd5 Be5 56. Ke4 Bf6 57. Kf3 Bc3 58. Ra6 Bf6
+59. Ke2 g5 60. Kd3 h5 61. Ra7 h4 62. Ke4 h3 63. Kf5 h2 64. Ra6 h1=Q 0-1
+
+[Event "Rated Bullet game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "sutcunuri"]
+[Black "jonathandelacruz"]
+[Result "1-0"]
+[ECO "B17"]
+[WhiteElo "2540"]
+[BlackElo "2423"]
+[PlyCount "101"]
+[EventDate "2020.??.??"]
+
+1. d4 c6 2. Nc3 d5 3. e4 dxe4 4. Nxe4 Nd7 5. Qe2 e6 6. Bg5 Ngf6 7. Nf3 Be7 8.
+Bxf6 Nxf6 9. O-O-O O-O 10. h4 b6 11. Nxf6+ Bxf6 12. Qe4 Bb7 13. Bd3 g6 14. h5
+Bg7 15. hxg6 hxg6 16. Kb1 Qd5 17. Qh4 Rfe8 18. Ng5 c5 19. Be4 Qd7 20. Bxb7 Qxb7
+21. Rh2 cxd4 22. Rdh1 Kf8 23. Nh7+ Kg8 24. Ng5 Kf8 25. Nh7+ Kg8 26. Nf6+ Kf8
+27. Qxd4 Red8 28. Qb4+ Qe7 29. Nh7+ Ke8 30. Qg4 Kd7 31. c3 Kc7 32. Ng5 Rd6 33.
+Nf3 Rad8 34. Qg3 Qd7 35. a3 Qc6 36. Ka2 Kb7 37. Nd4 Qd5+ 38. b3 Bxd4 39. cxd4
+Qxd4 40. Rh7 Qd2+ 41. Kb1 Qd3+ 42. Ka2 Qxg3 43. Rxf7+ R6d7 44. fxg3 Rxf7 45.
+Kb1 Rf2 46. Re1 Rf1 47. Rxf1 Rd7 48. Re1 Rc7 49. Rd1 Rd7 50. Rc1 Rc7 51. Rc2
+1-0
+
+[Event "Rated Blitz game"]
+[Site "lichess.org"]
+[Date "2020.09.01"]
+[Round "?"]
+[White "NEKI_NOVI_KLINAC"]
+[Black "Evgen_88"]
+[Result "0-1"]
+[ECO "C00"]
+[WhiteElo "2444"]
+[BlackElo "2535"]
+[PlyCount "42"]
+[EventDate "2020.??.??"]
+[EventType "blitz"]
+
+1. e4 e6 2. Nf3 d5 3. exd5 exd5 4. d4 Bg4 5. Nc3 Bb4 6. Be2 Nf6 7. Bg5 O-O 8.
+O-O Bxc3 9. bxc3 Nbd7 10. h3 Bxf3 11. Bxf3 c6 12. Re1 h6 13. Bf4 Qa5 14. Qd2
+Rfe8 15. Bxh6 gxh6 16. Qxh6 Qxc3 17. Qg5+ Kh8 18. Qh6+ Nh7 19. Re3 Qxa1+ 20.
+Kh2 Qxd4 21. Rb3 b5 0-1
 

--- a/chess-api/pom.xml
+++ b/chess-api/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>chessapi4j</groupId>
   <artifactId>chessapi4j</artifactId>
-  <version>1.1.0-RELEASE</version>
+  <version>1.1.1-RELEASE</version>
   <name>ChessAPI4j</name>
   
   <properties>
@@ -23,8 +23,6 @@
 	    <version>5.8.2</version>
 	    <scope>test</scope>
 	</dependency>
-	
-    
   </dependencies>
   <build>
   	<plugins>

--- a/chess-api/src/main/java/chessapi4j/core/AbstractGenerator.java
+++ b/chess-api/src/main/java/chessapi4j/core/AbstractGenerator.java
@@ -2,7 +2,6 @@ package chessapi4j.core;
 
 import java.util.LinkedList;
 import java.util.List;
-import java.util.function.BiConsumer;
 
 import chessapi4j.Generator;
 import chessapi4j.Piece;

--- a/chess-api/src/test/java/chessapi4j/GeneratorTest.java
+++ b/chess-api/src/test/java/chessapi4j/GeneratorTest.java
@@ -85,9 +85,6 @@ public class GeneratorTest {
 		assertEquals(3894594, generationTest(4, generator));
 		assertEquals(164075551, generationTest(5, generator));
 	}
-	
-	
-	
 
 	private int generationTest(int depth, Generator generator) {
 		if (depth == 0)

--- a/chess-api/src/test/java/chessapi4j/PGNHandlerTest.java
+++ b/chess-api/src/test/java/chessapi4j/PGNHandlerTest.java
@@ -2,11 +2,7 @@ package chessapi4j;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import java.util.Arrays;
-import java.util.LinkedList;
 import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
A bug was fixed that prevented handling PGN databases in which the moves of each game were not all found on a single line.