### PR TITLE
Refactor chess move handling and introduce MoveFactory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@
 /chess-api/.classpath
 /chess-api/.project
 /chess-api/.settings/
+/chess-api/.idea/
 /.idea/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![Java](https://img.shields.io/badge/Java-11%2B-green)
-[![Static Badge](https://img.shields.io/badge/javadoc-1.2.9-brightgreen)](https://lunalobos.github.io/chessapi4j/apidocs/chessapi4j/package-summary.html)
+[![Static Badge](https://img.shields.io/badge/javadoc-1.2.10-brightgreen)](https://lunalobos.github.io/chessapi4j/apidocs/chessapi4j/package-summary.html)
 [![Maven Central](https://img.shields.io/maven-central/v/io.github.lunalobos/chessapi4j)](https://central.sonatype.com/artifact/io.github.lunalobos/chessapi4j)
 ![License](https://img.shields.io/github/license/lunalobos/chessapi4j)
 
@@ -7,7 +7,7 @@
 
 # Overview
 
-ChessAPI4j is a Java library that allows representing and performing operations related to chess. With this library, it is possible to create representations of positions, generate legal moves, execute moves, detect moves between different positions, work with PGN files (import and export), use or implement heuristic evaluations of positions, and use or implement algorithms for searching the best move.
+This library aims to provide a solid foundation for handling abstractions of chess concepts such as board positions, determination of the state of a position (checkmate, stalemate, insufficient material, etc.), games between players (either in progress or already played), legal move generation and validation, FEN validation, ECO code determination, and conversion to and from PGN format.
 
 
 > **⚠️ Java 11 Compatibility Note:**  
@@ -75,7 +75,7 @@ Add the following to your dependencies:
 <dependency>
     <groupId>io.github.lunalobos</groupId>
     <artifactId>chessapi4j</artifactId>
-    <version>1.2.9</version>
+    <version>1.2.10</version>
 </dependency>
 
 ```

--- a/README.md
+++ b/README.md
@@ -1,15 +1,21 @@
 ![Java](https://img.shields.io/badge/Java-11%2B-green)
-[![Static Badge](https://img.shields.io/badge/javadoc-1.2.9-brightgreen?style=plastic)](https://lunalobos.github.io/chessapi4j/apidocs/chessapi4j/package-summary.html)
+[![Static Badge](https://img.shields.io/badge/javadoc-1.2.9-brightgreen)](https://lunalobos.github.io/chessapi4j/apidocs/chessapi4j/package-summary.html)
 [![Maven Central](https://img.shields.io/maven-central/v/io.github.lunalobos/chessapi4j)](https://central.sonatype.com/artifact/io.github.lunalobos/chessapi4j)
 ![License](https://img.shields.io/github/license/lunalobos/chessapi4j)
 
-
 ![chessapi4j](https://chessapi4j.my.canva.site/media/7547b1586c5d91c735c3b3a67838eb13.png)
-
 
 # Overview
 
 ChessAPI4j is a Java library that allows representing and performing operations related to chess. With this library, it is possible to create representations of positions, generate legal moves, execute moves, detect moves between different positions, work with PGN files (import and export), use or implement heuristic evaluations of positions, and use or implement algorithms for searching the best move.
+
+
+> **⚠️ Java 11 Compatibility Note:**  
+> Full compatibility with Java 11 is ensured starting from version **1.2.10**. However, it is **strongly recommended** to use the `functional` package when working with Java 11, as the original package is significantly slower in this environment (the cause is currently unknown).
+
+
+> **⚠️ Java 17 Compatibility Note:** 
+> There do not appear to be performance issues with the original package when running on Java 17. Nevertheless, it is still recommended to use the `functional` package, as it is generally more robust and safer for concurrent or complex applications.
 
 ## Table of contents
 

--- a/chess-api/pom.xml
+++ b/chess-api/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>io.github.lunalobos</groupId>
 	<artifactId>chessapi4j</artifactId>
-	<version>1.2.9</version>
+	<version>1.2.10</version>
 	<packaging>jar</packaging>
 
 	<name>ChessAPI4j</name>
@@ -58,7 +58,7 @@
 			<version>1.18.30</version>
 			<scope>provided</scope>
 		</dependency>
-		
+
 	</dependencies>
 
 	<build>
@@ -96,7 +96,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>2.9.1</version>
+				<version>3.11.2</version>
 				<executions>
 					<execution>
 						<id>attach-javadocs</id>
@@ -107,6 +107,9 @@
 				</executions>
 				<configuration>
 					<show>protected</show>
+					<additionalOptions>
+						<additionalOption>-Xdoclint:none</additionalOption>
+					</additionalOptions>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/chess-api/src/main/java/chessapi4j/Game.java
+++ b/chess-api/src/main/java/chessapi4j/Game.java
@@ -209,7 +209,7 @@ public class Game implements Iterable<Position> {
 	 * @since 1.2.3
 	 */
 	public Position addMove(Move move) throws MovementException {
-		var lastPosition = positions.getLast();
+		var lastPosition = positions.get(positions.size() -1);
 		positions.add(lastPosition.childFromMove(MoveFactory.instance(move))
 				.orElseThrow(() -> new MovementException(move, lastPosition)));
 		if (move instanceof PGNMove) {
@@ -218,7 +218,7 @@ public class Game implements Iterable<Position> {
 			moves.add(new PGNMove(move, lastPosition));
 		}
 
-		return positions.getLast();
+		return positions.get(positions.size() -1);
 	}
 
 	/**
@@ -245,7 +245,7 @@ public class Game implements Iterable<Position> {
 	 * @since 1.2.5
 	 */
 	public Position currentPosition() {
-		return positions.getLast();
+		return positions.get(positions.size() -1);
 	}
 
 	/**

--- a/chess-api/src/main/java/chessapi4j/LoggerFactory.java
+++ b/chess-api/src/main/java/chessapi4j/LoggerFactory.java
@@ -24,7 +24,7 @@ import java.util.Map;
  */
 final class LoggerFactory {
     private static final Map<String, LoggerImpl> LOGGERS = new HashMap<>();
-    private static final String DEFAULT_FILTER_LEVEL = "DEBUG";
+    private static final String DEFAULT_FILTER_LEVEL = "WARN";
 
     public static Logger getLogger(Class<?> clazz) {
         var logger = LOGGERS.computeIfAbsent(clazz.getCanonicalName(), k -> new LoggerImpl(clazz));

--- a/chess-api/src/main/java/chessapi4j/LoggerFactory.java
+++ b/chess-api/src/main/java/chessapi4j/LoggerFactory.java
@@ -24,7 +24,7 @@ import java.util.Map;
  */
 final class LoggerFactory {
     private static final Map<String, LoggerImpl> LOGGERS = new HashMap<>();
-    private static final String DEFAULT_FILTER_LEVEL = "WARN";
+    private static final String DEFAULT_FILTER_LEVEL = "DEBUG";
 
     public static Logger getLogger(Class<?> clazz) {
         var logger = LOGGERS.computeIfAbsent(clazz.getCanonicalName(), k -> new LoggerImpl(clazz));

--- a/chess-api/src/main/java/chessapi4j/functional/BishopGenerator.java
+++ b/chess-api/src/main/java/chessapi4j/functional/BishopGenerator.java
@@ -23,10 +23,12 @@ final class BishopGenerator {
     private static final Logger logger = Factory.getLogger(BishopGenerator.class);
     private final VisibleMetrics visibleMetrics;
     private final InternalUtil internalUtil;
+    private final MoveFactory moveFactory;
 
-    public BishopGenerator(VisibleMetrics visibleMetrics, InternalUtil internalUtil) {
+    public BishopGenerator(VisibleMetrics visibleMetrics, InternalUtil internalUtil, MoveFactory moveFactory) {
         this.visibleMetrics = visibleMetrics;
         this.internalUtil = internalUtil;
+        this.moveFactory = moveFactory;
         logger.instantiation();
     }
 
@@ -35,6 +37,6 @@ final class BishopGenerator {
         final long pseudoLegalMoves = visibleMetrics.visibleSquaresBishop(square, friends, enemies);
         final long[] pin = new long[] { -1L, pseudoLegalMoves & checkMask & internalUtil.defenseDirection(kingSquare, square) };
         final long isPin = pin[(int) ((br & checkMask) >>> Long.numberOfTrailingZeros(br & checkMask))];
-        return new RegularPieceMoves(pieceType, square, enemies,pseudoLegalMoves & isPin & inCheckMask);
+        return new RegularPieceMoves(pieceType, square, enemies,pseudoLegalMoves & isPin & inCheckMask, moveFactory);
     }
 }

--- a/chess-api/src/main/java/chessapi4j/functional/BlockingList.java
+++ b/chess-api/src/main/java/chessapi4j/functional/BlockingList.java
@@ -783,14 +783,13 @@ class BlockingList<E> extends AbstractList<E> implements Deque<E>, RandomAccess,
         return isEmpty() ? null : removeLast();
     }
 
-    @Override
     public E getFirst() {
-        return super.getFirst();
+        return get(0);
     }
 
-    @Override
+   
     public E getLast() {
-        return super.getLast();
+        return get(size() - 1);
     }
 
     @Override
@@ -873,13 +872,14 @@ class BlockingList<E> extends AbstractList<E> implements Deque<E>, RandomAccess,
 
     @Override
     public Iterator<E> descendingIterator() {
-        return reversed().iterator();
+        // return reversed().iterator();
+        throw new UnsupportedOperationException();
     }
-
-    @Override
+    
     public chessapi4j.functional.BlockingList<E> reversed() {
-        return new chessapi4j.functional.BlockingList.ReverseOrderShiftListView<>(this, super.reversed(),
-                Deque.super.reversed());
+        throw new UnsupportedOperationException();
+        //return new chessapi4j.functional.BlockingList.ReverseOrderShiftListView<>(this, super.reversed(),
+        //        Deque.super.reversed());
     }
 
     @Override
@@ -947,7 +947,7 @@ class BlockingList<E> extends AbstractList<E> implements Deque<E>, RandomAccess,
             this.reversedDeque = reversedDeque;
         }
 
-        @Override
+        
         public chessapi4j.functional.BlockingList<E> reversed() {
             return originalList;
         }
@@ -1162,12 +1162,11 @@ class BlockingList<E> extends AbstractList<E> implements Deque<E>, RandomAccess,
             return reversedDeque.removeFirst();
         }
 
-        @Override
+        
         public E getLast() {
             return reversedDeque.getLast();
         }
 
-        @Override
         public E getFirst() {
             return reversedDeque.getFirst();
         }

--- a/chess-api/src/main/java/chessapi4j/functional/Container.java
+++ b/chess-api/src/main/java/chessapi4j/functional/Container.java
@@ -17,7 +17,6 @@ package chessapi4j.functional;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Getter;
 
 import java.util.Random;
 
@@ -25,13 +24,13 @@ import java.util.Random;
  * @author lunalobos
  * @since 1.2.9
  */
-@Getter
 @AllArgsConstructor
 @Builder
 final class Container {
     final Random random;
     final InternalUtil internalUtil;
     final MatrixUtil matrixUtil;
+    final MoveFactory moveFactory;
     final VisibleMetrics visibleMetrics;
     final LackOfMaterialMetrics lackOfMaterialMetrics;
     final CheckMetrics checkMetrics;

--- a/chess-api/src/main/java/chessapi4j/functional/EcoDBParser.java
+++ b/chess-api/src/main/java/chessapi4j/functional/EcoDBParser.java
@@ -34,9 +34,9 @@ import java.util.stream.Collectors;
  * 
  * @since 1.2.7
  */
-final class CsvParser {
-    private static final Logger logger = Factory.getLogger(CsvParser.class);
-    public CsvParser() {
+final class EcoDBParser {
+    private static final Logger logger = Factory.getLogger(EcoDBParser.class);
+    public EcoDBParser() {
         logger.instantiation();
     }
 

--- a/chess-api/src/main/java/chessapi4j/functional/Factory.java
+++ b/chess-api/src/main/java/chessapi4j/functional/Factory.java
@@ -36,7 +36,7 @@ import static chessapi4j.Square.*;
  */
 public class Factory {
     private static final Map<String, Logger> LOGGERS = new HashMap<>();
-    private static final String DEFAULT_FILTER_LEVEL = "DEBUG";
+    private static final String DEFAULT_FILTER_LEVEL = "WARN";
     static final ZobristHasher zobristHasher = new ZobristHasher();
     static final long initialHash = zobristHasher.computeZobristHash(
             new long[] {

--- a/chess-api/src/main/java/chessapi4j/functional/Factory.java
+++ b/chess-api/src/main/java/chessapi4j/functional/Factory.java
@@ -15,29 +15,31 @@
  */
 package chessapi4j.functional;
 
-
 import chessapi4j.*;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Random;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import static chessapi4j.Square.*;
+
 /**
  * Main factory class for the functional API. Provides convenience methods for
  * creating {@link Position}, {@link Generator} and {@link Move} instances.
+ * Some methods for moves are optimized to avoid creating new instances,
+ * resulting
+ * in less garbage collection.
+ * 
  * @author lunalobos
  * @since 1.2.9
  */
 public class Factory {
     private static final Map<String, Logger> LOGGERS = new HashMap<>();
-    private static final String DEFAULT_FILTER_LEVEL = "WARN";
+    private static final String DEFAULT_FILTER_LEVEL = "DEBUG";
     static final ZobristHasher zobristHasher = new ZobristHasher();
     static final long initialHash = zobristHasher.computeZobristHash(
-            new long[]{
+            new long[] {
                     new Bitboard(A2, B2, C2, D2, E2, F2, G2, H2).getValue(),
                     new Bitboard(B1, G1).getValue(),
                     new Bitboard(C1, F1).getValue(),
@@ -56,8 +58,7 @@ public class Factory {
             true,
             true,
             true,
-            -1
-    );
+            -1);
 
     static final Container container = defaultContainer();
     static final Position startPos = new Position();
@@ -68,27 +69,29 @@ public class Factory {
         return logger;
     }
 
-    static Container defaultContainer(){
+    static Container defaultContainer() {
         var random = new Random();
         var matrixUtil = new MatrixUtil();
+        var moveFactory = new MoveFactory();
         var internalUtil = new InternalUtil(matrixUtil);
         var visibleMetrics = new VisibleMetrics(matrixUtil, random);
         var lackOfMaterialMetrics = new LackOfMaterialMetrics();
         var checkMetrics = new CheckMetrics(visibleMetrics, internalUtil);
         var checkmateMetrics = new CheckmateMetrics(visibleMetrics, internalUtil);
-        var stalemateMetrics =  new StalemateMetrics(visibleMetrics, internalUtil);
-        var pawnGenerator =  new PawnGenerator(visibleMetrics, checkMetrics, matrixUtil, internalUtil);
-        var knightGenerator = new KnightGenerator(matrixUtil);
-        var bishopGenerator = new BishopGenerator(visibleMetrics, internalUtil);
-        var rookGenerator = new RookGenerator(visibleMetrics, internalUtil);
-        var queenGenerator = new QueenGenerator(visibleMetrics, internalUtil);
-        var kingGenerator = new KingGenerator(visibleMetrics, matrixUtil);
+        var stalemateMetrics = new StalemateMetrics(visibleMetrics, internalUtil);
+        var pawnGenerator = new PawnGenerator(visibleMetrics, checkMetrics, matrixUtil, internalUtil, moveFactory);
+        var knightGenerator = new KnightGenerator(matrixUtil, moveFactory);
+        var bishopGenerator = new BishopGenerator(visibleMetrics, internalUtil, moveFactory);
+        var rookGenerator = new RookGenerator(visibleMetrics, internalUtil, moveFactory);
+        var queenGenerator = new QueenGenerator(visibleMetrics, internalUtil, moveFactory);
+        var kingGenerator = new KingGenerator(visibleMetrics, matrixUtil, moveFactory);
         var bitboardGenerator = new BitboardGenerator(pawnGenerator, knightGenerator, bishopGenerator, rookGenerator,
                 queenGenerator, kingGenerator, visibleMetrics, internalUtil, matrixUtil);
         var generator = new Generator(pawnGenerator, kingGenerator, matrixUtil);
         return Container.builder()
                 .random(random)
                 .matrixUtil(matrixUtil)
+                .moveFactory(moveFactory)
                 .internalUtil(internalUtil)
                 .visibleMetrics(visibleMetrics)
                 .lackOfMaterialMetrics(lackOfMaterialMetrics)
@@ -107,104 +110,153 @@ public class Factory {
     }
 
     /**
-     * {@link Generator} class is a singleton class. This method provides the instance.
-     * <p>There is no state in this class, so all methods are thread-safe.</p>
+     * {@link Generator} class is a singleton class. This method provides the
+     * instance.
+     * <p>
+     * There is no state in this class, so all methods are thread-safe.
+     * </p>
+     * 
      * @return the {@link Generator} instance
      */
-    public static Generator generator(){
+    public static Generator generator() {
         return container.generator;
     }
 
     /**
-     * Takes a FEN string and returns a {@link Position} instance if the FEN is valid.
+     * Takes a FEN string and returns a {@link Position} instance if the FEN is
+     * valid.
+     * 
      * @param fen the FEN string
      * @return a {@link Position} instance wrapped in an {@link Optional}
      */
-    public static Optional<Position> safePosition(String fen){
+    public static Optional<Position> safePosition(String fen) {
         return Optional.ofNullable(Rules.isValidFen(fen) ? new Position(fen) : null);
     }
 
     /**
      * Takes a FEN string and returns a {@link Position} instance
+     * 
      * @param fen the FEN string
      * @return a {@link Position} instance
      */
-    public static Position position(String fen){
+    public static Position position(String fen) {
         return new Position(fen);
     }
 
     /**
      * Starter position.
+     * 
      * @return the starter position
      */
-    public static Position startPos(){
+    public static Position startPos() {
         return startPos;
+    }
+
+    /**
+     * Creates a move from the origin and target square
+     * 
+     * @param origin the origin square, given as an integer in the 0-63 range
+     * @param target the target square, given as an integer in the 0-63 range
+     * @return a Move instance
+     * @since 1.2.10
+     */
+    public static Move move(int origin, int target) {
+        return container.moveFactory.move(origin, target);
+    }
+
+    /**
+     * Creates a move from a bitboard representation and origin square.
+     * 
+     * @param move   the bitboard representation of the move
+     * @param origin the origin square, given as an integer in the 0-63 range
+     * @return a Move instance
+     */
+    public static Move move(long move, int origin) {
+        return container.moveFactory.move(origin, Long.numberOfTrailingZeros(move));
+    }
+
+    /**
+     * Creates a move from a bitboard representation, origin square, and promotion
+     * piece.
+     * 
+     * @param move           the bitboard representation of the move
+     * @param origin         the origin square, given as an integer in the 0-63
+     *                       range
+     * @param promotionPiece the promotion piece, given as the ordinal value of the
+     *                       equivalent {@link Piece} or -1 for no promotion
+     * @return a Move instance
+     */
+
+    public static Move move(long move, int origin, int promotionPiece) {
+        return promotionPiece == -1 ? container.moveFactory.move(origin, Long.numberOfTrailingZeros(move))
+                : container.moveFactory.move(origin, Long.numberOfTrailingZeros(move), promotionPiece);
+    }
+
+    /**
+     * Creates a move from the origin and target square, and a promotion piece
+     * 
+     * @param origin         the origin square, given as an integer in the 0-63
+     *                       range
+     * @param target         the target square, given as an integer in the 0-63
+     *                       range
+     * @param promotionPiece the promotion piece, given as the ordinal value of the
+     *                       equivalent {@link Piece} or -1 for no promotion
+     * @return a Move instance
+     * @since 1.2.10
+     */
+    public static Move move(int origin, int target, int promotionPiece) {
+        return promotionPiece == -1 ? container.moveFactory.move(origin, target) : 
+                container.moveFactory.move(origin, target, promotionPiece);
     }
 
     /**
      * Takes a move string (UCI notation) and a boolean indicating the player who
      * moves and return the move representation.
      *
-     * @param move the move string in UCI notation
+     * @param move      the move string in UCI notation
      * @param whiteMove the player who moves
      * @return a Move instance
      */
     public static Move move(String move, boolean whiteMove) {
-        String regex = "(?<colOrigin>[a-h])(?<rowOrigin>[1-8])(?<colTarget>[a-h])(?<rowTarget>[1-8])(?<promotion>[nbrq])?";
-        Pattern pattern = Pattern.compile(regex);
-        Matcher matcher = pattern.matcher(move);
-        if (matcher.find()) {
-            int xOrigin = Util.getColIndex(matcher.group("colOrigin"));
-            int yOrigin = Integer.parseInt(matcher.group("rowOrigin")) - 1;
-            int xTarget = Util.getColIndex(matcher.group("colTarget"));
-            int yTarget = Integer.parseInt(matcher.group("rowTarget")) - 1;
-            int origin = Util.getSquareIndex(xOrigin, yOrigin);
-            int target = Util.getSquareIndex(xTarget, yTarget);
-            String promotionPiece  = matcher.group("promotion");
-            if (promotionPiece != null && !promotionPiece.isEmpty()) {
-                String name = (whiteMove ? "W" : "B") + promotionPiece.toUpperCase();
-                int promotion = Piece.valueOf(name).ordinal();
-                return new Move(origin, target, promotion);
-            } else {
-                return new Move(origin, target);
-            }
-        } else {
-            throw MovementException.invalidString(move);
-        }
+        return container.moveFactory.move(move, whiteMove);
     };
 
     /**
      * Creates a move from the origin and target square
+     * 
      * @param origin the origin square
      * @param target the target square
      * @return a Move instance
      */
     public static Move move(Square origin, Square target) {
-        return new Move(origin, target);
+        return container.moveFactory.move(origin, target);
     }
 
     /**
      * Creates a move from the origin and target square
-     * @param origin the origin square
-     * @param target the target square
+     * 
+     * @param origin         the origin square
+     * @param target         the target square
      * @param promotionPiece the promotion piece
      * @return a Move instance
      */
     public static Move move(Square origin, Square target, Piece promotionPiece) {
-        return new Move(origin, target, promotionPiece);
+        return promotionPiece == Piece.EMPTY ? container.moveFactory.move(origin, target) : container.moveFactory.move(origin, target, promotionPiece);
     }
 
     /**
-     * Takes a move string (SAN notation) and the position from which the move came and returns
+     * Takes a move string (SAN notation) and the position from which the move came
+     * and returns
      * a {@link PGNMove} instance.
-     * @param move the move in SAN notation
+     * 
+     * @param move     the move in SAN notation
      * @param position the position before the move
      * @return a PGNMove instance
      */
-    public static PGNMove pgnMove(String move, Position position){
+    public static PGNMove pgnMove(String move, Position position) {
         var moveObj = PGNHandler.toUCI(position, move).orElseThrow(
-                () -> new MovementException(String.format("move %s is not valid for position %s", move, position.fen()))
-        );
+                () -> new MovementException(
+                        String.format("move %s is not valid for position %s", move, position.fen())));
         return new PGNMove(
                 moveObj.getOrigin(),
                 moveObj.getTarget(),
@@ -212,6 +264,7 @@ public class Factory {
                 position);
     }
 
-    private Factory() {}
+    private Factory() {
+    }
 
 }

--- a/chess-api/src/main/java/chessapi4j/functional/Game.java
+++ b/chess-api/src/main/java/chessapi4j/functional/Game.java
@@ -74,7 +74,7 @@ import chessapi4j.Side;
  * @author lunalobos
  */
 public class Game implements Iterable<Position> {
-    static final Eco eco = new Eco(new CsvParser());
+    static final Eco eco = new Eco(new EcoDBParser());
     /**
      * This enum represents the possible modes for handling three repetitions.
      */

--- a/chess-api/src/main/java/chessapi4j/functional/KingGenerator.java
+++ b/chess-api/src/main/java/chessapi4j/functional/KingGenerator.java
@@ -25,10 +25,12 @@ final class KingGenerator {
     private static final Logger logger = Factory.getLogger(KingGenerator.class);
     private final VisibleMetrics visibleMetrics;
     private final MatrixUtil matrixUtil;
+    private final MoveFactory moveFactory;
 
-    public KingGenerator(VisibleMetrics visibleMetrics, MatrixUtil matrixUtil) {
+    public KingGenerator(VisibleMetrics visibleMetrics, MatrixUtil matrixUtil, MoveFactory moveFactory) {
         this.visibleMetrics = visibleMetrics;
         this.matrixUtil = matrixUtil;
+        this.moveFactory = moveFactory;
         logger.instantiation();
     }
 
@@ -39,14 +41,14 @@ final class KingGenerator {
         var threats = visibleMetrics.threats(bitboards, friends & ~(1L << square), enemies, square, wm);
         var regularMoves = moves & emptyOrEnemy & ~threats;
         if(inCheck == 1L){
-            return new KingMoves(pieceType, square, enemies, regularMoves, 0L);
+            return new KingMoves(pieceType, square, enemies, regularMoves, 0L, moveFactory);
         }
         var castleMoves = 0L;
         castleMoves = castleMoves | (isShortCastleWhiteEnable(square, enemies, friends, wk, inCheck, threats) << 6);
         castleMoves = castleMoves | (isLongCastleWhiteEnable(square, enemies, friends, wq, inCheck, threats) << 2);
         castleMoves = castleMoves | (isShortCastleBlackEnable(square, enemies, friends, bk, inCheck, threats) << 62);
         castleMoves = castleMoves | (isLongCastleBlackEnable(square, enemies, friends, bq, inCheck, threats) << 58);
-        return new KingMoves(pieceType, square, enemies, regularMoves, castleMoves);
+        return new KingMoves(pieceType, square, enemies, regularMoves, castleMoves, moveFactory);
     }
 
 

--- a/chess-api/src/main/java/chessapi4j/functional/KingMoves.java
+++ b/chess-api/src/main/java/chessapi4j/functional/KingMoves.java
@@ -36,22 +36,22 @@ final class KingMoves {
     private final List<Move> regularMoves;
     private final List<Move> castleMoves;
 
-    public KingMoves(int kingPiece, int originSquare, long enemies, long regularMoves, long castleMoves){
+    public KingMoves(int kingPiece, int originSquare, long enemies, long regularMoves, long castleMoves, MoveFactory moveFactory){
         this.kingPiece = kingPiece;
         this.originSquare = originSquare;
         this.$regularMoves = regularMoves;
         this.$castleMoves = castleMoves;
         this.enemies = enemies;
         this.regularMoves = CollectionUtil.bitboardToList(this.$regularMoves,
-                bitboard -> new Move(bitboard, this.originSquare, -1),
+                bitboard -> moveFactory.move( this.originSquare, Long.numberOfTrailingZeros(bitboard)),
                 BlockingList::new);
         this.castleMoves = CollectionUtil.bitboardToList(this.$castleMoves,
-                bitboard -> new Move(bitboard, this.originSquare, -1),
+                bitboard -> moveFactory.move(this.originSquare, Long.numberOfTrailingZeros(bitboard)),
                 BlockingList::new);
     }
 
-    public KingMoves(Piece piece, Square square, Bitboard enemies, Bitboard regularMoves, Bitboard castleMoves){
-        this(piece.ordinal(), square.ordinal(), enemies.getValue(), regularMoves.getValue(), castleMoves.getValue());
+    public KingMoves(Piece piece, Square square, Bitboard enemies, Bitboard regularMoves, Bitboard castleMoves, MoveFactory moveFactory){
+        this(piece.ordinal(), square.ordinal(), enemies.getValue(), regularMoves.getValue(), castleMoves.getValue(), moveFactory);
     }
 
     public long allMoves(){

--- a/chess-api/src/main/java/chessapi4j/functional/KnightGenerator.java
+++ b/chess-api/src/main/java/chessapi4j/functional/KnightGenerator.java
@@ -22,9 +22,10 @@ package chessapi4j.functional;
 final class KnightGenerator {
     private static final Logger logger = Factory.getLogger(KnightGenerator.class);
     private final MatrixUtil matrixUtil;
-
-    public KnightGenerator(MatrixUtil matrixUtil) {
+    private final MoveFactory moveFactory;
+    public KnightGenerator(MatrixUtil matrixUtil, MoveFactory moveFactory) {
         this.matrixUtil = matrixUtil;
+        this.moveFactory = moveFactory;
         logger.instantiation();
     }
 
@@ -34,6 +35,6 @@ final class KnightGenerator {
         long moves = matrixUtil.knightMoves[square];
         final long[] pin = new long[] { -1L, 0L };
         final long pinMask = pin[(int) ((br & checkMask) >>> Long.numberOfTrailingZeros(br & checkMask))];
-        return new RegularPieceMoves(pieceType, square, enemies,moves & emptyOrEnemy & pinMask & inCheckMask);
+        return new RegularPieceMoves(pieceType, square, enemies,moves & emptyOrEnemy & pinMask & inCheckMask, moveFactory);
     }
 }

--- a/chess-api/src/main/java/chessapi4j/functional/Logger.java
+++ b/chess-api/src/main/java/chessapi4j/functional/Logger.java
@@ -37,6 +37,11 @@ final class Logger {
         debug("%s created", className);
     }
 
+    public void instantiation(OffsetDateTime t1, OffsetDateTime t2) {
+        var ms = t2.toInstant().toEpochMilli() - t1.toInstant().toEpochMilli();
+        debug("%s created in %d ms", className, ms);
+    }
+
     public void trace(String msg) {
         executor.execute(() -> {
             if (check(Level.TRACE)) {
@@ -134,7 +139,7 @@ final class Logger {
     }
 
     private void append(String msg) {
-        System.out.println(msg);
+        System.out.println(msg.trim());
     }
 
     private String format(String msg, Level level) {

--- a/chess-api/src/main/java/chessapi4j/functional/Move.java
+++ b/chess-api/src/main/java/chessapi4j/functional/Move.java
@@ -19,7 +19,6 @@ import chessapi4j.Bitboard;
 import chessapi4j.Piece;
 import chessapi4j.Square;
 
-import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -53,7 +52,6 @@ public class Move {
      * @param origin the origin square
      * @param target the target square
      *
-     * @since 1.2.7
      */
     public Move(Square origin, Square target) {
         this(1L << target.ordinal(), origin.ordinal(), -1);
@@ -66,7 +64,6 @@ public class Move {
      * @param target the target square
      * @param promotionPiece the promotion piece
      *
-     * @since 1.2.7
      */
     public Move(Square origin, Square target, Piece promotionPiece) {
         this(1L << target.ordinal(), origin.ordinal(), promotionPiece.ordinal());
@@ -78,7 +75,6 @@ public class Move {
      * @param origin the origin square
      * @param target the target square
      *
-     * @since 1.2.7
      */
     public Move(int origin, int target) {
         this.move = 1L << target;
@@ -91,7 +87,6 @@ public class Move {
      *
      * @return the origin square
      *
-     * @since 1.2.3
      */
     public Square origin() {
         return Square.get(origin);
@@ -102,7 +97,6 @@ public class Move {
      *
      * @return the bitboard move representation
      *
-     * @since 1.2.3
      */
     public Bitboard bitboardMove() {
         return new Bitboard(move);
@@ -122,7 +116,6 @@ public class Move {
      *
      * @return the target square
      *
-     * @since 1.2.3
      */
     public Square target() {
         return Square.get(Long.numberOfTrailingZeros(move));
@@ -133,7 +126,6 @@ public class Move {
      *
      * @return the promotion piece or {@code Piece.EMPTY} if there is no promotion
      *
-     * @since 1.2.3
      */
     public Piece promotionPiece() {
         if (promotionPiece < 0)
@@ -165,7 +157,8 @@ public class Move {
 
     @Override
     public int hashCode() {
-        return Objects.hash(move, origin, promotionPiece);
+        // 16 bits hash
+        return getOrigin() | (getTarget() << 6) | (getPromotionPiece() == -1 ? 0 : (getPromotionPiece() << 12));
     }
 
     @Override

--- a/chess-api/src/main/java/chessapi4j/functional/MoveFactory.java
+++ b/chess-api/src/main/java/chessapi4j/functional/MoveFactory.java
@@ -1,0 +1,162 @@
+package chessapi4j.functional;
+
+import java.time.OffsetDateTime;
+import java.util.Arrays;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import chessapi4j.MovementException;
+import chessapi4j.Piece;
+import chessapi4j.Square;
+import chessapi4j.Util;
+
+import static chessapi4j.Piece.*;
+
+final class MoveFactory {
+    private static final Logger logger = Factory.getLogger(MoveFactory.class);
+    private static final Pattern MOVE_PATTERN = Pattern.compile(
+            "(?<colOrigin>[a-h])(?<rowOrigin>[1-8])(?<colTarget>[a-h])(?<rowTarget>[1-8])(?<promotion>[nbrq])?");
+
+    private static void checkCollision(Move move, Move[] moves) {
+        Move m = moves[move.hashCode()];
+        if (m != null && !m.equals(move)) {
+            throw new RuntimeException(String.format("hash collision for %s and %s", m, move));
+        }
+    }
+
+    private static int hash(int origin, int target) {
+        return origin | (target << 6);
+    }
+
+    private static int hash(int origin, int target, int promotionPiece) {
+        return origin | (target << 6) | (promotionPiece << 12);
+    }
+    /**
+     * Array for hashing moves
+     */
+    private final Move[] moves;
+
+    public MoveFactory() {
+        var t1 = OffsetDateTime.now();
+        final var moves = new BlockingList<Move>();
+
+        var cols = new String[] { "a", "b", "c", "d", "e", "f", "g", "h" };
+
+        // white promotions
+        final var white = new Piece[] { WQ, WR, WN, WB };
+
+        Arrays.stream(cols)
+                .map(String::toUpperCase)
+                .flatMap(col -> {
+                    final var origin = Square.valueOf(col + "7");
+                    final var target = Square.valueOf(col + "8");
+                    return Arrays.stream(white)
+                            .map(piece -> new Move(origin, target, piece));
+                }).forEach(moves::add);
+        
+
+        Arrays.stream(Arrays.copyOfRange(cols, 0, 7))
+                .map(String::toUpperCase)
+                .flatMap(col -> {
+                    final var origin = Square.valueOf(col + "7");
+                    final var target = Square.get(Square.valueOf(col + "8").ordinal() + 1);
+                    return Arrays.stream(white)
+                            .map(piece -> new Move(origin, target, piece));
+                }).forEach(moves::add);
+
+        Arrays.stream(Arrays.copyOfRange(cols, 1, 8))
+                .map(String::toUpperCase)
+                .flatMap(col -> {
+                    final var origin = Square.valueOf(col + "7");
+                    final var target = Square.get(Square.valueOf(col + "8").ordinal() -1);
+                    return Arrays.stream(white)
+                            .map(piece -> new Move(origin, target, piece));
+                }).forEach(moves::add);
+        
+        // black promotions
+        final var black = new Piece[] { BQ, BR, BN, BB };
+
+        Arrays.stream(cols)
+                .map(String::toUpperCase)
+                .flatMap(col -> {
+                    final var origin = Square.valueOf(col + "2");
+                    final var target = Square.valueOf(col + "1");
+                    return Arrays.stream(black)
+                            .map(piece -> new Move(origin, target, piece));
+                }).forEach(moves::add);
+        
+        Arrays.stream(Arrays.copyOfRange(cols, 0, 7))
+                .map(String::toUpperCase)
+                .flatMap(col -> {
+                    final var origin = Square.valueOf(col + "2");
+                    final var target = Square.get(Square.valueOf(col + "1").ordinal() + 1);
+                    return Arrays.stream(black)
+                            .map(piece -> new Move(origin, target, piece));
+                }).forEach(moves::add);
+
+        Arrays.stream(Arrays.copyOfRange(cols, 1, 8))
+                .map(String::toUpperCase)
+                .flatMap(col -> {
+                    final var origin = Square.valueOf(col + "2");
+                    final var target = Square.get(Square.valueOf(col + "1").ordinal() - 1);
+                    return Arrays.stream(black)
+                            .map(piece -> new Move(origin, target, piece));
+                }).forEach(moves::add);
+
+        // regular moves, some are not possible
+        for (var i = 0; i < 64; i++) {
+            for (var j = 0; j < 64; j++) {
+                if (j != i) {
+                    moves.add(new Move(Square.get(i), Square.get(j)));
+                }
+
+            }
+        }
+        // 16 bits are enough because we have 65535 hash combinations
+        this.moves = new Move[65535];
+        moves.forEach(move -> {
+            checkCollision(move, this.moves);
+            this.moves[move.hashCode()] = move;
+        });
+        var t2 = OffsetDateTime.now();
+        logger.instantiation(t1, t2);
+    }
+
+    public Move move(int origin, int target) {
+        return this.moves[hash(origin, target)];
+    }
+
+    public Move move(int origin, int target, int promotionPiece) {
+        return this.moves[hash(origin, target, promotionPiece)];
+    }
+
+    public Move move(Square origin, Square target) {
+        return this.moves[hash(origin.ordinal(), target.ordinal())];
+    }
+
+    public Move move(Square origin, Square target, Piece promotionPiece) {
+        return this.moves[hash(origin.ordinal(), target.ordinal(), promotionPiece.ordinal())];
+    }
+
+    public Move move(String move, boolean whiteMove) {
+        Matcher matcher = MOVE_PATTERN.matcher(move);
+        if (matcher.find()) {
+            int xOrigin = Util.getColIndex(matcher.group("colOrigin"));
+            int yOrigin = Integer.parseInt(matcher.group("rowOrigin")) - 1;
+            int xTarget = Util.getColIndex(matcher.group("colTarget"));
+            int yTarget = Integer.parseInt(matcher.group("rowTarget")) - 1;
+            int origin = Util.getSquareIndex(xOrigin, yOrigin);
+            int target = Util.getSquareIndex(xTarget, yTarget);
+            String promotionPiece = matcher.group("promotion");
+            if (promotionPiece != null && !promotionPiece.isEmpty()) {
+                String name = (whiteMove ? "W" : "B") + promotionPiece.toUpperCase();
+                int promotion = Piece.valueOf(name).ordinal();
+                return this.moves[hash(origin, target, promotion)];
+            } else {
+                return this.moves[hash(origin, target)];
+            }
+        } else {
+            throw MovementException.invalidString(move);
+        }
+    };
+}

--- a/chess-api/src/main/java/chessapi4j/functional/MoveFactory.java
+++ b/chess-api/src/main/java/chessapi4j/functional/MoveFactory.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2025 Miguel Angel Luna Lobos
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/lunalobos/chessapi4j/blob/master/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package chessapi4j.functional;
 
 import java.time.OffsetDateTime;
@@ -12,6 +27,11 @@ import chessapi4j.Util;
 
 import static chessapi4j.Piece.*;
 
+/**
+ *
+ * @author lunalobos
+ * @since 1.2.10
+ */
 final class MoveFactory {
     private static final Logger logger = Factory.getLogger(MoveFactory.class);
     private static final Pattern MOVE_PATTERN = Pattern.compile(
@@ -158,5 +178,5 @@ final class MoveFactory {
         } else {
             throw MovementException.invalidString(move);
         }
-    };
+    }
 }

--- a/chess-api/src/main/java/chessapi4j/functional/PGNHandler.java
+++ b/chess-api/src/main/java/chessapi4j/functional/PGNHandler.java
@@ -292,10 +292,10 @@ public class PGNHandler {
 			boolean longCastle = matcher.group("castle").equals("O-O-O");
 			if (!longCastle) {
 				return Optional
-						.of(position.whiteMove() ? new Move(Square.E1, Square.G1) : new Move(Square.E8, Square.G8));
+						.of(position.whiteMove() ? Factory.move(Square.E1, Square.G1) : Factory.move(Square.E8, Square.G8));
 			} else {
 				return Optional
-						.of(position.whiteMove() ? new Move(Square.E1, Square.C1) : new Move(Square.E8, Square.C8));
+						.of(position.whiteMove() ? Factory.move(Square.E1, Square.C1) : Factory.move(Square.E8, Square.C8));
 			}
 		}
 
@@ -310,7 +310,7 @@ public class PGNHandler {
 
 		if (origin.length() == 2) {
 
-			return Optional.of(new Move(Util.getSquare(origin), Util.getSquare(target), Piece.valueOf(
+			return Optional.of(Factory.move(Util.getSquare(origin), Util.getSquare(target), Piece.valueOf(
 					position.whiteMove() ? ("W" + promotionPiece.toUpperCase())
 							: ("B" + promotionPiece.toUpperCase()))));
 		}

--- a/chess-api/src/main/java/chessapi4j/functional/PGNMove.java
+++ b/chess-api/src/main/java/chessapi4j/functional/PGNMove.java
@@ -75,7 +75,7 @@ public class PGNMove extends Move {
 
     @Override
 	public String toString() {
-		return PGNHandler.toSAN(position, new Move(1L << getTarget(), getOrigin(), getPromotionPiece()));
+		return PGNHandler.toSAN(position, Factory.move(getOrigin(), getTarget(), getPromotionPiece()));
 	}
 
 	@Override

--- a/chess-api/src/main/java/chessapi4j/functional/PawnGenerator.java
+++ b/chess-api/src/main/java/chessapi4j/functional/PawnGenerator.java
@@ -42,13 +42,15 @@ final class PawnGenerator {
     private final CheckMetrics checkMetrics;
     private final MatrixUtil matrixUtil;
     private final InternalUtil internalUtil;
+    private final MoveFactory moveFactory;
 
     public PawnGenerator(VisibleMetrics visibleMetrics, CheckMetrics checkMetrics,
-                         MatrixUtil matrixUtil, InternalUtil internalUtil) {
+                         MatrixUtil matrixUtil, InternalUtil internalUtil, MoveFactory moveFactory) {
         this.visibleMetrics = visibleMetrics;
         this.checkMetrics = checkMetrics;
         this.matrixUtil = matrixUtil;
         this.internalUtil = internalUtil;
+        this.moveFactory = moveFactory;
         logger.instantiation();
     }
 
@@ -106,7 +108,8 @@ final class PawnGenerator {
                         pieceType,
                         square,
                         bitboards,
-                        wm));
+                        wm),
+                moveFactory);
     }
 
     private long isEnPassant(int originSquare, int finalSquare, long whiteMoveNumeric) {

--- a/chess-api/src/main/java/chessapi4j/functional/PawnMoves.java
+++ b/chess-api/src/main/java/chessapi4j/functional/PawnMoves.java
@@ -43,18 +43,18 @@ final class PawnMoves {
     private Move $epCaptureMove;
 
     public PawnMoves(int pawnPiece, int originSquare, long enemies, long regularMoves, long advanceEpMoves,
-                     long promotionMoves, long epCapture){
+            long promotionMoves, long epCapture, MoveFactory moveFactory) {
         this.pawnPiece = pawnPiece;
         this.originSquare = originSquare;
         this.enemies = enemies;
         this.$regularMoves = regularMoves;
         this.regularMoves = CollectionUtil.bitboardToList(this.$regularMoves,
-                move -> new Move(move, this.originSquare, -1),
+                move -> moveFactory.move(this.originSquare, Long.numberOfTrailingZeros(move)),
                 BlockingList::new);
         this.$advanceEpMoves = advanceEpMoves;
         this.advanceEpMoves = CollectionUtil.bitboardToList(this.$advanceEpMoves,
-                move -> new Move(move, this.originSquare, -1),
-                        BlockingList::new);
+                move -> moveFactory.move(this.originSquare, Long.numberOfTrailingZeros(move)),
+                BlockingList::new);
         this.$promotionMoves = promotionMoves;
         this.promotionMoves = CollectionUtil.bitboardToCollectedList(this.$promotionMoves,
                 bitboard -> {
@@ -62,36 +62,44 @@ final class PawnMoves {
                     Move rook;
                     Move bishop;
                     Move knight;
-                    if(pawnPiece == Piece.WP.ordinal()){
-                        queen = new Move(bitboard, this.originSquare, Piece.WQ.ordinal());
-                        rook = new Move(bitboard, this.originSquare, Piece.WR.ordinal());
-                        bishop = new Move(bitboard, this.originSquare, Piece.WB.ordinal());
-                        knight = new Move(bitboard, this.originSquare, Piece.WN.ordinal());
+                    if (pawnPiece == Piece.WP.ordinal()) {
+                        queen = moveFactory.move(this.originSquare, Long.numberOfTrailingZeros(bitboard),
+                                Piece.WQ.ordinal());
+                        rook = moveFactory.move(this.originSquare, Long.numberOfTrailingZeros(bitboard),
+                                Piece.WR.ordinal());
+                        bishop = moveFactory.move(this.originSquare, Long.numberOfTrailingZeros(bitboard),
+                                Piece.WB.ordinal());
+                        knight = moveFactory.move(this.originSquare, Long.numberOfTrailingZeros(bitboard),
+                                Piece.WN.ordinal());
                     } else {
-                        queen = new Move(bitboard, this.originSquare, Piece.BQ.ordinal());
-                        rook = new Move(bitboard, this.originSquare, Piece.BR.ordinal());
-                        bishop = new Move(bitboard, this.originSquare, Piece.BB.ordinal());
-                        knight = new Move(bitboard, this.originSquare, Piece.BN.ordinal());
+                        queen = moveFactory.move(this.originSquare, Long.numberOfTrailingZeros(bitboard),
+                                Piece.BQ.ordinal());
+                        rook = moveFactory.move(this.originSquare, Long.numberOfTrailingZeros(bitboard),
+                                Piece.BR.ordinal());
+                        bishop = moveFactory.move(this.originSquare, Long.numberOfTrailingZeros(bitboard),
+                                Piece.BB.ordinal());
+                        knight = moveFactory.move(this.originSquare, Long.numberOfTrailingZeros(bitboard),
+                                Piece.BN.ordinal());
                     }
                     return List.of(queen, rook, bishop, knight);
                 }, BlockingList::new);
         this.$epCapture = epCapture;
-        this.$epCaptureMove = epCapture != 0L ?
-                new Move(epCapture, this.originSquare, -1) :
-                null;
+        this.$epCaptureMove = epCapture != 0L
+                ? moveFactory.move(this.originSquare, Long.numberOfTrailingZeros(epCapture))
+                : null;
     }
 
     public PawnMoves(Piece piece, Square square, Bitboard enemies, Bitboard regularMoves, Bitboard advanceEpMoves,
-                     Bitboard promotionMoves, Bitboard epCapture){
+            Bitboard promotionMoves, Bitboard epCapture, MoveFactory moveFactory) {
         this(piece.ordinal(), square.ordinal(), enemies.getValue(), regularMoves.getValue(), advanceEpMoves.getValue(),
-                promotionMoves.getValue(), epCapture.getValue());
+                promotionMoves.getValue(), epCapture.getValue(), moveFactory);
     }
 
-    public Optional<Move> getEpCapture(){
+    public Optional<Move> getEpCapture() {
         return Optional.ofNullable($epCaptureMove);
     }
 
-    public long allMoves(){
+    public long allMoves() {
         return $regularMoves | $advanceEpMoves | $promotionMoves | $epCapture;
     }
 }

--- a/chess-api/src/main/java/chessapi4j/functional/Position.java
+++ b/chess-api/src/main/java/chessapi4j/functional/Position.java
@@ -143,23 +143,23 @@ public final class Position implements Serializable {
         mi = new MovesInfo(
                 new Bitboard(A3, A4, B3, B4, C3, C4, D3, D4, E3, E4, F3, F4, G3, G4, H3, H4).getValue(),
                 List.of(
-                        new PawnMoves(Piece.WP, A2, enemies, new Bitboard(A3), new Bitboard(A4), new Bitboard(), new Bitboard()),
-                        new PawnMoves(Piece.WP, B2, enemies, new Bitboard(B3), new Bitboard(B4), new Bitboard(), new Bitboard()),
-                        new PawnMoves(Piece.WP, C2, enemies, new Bitboard(C3), new Bitboard(C4), new Bitboard(), new Bitboard()),
-                        new PawnMoves(Piece.WP, D2, enemies, new Bitboard(D3), new Bitboard(D4), new Bitboard(), new Bitboard()),
-                        new PawnMoves(Piece.WP, E2, enemies, new Bitboard(E3), new Bitboard(E4), new Bitboard(), new Bitboard()),
-                        new PawnMoves(Piece.WP, F2, enemies, new Bitboard(F3), new Bitboard(F4), new Bitboard(), new Bitboard()),
-                        new PawnMoves(Piece.WP, G2, enemies, new Bitboard(G3), new Bitboard(G4), new Bitboard(), new Bitboard()),
-                        new PawnMoves(Piece.WP, H2, enemies, new Bitboard(H3), new Bitboard(H4), new Bitboard(), new Bitboard())
+                        new PawnMoves(Piece.WP, A2, enemies, new Bitboard(A3), new Bitboard(A4), new Bitboard(), new Bitboard(), Factory.container.moveFactory),
+                        new PawnMoves(Piece.WP, B2, enemies, new Bitboard(B3), new Bitboard(B4), new Bitboard(), new Bitboard(), Factory.container.moveFactory),
+                        new PawnMoves(Piece.WP, C2, enemies, new Bitboard(C3), new Bitboard(C4), new Bitboard(), new Bitboard(), Factory.container.moveFactory),
+                        new PawnMoves(Piece.WP, D2, enemies, new Bitboard(D3), new Bitboard(D4), new Bitboard(), new Bitboard(), Factory.container.moveFactory),
+                        new PawnMoves(Piece.WP, E2, enemies, new Bitboard(E3), new Bitboard(E4), new Bitboard(), new Bitboard(), Factory.container.moveFactory),
+                        new PawnMoves(Piece.WP, F2, enemies, new Bitboard(F3), new Bitboard(F4), new Bitboard(), new Bitboard(), Factory.container.moveFactory),
+                        new PawnMoves(Piece.WP, G2, enemies, new Bitboard(G3), new Bitboard(G4), new Bitboard(), new Bitboard(), Factory.container.moveFactory),
+                        new PawnMoves(Piece.WP, H2, enemies, new Bitboard(H3), new Bitboard(H4), new Bitboard(), new Bitboard(), Factory.container.moveFactory)
                 ),
                 List.of(
-                        new RegularPieceMoves(Piece.WN, B1, enemies, new Bitboard(A3, C3)),
-                        new RegularPieceMoves(Piece.WN, G1, enemies, new Bitboard(H3, F3))
+                        new RegularPieceMoves(Piece.WN, B1, enemies, new Bitboard(A3, C3), Factory.container.moveFactory),
+                        new RegularPieceMoves(Piece.WN, G1, enemies, new Bitboard(H3, F3), Factory.container.moveFactory)
                 ),
                 List.of(),
                 List.of(),
                 List.of(),
-                new KingMoves(Piece.WK, E1, enemies, new Bitboard(), new Bitboard())
+                new KingMoves(Piece.WK, E1, enemies, new Bitboard(), new Bitboard(), Factory.container.moveFactory)
         );
         movesInfoPresent = true;
     }

--- a/chess-api/src/main/java/chessapi4j/functional/QueenGenerator.java
+++ b/chess-api/src/main/java/chessapi4j/functional/QueenGenerator.java
@@ -23,10 +23,11 @@ final class QueenGenerator {
 
     private final VisibleMetrics visibleMetrics;
     private final InternalUtil internalUtil;
-
-    public QueenGenerator(VisibleMetrics visibleMetrics, InternalUtil internalUtil){
+    private final MoveFactory moveFactory;
+    public QueenGenerator(VisibleMetrics visibleMetrics, InternalUtil internalUtil, MoveFactory moveFactory){
         this.visibleMetrics = visibleMetrics;
         this.internalUtil = internalUtil;
+        this.moveFactory = moveFactory;
         logger.instantiation();
     }
 
@@ -36,6 +37,6 @@ final class QueenGenerator {
         final long pseudoLegalMoves = visibleMetrics.visibleSquaresQueen(square, friends, enemies);
         final long[] pin = new long[] { -1L, pseudoLegalMoves & checkMask & defense };
         final long pinMask = pin[(int) ((br & checkMask) >>> Long.numberOfTrailingZeros(br & checkMask))];
-        return new RegularPieceMoves(pieceType, square, enemies, pseudoLegalMoves & pinMask & inCheckMask);
+        return new RegularPieceMoves(pieceType, square, enemies, pseudoLegalMoves & pinMask & inCheckMask, moveFactory);
     }
 }

--- a/chess-api/src/main/java/chessapi4j/functional/RegularPieceMoves.java
+++ b/chess-api/src/main/java/chessapi4j/functional/RegularPieceMoves.java
@@ -33,21 +33,22 @@ final class RegularPieceMoves {
     private final long enemies;
     private final long $moves;
     private final List<Move> moves;
-    public RegularPieceMoves(int piece, int square, long enemies, long moves){
+
+    public RegularPieceMoves(int piece, int square, long enemies, long moves, MoveFactory moveFactory) {
         this.piece = piece;
         this.square = square;
         this.enemies = enemies;
         this.$moves = moves;
         this.moves = CollectionUtil.bitboardToList(this.$moves,
-                bitboard -> new Move(bitboard, square, -1),
+                bitboard -> moveFactory.move(square, Long.numberOfTrailingZeros(bitboard)),
                 BlockingList::new);
     }
 
-    public RegularPieceMoves(Piece piece, Square square, Bitboard enemies, Bitboard moves){
-        this(piece.ordinal(), square.ordinal(), enemies.getValue(), moves.getValue());
+    public RegularPieceMoves(Piece piece, Square square, Bitboard enemies, Bitboard moves, MoveFactory moveFactory) {
+        this(piece.ordinal(), square.ordinal(), enemies.getValue(), moves.getValue(), moveFactory);
     }
 
-    public long allMoves(){
+    public long allMoves() {
         return $moves;
     }
 }

--- a/chess-api/src/main/java/chessapi4j/functional/RookGenerator.java
+++ b/chess-api/src/main/java/chessapi4j/functional/RookGenerator.java
@@ -22,10 +22,11 @@ final class RookGenerator {
     private static final Logger logger = Factory.getLogger(RookGenerator.class);
     private final VisibleMetrics visibleMetrics;
     private final InternalUtil internalUtil;
-
-    public RookGenerator(VisibleMetrics visibleMetrics, InternalUtil internalUtil){
+    private final MoveFactory moveFactory;
+    public RookGenerator(VisibleMetrics visibleMetrics, InternalUtil internalUtil, MoveFactory moveFactory){
         this.visibleMetrics = visibleMetrics;
         this.internalUtil = internalUtil;
+        this.moveFactory = moveFactory;
         logger.instantiation();
     }
 
@@ -35,6 +36,6 @@ final class RookGenerator {
         final long pseudoLegalMoves = visibleMetrics.visibleSquaresRook(square, friends, enemies);
         final long[] pin = new long[] { -1L, pseudoLegalMoves & checkMask & defense };
         final long pinMask = pin[(int) ((br & checkMask) >>> Long.numberOfTrailingZeros(br))];
-        return new RegularPieceMoves(pieceType, square, enemies, pseudoLegalMoves & pinMask & inCheckMask);
+        return new RegularPieceMoves(pieceType, square, enemies, pseudoLegalMoves & pinMask & inCheckMask, moveFactory);
     }
 }

--- a/chess-api/src/main/java/chessapi4j/functional/Tuple.java
+++ b/chess-api/src/main/java/chessapi4j/functional/Tuple.java
@@ -39,8 +39,8 @@ public final class Tuple <T1,T2> {
      * @param v2 the second value
      */
     public Tuple(T1 v1, T2 v2) {
-        this.v1 = Objects.requireNonNull(v1);
-        this.v2 = Objects.requireNonNull(v2);
+        this.v1 = Objects.requireNonNull(v1, "v1 cannot be null");
+        this.v2 = Objects.requireNonNull(v2, "v2 cannot be null");
     }
     
     /**

--- a/chess-api/src/main/java/chessapi4j/functional/VisibleMetrics.java
+++ b/chess-api/src/main/java/chessapi4j/functional/VisibleMetrics.java
@@ -19,6 +19,7 @@ package chessapi4j.functional;
 import lombok.Getter;
 
 import java.math.BigInteger;
+import java.time.OffsetDateTime;
 import java.util.*;
 import java.util.stream.IntStream;
 /**
@@ -101,6 +102,7 @@ final class VisibleMetrics {
     private final MagicNumbers bishopMagicNumbers;
 
     public VisibleMetrics(MatrixUtil matrixUtil, Random random){
+        var t1 = OffsetDateTime.now();
         this.matrixUtil = matrixUtil;
         fillMap();
         // magic numbers calculation
@@ -135,7 +137,8 @@ final class VisibleMetrics {
                 this::visibleSquaresQueen,
                 (sq, f, e) -> visibleSquaresKing(sq, f)
         };
-        logger.instantiation();
+        var t2 = OffsetDateTime.now();
+        logger.instantiation(t1, t2);
     }
 
     private void fillMap() {
@@ -427,9 +430,11 @@ final class MagicHasher {
     private final long[] maskMatrix;
 
     public MagicHasher(int indexBits, int[][][] queenMatrix, int[] directions) {
+        var t1 = OffsetDateTime.now();
         this.indexBits = indexBits;
         maskMatrix = createMaskMatrix(queenMatrix, directions);
-        logger.instantiation();
+        var t2 = OffsetDateTime.now();
+        logger.instantiation(t1, t2);
     }
 
     private long[] createMaskMatrix(int[][][] queenMatrix, int[] directions) {

--- a/chess-api/src/main/java/chessapi4j/functional/ZobristHasher.java
+++ b/chess-api/src/main/java/chessapi4j/functional/ZobristHasher.java
@@ -17,6 +17,7 @@ package chessapi4j.functional;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.stream.Collectors;
@@ -32,6 +33,7 @@ final class ZobristHasher {
     private final long zobristTurn;
 
     public ZobristHasher() {
+        var t1 = OffsetDateTime.now();
         var longProvider = new LongProvider();
         zobristTable = new long[12][64];
         zobristCastle = new long[4];
@@ -48,7 +50,8 @@ final class ZobristHasher {
             zobristEnPassant[i] = longProvider.nextLong();
         }
         zobristTurn = longProvider.nextLong();
-        logger.instantiation();
+        var t2 = OffsetDateTime.now();
+        logger.instantiation(t1, t2);
     }
 
     public long computeZobristHash(long[] bitBoards, boolean whiteMove, boolean shortCastleWhite, boolean longCastleWhite,
@@ -87,9 +90,9 @@ final class LongProvider {
     private static final Logger logger = Factory.getLogger(LongProvider.class);
     private final Long[] backedArray;
     private int pointer;
-    //private Random random;
 
-    public LongProvider(){//Random random) {
+    public LongProvider(){
+        var t1 = OffsetDateTime.now();
         pointer = 0;
         try (var is = this.getClass().getClassLoader().getResourceAsStream("zobrist.txt")) {
             backedArray = Arrays.stream(new String(is.readAllBytes(), StandardCharsets.UTF_8).split("\n"))
@@ -99,7 +102,8 @@ final class LongProvider {
         } catch (IOException | NumberFormatException e) {
             throw new ResourceAccessException("zobrist.txt", e);
         }
-        logger.instantiation();
+        var t2 = OffsetDateTime.now();
+        logger.instantiation(t1, t2);
     }
 
     public long nextLong() {

--- a/chess-api/src/test/java/chessapi4j/functional/FunctionalMoveFactoryTest.java
+++ b/chess-api/src/test/java/chessapi4j/functional/FunctionalMoveFactoryTest.java
@@ -1,0 +1,61 @@
+package chessapi4j.functional;
+
+import chessapi4j.MovementException;
+import chessapi4j.Piece;
+import chessapi4j.Square;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class FunctionalMoveFactoryTest {
+
+    @Test
+    void testGetMoveWithoutPromotion() {
+        Move move = Factory.container.moveFactory.move(Square.E2, Square.E4);
+        assertNotNull(move);
+        assertEquals(Square.E2, move.origin());
+        assertEquals(Square.E4, move.target());
+        assertEquals(Piece.EMPTY, move.promotionPiece());
+    }
+
+    @Test
+    void testGetMoveWithPromotion() {
+        Move move = Factory.container.moveFactory.move(Square.A7, Square.A8, Piece.WQ);
+        assertNotNull(move);
+        assertEquals(Square.A7, move.origin());
+        assertEquals(Square.A8, move.target());
+        assertEquals(Piece.WQ, move.promotionPiece());
+    }
+
+    @Test
+    void testMoveUciWithoutPromotion() {
+        Move move = Factory.container.moveFactory.move("e2e4", true);
+        assertNotNull(move);
+        assertEquals(Square.E2, move.origin());
+        assertEquals(Square.E4, move.target());
+        assertEquals(Piece.EMPTY, move.promotionPiece());
+    }
+
+    @Test
+    void testMoveUciWithPromotionWhite() {
+        Move move = Factory.container.moveFactory.move("a7a8q", true);
+        assertNotNull(move);
+        assertEquals(Square.A7, move.origin());
+        assertEquals(Square.A8, move.target());
+        assertEquals(Piece.WQ, move.promotionPiece());
+    }
+
+    @Test
+    void testMoveUciWithPromotionBlack() {
+        Move move = Factory.container.moveFactory.move("h2h1n", false);
+        assertNotNull(move);
+        assertEquals(Square.H2, move.origin());
+        assertEquals(Square.H1, move.target());
+        assertEquals(Piece.BN, move.promotionPiece());
+    }
+
+    @Test
+    void testMoveUciInvalidString() {
+        assertThrows(MovementException.class, () -> Factory.container.moveFactory.move("invalid", true));
+    }
+}


### PR DESCRIPTION
- Enhanced KingGenerator, KnightGenerator, PawnGenerator, and other piece generators to utilize MoveFactory for move creation.
- Updated KingMoves, RegularPieceMoves, and PawnMoves to accept MoveFactory for generating moves.
- Introduced MoveFactory to centralize move creation logic and improve performance with hash-based move retrieval.
- Added unit tests for MoveFactory to ensure correct move generation and handling of promotions.
- Improved logging in various classes to track instantiation times.
- Ensured Java 11 compatibility: Internal collections no longer rely on the reverse method available in Java 21 sequential collections. As a trade-off, some internal collections do not implement reverse, but the library is now fully compatible with Java 11.